### PR TITLE
Fix compilation with DEBUG and release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ CONFIG_CLEAN_VPATH_FILES =
 am__installdirs = "$(DESTDIR)$(ipathbindir)" \
 	"$(DESTDIR)$(ipathdatadir)"
 PROGRAMS = $(ipathbin_PROGRAMS)
-am_CaumeDSE_OBJECTS = main.$(OBJEXT) crypto.$(OBJEXT) db.$(OBJEXT) \
+am_CaumeDSE_OBJECTS = main.$(OBJEXT) config.$(OBJEXT) crypto.$(OBJEXT) db.$(OBJEXT) \
 	engine_admin.$(OBJEXT) engine_interface.$(OBJEXT) \
 	filehandling.$(OBJEXT) function_tests.$(OBJEXT) \
 	perl_interpreter.$(OBJEXT) strhandling.$(OBJEXT) \

--- a/Makefile.in
+++ b/Makefile.in
@@ -108,7 +108,7 @@ CONFIG_CLEAN_VPATH_FILES =
 am__installdirs = "$(DESTDIR)$(ipathbindir)" \
 	"$(DESTDIR)$(ipathdatadir)"
 PROGRAMS = $(ipathbin_PROGRAMS)
-am_CaumeDSE_OBJECTS = main.$(OBJEXT) crypto.$(OBJEXT) db.$(OBJEXT) \
+am_CaumeDSE_OBJECTS = main.$(OBJEXT) config.$(OBJEXT) crypto.$(OBJEXT) db.$(OBJEXT) \
 	engine_admin.$(OBJEXT) engine_interface.$(OBJEXT) \
 	filehandling.$(OBJEXT) function_tests.$(OBJEXT) \
 	perl_interpreter.$(OBJEXT) strhandling.$(OBJEXT) \

--- a/filehandling.c
+++ b/filehandling.c
@@ -42,7 +42,9 @@ Copyright 2010-2021 by Omar Alejandro Herrera Reyna
     by Larry Wall and others.
 
 ***/
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include "common.h"
 
 int cmeDirectoryExists (const char *dirPath)
@@ -235,8 +237,13 @@ int cmeCSVFileRowsToMemTable (const char *fName, char ***elements, int *numCols,
         for (cont3=0;cont3<*numCols;cont3++) //Fill in generic names.
         {
             colNames[cont3]=(char *)malloc(sizeof(char) * cmeMaxCSVDefaultColNameSize);  //reserve memory for column name
-            strcpy(colNames[cont3],defaultColName);
-            sprintf((colNames[cont3])+7,"%d",cont3);
+            /* Use snprintf to avoid potential buffer overflows when generating
+             * generic column names.  The buffer has space for up to
+             * cmeMaxCSVDefaultColNameSize bytes including the terminating null
+             * byte.
+             */
+            snprintf(colNames[cont3], cmeMaxCSVDefaultColNameSize,
+                     "%s%d", defaultColName, cont3);
         }
     }
     for (rowCont=1;rowCont<rowStart;rowCont++) //Skip to starting row.


### PR DESCRIPTION
## Summary
- avoid `_GNU_SOURCE` redefinition warning
- prevent possible overflow in default CSV column names
- build `config.c` object explicitly so linking succeeds

## Testing
- `make clean && ./configure && make`
- `make clean && ./configure --enable-DEBUG && make`


------
https://chatgpt.com/codex/tasks/task_e_686b39c3778c8332b513faeb85b740e1