### PR TITLE
Fix HMAC API deprecation

### DIFF
--- a/common.h
+++ b/common.h
@@ -32,7 +32,7 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
     Tim Hudson (tjh@cryptsoft.com).
 
     This product includes software from the GNU Libmicrohttpd project, Copyright
-    © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+    Â© 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
     2008, 2009, 2010 , 2011, 2012 Free Software Foundation, Inc.
 
     This product includes software from Perl5, which is Copyright (C) 1993-2005,
@@ -456,6 +456,10 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
 #endif
 #if HAVE_OPENSSL_BUFFER_H
 #include <openssl/buffer.h>
+#endif
+#if OPENSSL_VERSION_MAJOR >= 3
+#include <openssl/core_names.h>
+#include <openssl/params.h>
 #endif
 
 // --- GnuTLS includes

--- a/crypto.h
+++ b/crypto.h
@@ -44,6 +44,13 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
 ***/
 #ifndef CRYPTO_H_INCLUDED
 #define CRYPTO_H_INCLUDED
+#if OPENSSL_VERSION_MAJOR >= 3
+typedef EVP_MAC_CTX CME_HMAC_CTX;
+#define CME_HMAC_CTX_free(ctx) EVP_MAC_CTX_free(ctx)
+#else
+typedef HMAC_CTX CME_HMAC_CTX;
+#define CME_HMAC_CTX_free(ctx) HMAC_CTX_free(ctx)
+#endif
 
 // --- OpenSSL Wrappers and CaumeDSE Crypto functions prototypes
 // Wrapper Function to get a digest function pointer by name
@@ -91,11 +98,11 @@ int cmeDigestByteString (const unsigned char *srcBuf, unsigned char **dstBuf, co
 // Function to return the size (in bytes) of digest for the specified hash algorithm.
 int cmeDigestLen (const char *algorithm, int *digestLen);
 // Wrapper Function for OpenSSL's HMAC_Init_ex().
-int cmeHMACInit (HMAC_CTX **ctx, ENGINE *engine, EVP_MD *digest, const char *key, int keyLen);
+int cmeHMACInit (CME_HMAC_CTX **ctx, ENGINE *engine, EVP_MD *digest, const char *key, int keyLen);
 // Wrapper Function for OpenSSL's HMAC_Update().
-int cmeHMACUpdate (HMAC_CTX *ctx, const void *in, size_t inl);
+int cmeHMACUpdate (CME_HMAC_CTX *ctx, const void *in, size_t inl);
 // Wrapper Function for OpenSSl's HMAC_Final().
-int cmeHMACFinal(HMAC_CTX **ctx, unsigned char *out, unsigned int *outl);
+int cmeHMACFinal(CME_HMAC_CTX **ctx, unsigned char *out, unsigned int *outl);
 // Function to create an HMAC MAC of byte string, in blocks of evpBufferSize.
 int cmeHMACByteString (const unsigned char *srcBuf, unsigned char **dstBuf, const int srcLen,
                        int *dstWritten, const char *algorithm, char **salt, const char *userKey);

--- a/function_tests.c
+++ b/function_tests.c
@@ -238,7 +238,7 @@ void testCryptoHMAC ()
     unsigned char localBuffer[10];
     unsigned char *HMACBytes=NULL;
     unsigned char *HMACStr=NULL;
-    HMAC_CTX *ctx=NULL;
+    CME_HMAC_CTX *ctx=NULL;
     EVP_MD *digest=NULL;
     const unsigned char cleartext[] = "This is cleartext This is cleartext This is cleartext This is cleartext.\n";
     const char dgstAlg[] = cmeDefaultMACAlg;


### PR DESCRIPTION
## Summary
- add OpenSSL 3 includes using version macro
- define `CME_HMAC_CTX_free` helper
- use `OPENSSL_VERSION_MAJOR` in crypto implementation

## Testing
- `./configure`
- `make -j$(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_684f095760b08332912ac3525ec3d33f