### PR TITLE
Fix include for cmeInitDefaultEncAlg

### DIFF
--- a/config.c
+++ b/config.c
@@ -1,5 +1,6 @@
 #include "common.h"
 #include <string.h>
+#include <stdlib.h>
 
 char cmeDefaultEncAlg[64] = "aes-256-cbc";
 


### PR DESCRIPTION
## Summary
- include `<stdlib.h>` in `config.c`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686b379825008332a2e99835329d316a