### PR TITLE
Check fwrite return value in symmetric test

### DIFF
--- a/function_tests.c
+++ b/function_tests.c
@@ -92,6 +92,10 @@ void testCryptoSymmetric(unsigned char *bufIn, unsigned char *bufOut)
     if (fp)
     {
         result=fwrite(ciphertext,cont2,1,fp);
+        if (result != 1)
+        {
+            printf("---error writing file '/opt/cdse/testfiles/enciphered.bin'\n");
+        }
         fflush(fp);
         fclose(fp);
     }


### PR DESCRIPTION
## Summary
- verify `fwrite` result in `testCryptoSymmetric`
- print an error message when the write fails

## Testing
- `./configure` *(fails: Library libmicrohttpd not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7b5eb22c8332906ef2a047d9264f