### PR TITLE
Fix typo in README

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,7 @@ open an simple data structures and interfaces to make portability and
 extensibility easy.
 
 CaumeDSE is not an end-user solution. It is a service platform for
-sopporting front end applications.
+supporting front end applications.
 
 
 2. Philosophy


### PR DESCRIPTION
## Summary
- fix spelling of "supporting" in README

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `./configure` *(fails: libmicrohttpd missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b784b82808332ae653303396e6d8d