### PR TITLE
Add config option for default cipher

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ ipathbindir = @BINDIR@
 ipathdatadir = @DATADIR@
 
 ipathbin_PROGRAMS = CaumeDSE
-CaumeDSE_SOURCES = main.c common.h crypto.c crypto.h db.c db.h engine_admin.c engine_admin.h engine_interface.c engine_interface.h filehandling.c filehandling.h function_tests.c function_tests.h perl_interpreter.c perl_interpreter.h strhandling.c strhandling.h webservice_interface.c webservice_interface.h xs_init.c
+CaumeDSE_SOURCES = main.c common.h config.c crypto.c crypto.h db.c db.h engine_admin.c engine_admin.h engine_interface.c engine_interface.h filehandling.c filehandling.h function_tests.c function_tests.h perl_interpreter.c perl_interpreter.h strhandling.c strhandling.h webservice_interface.c webservice_interface.h xs_init.c
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
 EXTRA_DIST = TEST README-alpha
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -393,7 +393,7 @@ tpath = @TESTFILES@
 ipath = @PREFIX@
 ipathbindir = @BINDIR@
 ipathdatadir = @DATADIR@
-CaumeDSE_SOURCES = main.c common.h crypto.c crypto.h db.c db.h engine_admin.c engine_admin.h engine_interface.c engine_interface.h filehandling.c filehandling.h function_tests.c function_tests.h perl_interpreter.c perl_interpreter.h strhandling.c strhandling.h webservice_interface.c webservice_interface.h xs_init.c
+CaumeDSE_SOURCES = main.c common.h config.c crypto.c crypto.h db.c db.h engine_admin.c engine_admin.h engine_interface.c engine_interface.h filehandling.c filehandling.h function_tests.c function_tests.h perl_interpreter.c perl_interpreter.h strhandling.c strhandling.h webservice_interface.c webservice_interface.h xs_init.c
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
 EXTRA_DIST = TEST README-alpha
 all: config.h

--- a/README
+++ b/README
@@ -1810,6 +1810,11 @@ PRNG, and since the key length are the same, key expansion is unnecessary
 the whole keyspace to take into account the provided salt).  Using this kind
 of keys improves performance considerably.
 
+The default symmetric encryption algorithm used by CaumeDSE is AES-256-CBC.
+You may change this at runtime by setting the environment variable
+`CDSE_DEFAULT_ENC_ALG` to any cipher name recognized by OpenSSL, such as
+`aes-256-gcm` for AES in GCM mode.
+
 All other keys are assumed to be human generated passwords or passphrases
 which require key expansion with a slow function, in order to limit
 dictionary and brute force attacks.  Therefore, they are processed by the

--- a/common.h
+++ b/common.h
@@ -98,7 +98,8 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
 #define cmeDefaultValueSaltLen 16        //Default size for prep-ended bytes for internal databases' encrypted values.
 #define cmeDefaultValueSaltCharLen 2*cmeDefaultValueSaltLen             //Default size for CaumeDSE ByteHexStr value salts used in protected DBs.
 #define cmeDefaultSqlBufferLen 8192         //Default size of Buffer for SQL queries. {8192}
-#define cmeDefaultEncAlg "aes-256-cbc"      //Default algorithm for symmetric encryption in engine admin. databases.
+extern char cmeDefaultEncAlg[];             //Default algorithm for symmetric encryption in engine admin. databases.
+void cmeInitDefaultEncAlg();                //Initialize default algorithm from environment
 #define cmeDefaultHshAlg "sha256"           //Default algorithm for bytestring hashing {digest}.
 #define cmeDefaultMACAlg "sha256"             //Default algorithm for bytestring HMAC MACs .
 #define cmeDefaultInsertSqlRows 512         //Default # of rows to be inserted into a sqlite3 db at a time {within a Begin - Commit block}.

--- a/config.c
+++ b/config.c
@@ -1,0 +1,25 @@
+#include "common.h"
+#include <string.h>
+
+char cmeDefaultEncAlg[64] = "aes-256-cbc";
+
+void cmeInitDefaultEncAlg()
+{
+    const char *envAlg = getenv("CDSE_DEFAULT_ENC_ALG");
+    const EVP_CIPHER *cipher = NULL;
+    if (envAlg && *envAlg)
+    {
+        if (cmeGetCipher(&cipher, envAlg) == 0)
+        {
+            strncpy(cmeDefaultEncAlg, envAlg, sizeof(cmeDefaultEncAlg)-1);
+            cmeDefaultEncAlg[sizeof(cmeDefaultEncAlg)-1] = '\0';
+#ifdef DEBUG
+            fprintf(stdout,"CaumeDSE Debug: using default encryption algorithm %s from environment.\n", cmeDefaultEncAlg);
+#endif
+            return;
+        }
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeInitDefaultEncAlg(), unsupported algorithm %s; using default %s.\n", envAlg, cmeDefaultEncAlg);
+#endif
+    }
+}

--- a/main.c
+++ b/main.c
@@ -79,6 +79,7 @@ int setup(unsigned char **bIn,unsigned char **bOut,PerlInterpreter **myPerl)
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_ADD_ALL_CIPHERS |
                         OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
 #endif
+    cmeInitDefaultEncAlg();
     return(0);
 }
 
@@ -106,7 +107,7 @@ int main(int argc, char *argv[], char *env[])
     unsigned char *bufIn=NULL;
     unsigned char *bufOut=NULL;
     char *title=NULL;
-    const char algorithm[]=cmeDefaultEncAlg;
+    const char *algorithm=cmeDefaultEncAlg;
     const EVP_CIPHER *cipher=NULL;
     #define mainFree() \
         do { \


### PR DESCRIPTION
## Summary
- allow overriding default encryption algorithm via `CDSE_DEFAULT_ENC_ALG`
- call the initializer when setting up the engine
- document the new environment variable
- update build files to include new source

## Testing
- `make` *(fails: missing aclocal script)*

------
https://chatgpt.com/codex/tasks/task_e_686b1ad713548332b0cb89e2cf40a419