### PR TITLE
v1.0.8: constant-time comparisons to fix timing attack (closes #5)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,34 @@
 2026-03-26 Omar A. Herrera Reyna <0h3rr3r4@gmail.com>
 
+	* configure.ac (AC_INIT): Bumped version to 1.0.8.
+
+	* strhandling.h, strhandling.c: Added cmeStrSafeEq() and
+	cmeMemSafeEq() — constant-time string and memory equality
+	functions that always run for the full length of their inputs,
+	preventing timing-based side-channel leakage on sensitive
+	post-decryption comparisons (fixes GitHub issue #5).
+
+	* webservice_interface.c (cmeWebServiceClientCertAuth): Replaced
+	three strcmp() calls that compared decrypted certificate CN/O
+	values against user-supplied userId and orgId with cmeStrSafeEq().
+
+	* engine_interface.c (cmeSecureSQLToMemDB, cmeDeleteSecureDB,
+	cmeExistsDocumentId): Replaced strncmp() MAC verification calls
+	with cmeMemSafeEq() and strcmp() decrypted documentId comparisons
+	with cmeStrSafeEq().
+
+	* filehandling.c (cmeSecureFileToTmpRAWFile): Replaced four
+	strncmp() MAC verification calls (documentId, documentType,
+	orgResourceId, storageId, columnFile) with cmeMemSafeEq() and
+	the four-field compound strcmp() identity check with
+	cmeStrSafeEq().
+
+	* function_tests.c (cmeTestThreadWorker): Added remove() at the
+	start of the test worker to eliminate stale DB files from a
+	previous failed run, ensuring idempotent test execution.
+
+2026-03-26 Omar A. Herrera Reyna <0h3rr3r4@gmail.com>
+
 	* configure.ac (AC_INIT): Bumped version to 1.0.7.
 
 	* configure.ac: Added --with-max-threads=N option (default 4).

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Caume Data Security Engine (CaumeDSE) version 1.0.7
+Caume Data Security Engine (CaumeDSE) version 1.0.8
 
 CONTENTS
 ========
@@ -127,6 +127,12 @@ Right now, the software is in a stable release:
 
 	* Basic functionality is complete and tested but some features are
 	  still pending.
+
+	* Constant-time comparisons (v1.0.8): all post-decryption string
+	  and MAC comparisons that could leak information via timing
+	  (strcmp/strncmp on decrypted values and HMAC results) replaced
+	  with new cmeStrSafeEq() and cmeMemSafeEq() functions.  Closes
+	  GitHub issue #5.
 
 	* Concurrent multi-user support added (v1.0.7): libmicrohttpd now
 	  runs a configurable worker-thread pool (default: 4 threads,

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([CaumeDSE], [1.0.7], [0h3rr3r4@gmail.com])
+AC_INIT([CaumeDSE], [1.0.8], [0h3rr3r4@gmail.com])
 AM_INIT_AUTOMAKE([dist-bzip2 color-tests readme-alpha])
 AC_CONFIG_SRCDIR([function_tests.c])
 AC_CONFIG_HEADERS([config.h])

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -35,7 +35,7 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
     the public domain (http://www.sqlite.org/copyright.html).
 
     This product includes software from the GNU Libmicrohttpd project, Copyright
-    © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+    ï¿½ 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
     2008, 2009, 2010 , 2011, 2012 Free Software Foundation, Inc.
 
     This product includes software from Perl5, which is Copyright (C) 1993-2005,
@@ -176,7 +176,7 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
         cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                           (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen),
                           &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-        if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
+        if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
         {
             result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                                              &currentDocumentId,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -200,14 +200,14 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
             cmeStrConstrAppend(&currentDocumentId,""); //This pointer can't be null (strcmp() will segfault), so we point it to an empty string.
         }
         //Check if register is part of the requested file. If so continue processing it:
-        if (!strcmp(currentDocumentId,documentId)) //This column is part of the table!
+        if (cmeStrSafeEq(currentDocumentId,documentId)) //This column is part of the table!
         {
             //Unprotect columnFile:
             cmeFree(protectedValueMAC);
             cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen,
                               (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen),
                               &written2,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-            if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile],MACLen)) //MAC is correct; proceed with decryption.
+            if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile],MACLen)) //MAC is correct; proceed with decryption.
             {
                 result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen,
                                      &(colSQLDBfNames[dbNumCols]),cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -460,7 +460,7 @@ int cmeDeleteSecureDB (sqlite3 *pResourcesDB,const char *documentId, const char 
             cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                               (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen),
                               &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-            if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
+            if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
             {
                 result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                                      &currentDocumentId,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -474,14 +474,14 @@ int cmeDeleteSecureDB (sqlite3 *pResourcesDB,const char *documentId, const char 
                     cmeDeleteSecureDBFree(); //CLEANUP.
                     return(2);
                 }
-                if (!strcmp(currentDocumentId,documentId))//This column is part of the table!
+                if (cmeStrSafeEq(currentDocumentId,documentId))//This column is part of the table!
                 {
                     //Unprotect columnFile:
                     cmeFree(protectedValueMAC);
                     cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen,
                                       (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen),
                                       &written2,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-                    if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile],MACLen)) //MAC is correct; proceed with decryption.
+                    if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile],MACLen)) //MAC is correct; proceed with decryption.
                     {
                         result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen,
                                              &(colSQLDBfNames[dbNumCols]),cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -1306,7 +1306,7 @@ int cmeExistsDocumentId (sqlite3 *pResourcesDB,const char *documentId, const cha
         cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                           (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen),
                           &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-        if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
+        if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
         {
             result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                                              &currentDocumentId,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -1330,7 +1330,7 @@ int cmeExistsDocumentId (sqlite3 *pResourcesDB,const char *documentId, const cha
             cmeStrConstrAppend(&currentDocumentId,""); //This pointer can't be null (strcmp() will segfault), so we point it to an empty string.
         }
         //Check if register is part of the requested file. If so continue processing it:
-        if (!strcmp(currentDocumentId,documentId)) //This column is part of the table!
+        if (cmeStrSafeEq(currentDocumentId,documentId)) //This column is part of the table!
         {
             (*numEntries)++;
         }

--- a/filehandling.c
+++ b/filehandling.c
@@ -1087,7 +1087,7 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
         cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                           (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen),
                           &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-        if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
+        if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId],MACLen)) //MAC is correct; proceed with decryption.
         {
             result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_documentId]+MACLen,
                                  &currentDocumentId,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -1115,7 +1115,7 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
         cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_type]+MACLen,
                           (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_type]+MACLen),
                           &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-        if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_type],MACLen)) //MAC is correct; proceed with decryption.
