### PR TITLE
Switch default encryption to AES-CBC

### DIFF
--- a/common.h
+++ b/common.h
@@ -98,7 +98,7 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
 #define cmeDefaultValueSaltLen 16        //Default size for prep-ended bytes for internal databases' encrypted values.
 #define cmeDefaultValueSaltCharLen 2*cmeDefaultValueSaltLen             //Default size for CaumeDSE ByteHexStr value salts used in protected DBs.
 #define cmeDefaultSqlBufferLen 8192         //Default size of Buffer for SQL queries. {8192}
-#define cmeDefaultEncAlg "aes-256-gcm"      //Default algorithm for symmetric encryption in engine admin. databases.
+#define cmeDefaultEncAlg "aes-256-cbc"      //Default algorithm for symmetric encryption in engine admin. databases.
 #define cmeDefaultHshAlg "sha256"           //Default algorithm for bytestring hashing {digest}.
 #define cmeDefaultMACAlg "sha256"             //Default algorithm for bytestring HMAC MACs .
 #define cmeDefaultInsertSqlRows 512         //Default # of rows to be inserted into a sqlite3 db at a time {within a Begin - Commit block}.


### PR DESCRIPTION
## Summary
- update `cmeDefaultEncAlg` constant to use `aes-256-cbc`

## Testing
- `./configure --enable-TESTDATABASE --enable-DEBUG`
- `make`
- `./CaumeDSE > /tmp/run_cbc.log`

------
https://chatgpt.com/codex/tasks/task_e_684f8ce03ff083329413f9aecc1bba3e