### PR TITLE
Add AES-GCM encryption test

### DIFF
--- a/function_tests.h
+++ b/function_tests.h
@@ -47,6 +47,7 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
 
 //Test functions for the rest of the engine functions
 void testCryptoSymmetric(unsigned char *bufIn, unsigned char *bufOut);
+void testCryptoSymmetricGCM();
 void testCryptoDigest_Str(unsigned char *bufIn);
 void testCryptoHMAC ();
 void testPerl (PerlInterpreter *myPerl);

--- a/main.c
+++ b/main.c
@@ -128,6 +128,7 @@ int main(int argc, char *argv[], char *env[])
         mainFree();
         return(1);
     }
+    testCryptoSymmetricGCM();
     testEngMgmnt();#ifdef DEBUG    // TODO (OHR#2#): Move tests to their own executable and add test checking to the configure script.
     testCryptoSymmetric(bufIn,bufOut);
     testCryptoDigest_Str(bufIn);


### PR DESCRIPTION
## Summary
- add AES-GCM encrypt/decrypt helper functions and test
- expose the new test via header and call it from `main`

## Testing
- `make -j$(nproc)`
- `./CaumeDSE` *(terminated after verifying test output)*


------
https://chatgpt.com/codex/tasks/task_e_686accc688048332b9dc87f7ad0ff616