+        if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_type],MACLen)) //MAC is correct; proceed with decryption.
         {
             result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_type]+MACLen,
                                  &currentDocumentType,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -1143,7 +1143,7 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
         cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_orgResourceId]+MACLen,
                           (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_orgResourceId]+MACLen),
                           &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-        if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_orgResourceId],MACLen)) //MAC is correct; proceed with decryption.
+        if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_orgResourceId],MACLen)) //MAC is correct; proceed with decryption.
         {
             result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_orgResourceId]+MACLen,
                                  &currentOrgResourceId,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -1171,7 +1171,7 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
         cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_storageId]+MACLen,
                           (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_storageId]+MACLen),
                           &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-        if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_storageId],MACLen)) //MAC is correct; proceed with decryption.
+        if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_storageId],MACLen)) //MAC is correct; proceed with decryption.
         {
             result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_storageId]+MACLen,
                                  &currentStorageId,cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),
@@ -1195,15 +1195,15 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
             cmeStrConstrAppend(&currentStorageId,""); //This pointer can't be null (strcmp() will segfault), so we point it to an empty string.
         }
         //Verify that this part belongs to the requested document. If so continue processing it:
-        if ((!(strcmp(currentDocumentId,documentId)))&&(!(strcmp(currentDocumentType,documentType)))
-            &&(!(strcmp(currentOrgResourceId,orgId)))&&(!(strcmp(currentStorageId,storageId))))  //This part belongs to the protected RAWFile -> process!
+        if (cmeStrSafeEq(currentDocumentId,documentId)&&cmeStrSafeEq(currentDocumentType,documentType)
+            &&cmeStrSafeEq(currentOrgResourceId,orgId)&&cmeStrSafeEq(currentStorageId,storageId))  //This part belongs to the protected RAWFile -> process!
         {
             //Unprotect columnFile:
             cmeFree(protectedValueMAC);
             cmeHMACByteString((const unsigned char*)queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen,
                               (unsigned char **)&protectedValueMAC,strlen(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen),
                               &written,cmeDefaultMACAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),orgKey);
