### PR TITLE
Improve password handling in PBKDF

### DIFF
--- a/strhandling.c
+++ b/strhandling.c
@@ -82,6 +82,21 @@ int cmeHexstrToBytes (unsigned char **bytearray, unsigned const char *hexstr)
     return(0);
 }
 
+int cmeIsHexString(const char *hexstr)
+{
+    if(!hexstr)
+        return 0;
+    size_t len=strlen(hexstr);
+    if(len % 2)
+        return 0;
+    for(size_t i=0;i<len;i++)
+    {
+        if(!isxdigit((unsigned char)hexstr[i]))
+            return 0;
+    }
+    return 1;
+}
+
 int cmeBytesToHexstr (unsigned const char *bytearray, unsigned char **hexstr, int len)
 {
     int cont=0;

--- a/strhandling.h
+++ b/strhandling.h
@@ -57,6 +57,8 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
 // --- Function prototypes
 // Convert Hexadecimal strings to Byte array (chars).
 int cmeHexstrToBytes (unsigned char **bytearray, unsigned const char *hexstr);
+// Check if a string is a valid hex representation (even length and all hex digits).
+int cmeIsHexString(const char *hexstr);
 // Convert Byte array to hexadecimal, uppercase string.
 int cmeBytesToHexstr (unsigned const char *bytearray, unsigned char **hexstr, int len);
 // Encode string Base 64


### PR DESCRIPTION
## Summary
- add `cmeIsHexString` helper to validate hexadecimal strings
- use new helper in PBKDF instead of calling `cmeHexstrToBytes`
- update headers with prototype

## Testing
- `make`
- `sudo make install`
- `sudo /opt/cdse/bin/CaumeDSE` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_684e1a16e5588332b3af50c48d802c27