### PR TITLE
Fix double free in cleanup macro

### DIFF
--- a/main.c
+++ b/main.c
@@ -102,7 +102,6 @@ int main(int argc, char *argv[], char *env[])
     #define mainFree() \
         do { \
             cmeFree(title); \
-            cmeFree(title); \
             end(&bufIn,&bufOut,&cdsePerl); \
             PERL_SYS_TERM(); \
         } while (0); //Local free() macro


### PR DESCRIPTION
## Summary
- prevent freeing the same pointer twice in `mainFree` macro

## Testing
- `./configure`
- `make`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_684b6253bd6c8332abde534112d65a6b