-            if (!strncmp(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile],MACLen)) //MAC is correct; proceed with decryption.
+            if (cmeMemSafeEq(protectedValueMAC,queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile],MACLen)) //MAC is correct; proceed with decryption.
             {
                 result=cmeUnprotectDBSaltedValue(queryResult[(cont*numCols)+cmeIDDResourcesDBDocuments_columnFile]+MACLen,
                                      &(colSQLDBfNames[dbNumCols]),cmeDefaultEncAlg,&(queryResult[(cont*numCols)+cmeIDDanydb_salt]),

--- a/function_tests.c
+++ b/function_tests.c
@@ -745,6 +745,7 @@ static void *cmeTestThreadWorker (void *arg)
 
     // Each thread uses its own temporary file-based DB with a unique name.
     cmeStrConstrAppend(&dbPath,"%stest_thread_%d.db",cmeDefaultFilePath,a->threadId);
+    remove(dbPath); // Ensure no stale data from a previous failed run.
 
     // Open (create) the per-thread DB.
     if (cmeDBCreateOpen(dbPath,&db))

--- a/strhandling.c
+++ b/strhandling.c
@@ -515,3 +515,34 @@ int cmex509GetElementFromDN (const char* DN, const char *elementId, char **eleme
         return(0);
     }
 }
+
+int cmeStrSafeEq (const char *a, const char *b)
+{   //Constant-time string equality to prevent timing attacks on sensitive comparisons (e.g. post-decryption values).
+    //Returns 1 if strings are equal, 0 if not. Runs for max(strlen(a),strlen(b)) iterations regardless of content.
+    size_t la=strlen(a);
+    size_t lb=strlen(b);
+    size_t maxLen=(la > lb) ? la : lb;
+    unsigned char diff=(unsigned char)(la != lb);
+    size_t i;
+    for (i=0; i<maxLen; i++)
+    {
+        unsigned char ca=(i < la) ? (unsigned char)a[i] : 0;
+        unsigned char cb=(i < lb) ? (unsigned char)b[i] : 0;
+        diff|=ca ^ cb;
+    }
+    return (diff == 0);
+}
+
+int cmeMemSafeEq (const void *a, const void *b, size_t n)
+{   //Constant-time memory equality to prevent timing attacks on sensitive comparisons (e.g. MAC verification).
+    //Returns 1 if first n bytes are equal, 0 if not.
+    const unsigned char *pa=(const unsigned char *)a;
+    const unsigned char *pb=(const unsigned char *)b;
+    unsigned char diff=0;
+    size_t i;
+    for (i=0; i<n; i++)
+    {
+        diff|=pa[i] ^ pb[i];
+    }
+    return (diff == 0);
+}

--- a/strhandling.h
+++ b/strhandling.h
@@ -85,5 +85,9 @@ int cmeConstructWebServiceTableResponse (const char **resultTable, const int tab
                                          char ***responseHeaders, char **resultTableStr, int *responseCode);
 //Function to get an element (C, ST, L, O, OU or CN) from an x509 DN.
 int cmex509GetElementFromDN (const char* DN, const char *elementId, char **element, int *elementLen);
+// Constant-time string equality: returns 1 if equal, 0 if not (prevents timing attacks on sensitive comparisons).
+int cmeStrSafeEq (const char *a, const char *b);
+// Constant-time memory equality: returns 1 if first n bytes are equal, 0 if not.
+int cmeMemSafeEq (const void *a, const void *b, size_t n);
 
 #endif // STRHANDLING_H_INCLUDED

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -9461,7 +9461,7 @@ int cmeWebServiceClientCertAuth (const char *userId, const char *orgId, struct M
     result=cmex509GetElementFromDN(userDN,"O",&userO,&len);
     result=cmex509GetElementFromDN(orgDN,"CN",&orgCN,&len);
     //Verify that user CN (in userDN), user O (in userDN) and org O (in orgDN) against corresponding userId and orgId:
-    if (strcmp(userId,userCN)) //Authentication error: userId does not match client certificate CN!
+    if (!cmeStrSafeEq(userId,userCN)) //Authentication error: userId does not match client certificate CN!
     {
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceClientCertAuth(), Warning, "
@@ -9470,7 +9470,7 @@ int cmeWebServiceClientCertAuth (const char *userId, const char *orgId, struct M
         cmeWebServiceClientCertAuthFree();
         return(9);
     }
-    if (strcmp(orgId,userO)) //Authentication error: orgId does not match client certificate O!
+    if (!cmeStrSafeEq(orgId,userO)) //Authentication error: orgId does not match client certificate O!
     {
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceClientCertAuth(), Warning, "
@@ -9479,7 +9479,7 @@ int cmeWebServiceClientCertAuth (const char *userId, const char *orgId, struct M
         cmeWebServiceClientCertAuthFree();
         return(10);
     }
-    if (strcmp(orgId,orgCN)) //Authentication error: orgId does not match issuer organization certificate CN!
+    if (!cmeStrSafeEq(orgId,orgCN)) //Authentication error: orgId does not match issuer organization certificate CN!
     {
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceClientCertAuth(), Warning, "


### PR DESCRIPTION
## Summary

- Add `cmeStrSafeEq()` and `cmeMemSafeEq()` to `strhandling` — constant-time string and memory equality functions that always run for the full length of their inputs, preventing timing side-channel leakage
- Replace all security-sensitive `strcmp`/`strncmp` calls operating on post-decryption values and HMAC results across `webservice_interface.c`, `engine_interface.c`, and `filehandling.c`
- Fix `testThreadSafety()` worker to remove stale DB files at startup, ensuring idempotent test runs

## Affected comparisons

| File | Function | Type | Old | New |
|------|----------|------|-----|-----|
| `webservice_interface.c` | `cmeWebServiceClientCertAuth` | string | `strcmp` (×3) | `cmeStrSafeEq` |
| `engine_interface.c` | `cmeSecureSQLToMemDB` | MAC + string | `strncmp`, `strcmp` (×2) | `cmeMemSafeEq`, `cmeStrSafeEq` |
| `engine_interface.c` | `cmeDeleteSecureDB` | MAC + string | `strncmp`, `strcmp` (×2) | `cmeMemSafeEq`, `cmeStrSafeEq` |
| `engine_interface.c` | `cmeExistsDocumentId` | MAC + string | `strncmp`, `strcmp` | `cmeMemSafeEq`, `cmeStrSafeEq` |
| `filehandling.c` | `cmeSecureFileToTmpRAWFile` | MAC + string | `strncmp` (×5), `strcmp` (×4) | `cmeMemSafeEq`, `cmeStrSafeEq` |

## Test plan

- [x] `make` — clean build, no warnings
- [x] `./CaumeDSE` — all tests pass including `testThreadSafety() PASSED (4 threads, 0 errors)`
- [x] Tests are idempotent across repeated runs

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)