### PR TITLE
v1.0.9: samples/hsm-db-crypto — four independent client apps

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,40 @@
+2026-03-27 Omar A. Herrera Reyna <0h3rr3r4@gmail.com>
+
+	* configure.ac (AC_INIT): Bumped version to 1.0.9.
+
+	* samples/hsm-db-crypto/: New directory with four independent
+	sample client applications demonstrating the CDSE API as a hybrid
+	HSM / encrypted-database / general-crypto interface.
+
+	* samples/hsm-db-crypto/a-web/index.html: Single-page HTML5/CSS3/
+	JavaScript application.  Provides tabbed UI for Secrets (file.raw),
+	Database (file.csv CRUD), Audit Log, and Info.  Uses the CORS
+	proxy below; no external JS/CSS dependencies.
+
+	* samples/hsm-db-crypto/a-web/proxy.py: Python 3 CORS proxy.
+	Serves index.html at http://localhost:8080 and forwards /cdse/*
+	requests to https://localhost:8443 (configurable).  Standard
+	library only; supports --insecure for development.
+
+	* samples/hsm-db-crypto/b-python/cdse_client.py: Python 3 CLI.
+	Supports interactive (-i) and one-shot parameter modes.  Reads
+	credentials from CLI flags or env vars (CDSE_SERVER, CDSE_USER_ID,
+	CDSE_ORG_ID, CDSE_ORG_KEY, CDSE_STORAGE).  Requires: requests.
+
+	* samples/hsm-db-crypto/c-golang/cdse_client.go: Go CLI.  Uses
+	standard library only (net/http, crypto/tls, mime/multipart,
+	encoding/csv).  Supports interactive (-i) and one-shot modes.
+	Build: go build -o cdse_client .
+
+	* samples/hsm-db-crypto/d-perl/cdse_client.pl: Perl CLI.  Uses
+	LWP::UserAgent and HTTP::Request::Common.  Supports interactive
+	(-i) and one-shot modes; optional Term::ReadKey for hidden
+	password input.
+
+	* samples/hsm-db-crypto/README: Plain-text quick-start guide
+	covering all four clients, API command-to-endpoint mapping table,
+	credential environment variables, and security notes.
+
 2026-03-26 Omar A. Herrera Reyna <0h3rr3r4@gmail.com>
 
 	* configure.ac (AC_INIT): Bumped version to 1.0.8.

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Caume Data Security Engine (CaumeDSE) version 1.0.8
+Caume Data Security Engine (CaumeDSE) version 1.0.9
 
 CONTENTS
 ========
@@ -127,6 +127,21 @@ Right now, the software is in a stable release:
 
 	* Basic functionality is complete and tested but some features are
 	  still pending.
+
+	* Sample applications added (v1.0.9): a new samples/hsm-db-crypto/
+	  directory provides four independent client implementations that
+	  demonstrate the CDSE API as a hybrid HSM / encrypted database /
+	  general cryptographic command interface:
+	    a) Web (HTML5 + JavaScript SPA with a local CORS proxy)
+	    b) Python 3 CLI (requires: requests)
+	    c) Go CLI (standard library only, no external dependencies)
+	    d) Perl CLI (requires: LWP::UserAgent, HTTP::Request::Common)
+	  All CLI variants support interactive sessions (credentials entered
+	  once) and one-shot parameter mode (credentials per call, or via
+	  environment variables CDSE_SERVER/CDSE_USER_ID/CDSE_ORG_ID/
+	  CDSE_ORG_KEY/CDSE_STORAGE).  Operations covered: encrypted secret
+	  storage, encrypted CSV databases (insert/query/update/delete),
+	  user/org info, and transaction audit log.
 
 	* Constant-time comparisons (v1.0.8): all post-decryption string
 	  and MAC comparisons that could leak information via timing

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([CaumeDSE], [1.0.8], [0h3rr3r4@gmail.com])
+AC_INIT([CaumeDSE], [1.0.9], [0h3rr3r4@gmail.com])
 AM_INIT_AUTOMAKE([dist-bzip2 color-tests readme-alpha])
 AC_CONFIG_SRCDIR([function_tests.c])
 AC_CONFIG_HEADERS([config.h])

--- a/samples/hsm-db-crypto/README
+++ b/samples/hsm-db-crypto/README
@@ -1,0 +1,256 @@
+CaumeDSE Sample Client Applications - HSM / Encrypted Database / Crypto Interface
+==================================================================================
+
+CONTENTS
+========
+I.      Overview
+II.     Prerequisites
+III.    Directory structure
+IV.     Quick start
+V.      Common operations
+VI.     Interactive vs. parameter mode
+VII.    Security notes
+VIII.   API mapping
+
+
+I. Overview
+-----------
+
+These four sample clients demonstrate using CaumeDSE (Caume Data Security
+Engine) as a hybrid HSM / encrypted database / general cryptographic command
+interface via its REST API.
+
+Each client covers the same set of operations:
+
+  * Encrypted secret storage - arbitrary binary blobs stored as file.raw
+    documents, encrypted at rest inside the CDSE engine.
+
+  * Encrypted CSV databases - structured tabular data stored as file.csv
+    documents, supporting full CRUD (create, insert, query, update, delete).
+
+  * User / organization info - retrieve metadata for the authenticated user
+    and organization.
+
+  * Audit log - retrieve the transaction log for all operations performed
+    against the engine.
+
+The clients are intentionally straightforward so that they serve as a
+starting point for integrating CDSE into real applications.
+
+
+II. Prerequisites
+-----------------
+
+  * A running CaumeDSE instance.  The samples default to:
+
+      https://localhost:8443
+
+  * Default admin credentials used by the samples:
+
+      userId  : EngineAdmin
+      orgId   : EngineOrg
+      orgKey  : 0CDBB9AF76AF43BDB72E095989E612CC
+      storage : EngineStorage
+
+  * TLS certificate: development builds ship with a self-signed certificate.
+    Pass --insecure (or -insecure for Go) to disable TLS verification, or
+    supply the CA certificate path if your client supports it.  Never use
+    --insecure in production.
+
+
+III. Directory structure
+------------------------
+
+  a-web/              HTML5 single-page application with a Python CORS proxy
+    proxy.py            Python 3 reverse proxy (forwards browser requests to
+                        CDSE and adds CORS headers)
+
+  b-python/           Python 3 command-line client
+    cdse_client.py      Main client script
+
+  c-golang/           Go command-line client
+    cdse_client.go      Main client source
+    go.mod              Go module definition
+
+  d-perl/             Perl command-line client
+    cdse_client.pl      Main client script
+
+
+IV. Quick start
+---------------
+
+1. Web client (a-web)
+
+   The browser cannot contact CDSE directly when origins differ, so proxy.py
+   must be running first.
+
+     cd a-web
+     python3 proxy.py --insecure
+
+   Then open http://localhost:8080 in a browser.  The page connects to
+   proxy.py, which forwards requests to https://localhost:8443.
+
+2. Python client (b-python)
+
+   Dependency:
+
+     pip install requests
+
+   Interactive mode (prompts for credentials and command):
+
+     python3 cdse_client.py --insecure -i
+
+   One-shot example (store a secret):
+
+     python3 cdse_client.py --insecure \
+       --user EngineAdmin --org EngineOrg --key 0CDBB9AF76AF43BDB72E095989E612CC \
+       --storage EngineStorage store-secret my_key /path/to/keyfile.bin
+
+3. Go client (c-golang)
+
+   Build:
+
+     cd c-golang
+     go build -o cdse_client .
+
+   Interactive mode:
+
+     ./cdse_client -insecure -i
+
+   One-shot example (query a database):
+
+     ./cdse_client -insecure \
+       -user EngineAdmin -org EngineOrg -key 0CDBB9AF76AF43BDB72E095989E612CC \
+       -storage EngineStorage db-query contacts
+
+4. Perl client (d-perl)
+
+   Dependencies:
+
+     apt install libwww-perl          # Debian / Ubuntu
+     # or
+     cpan LWP::UserAgent HTTP::Request::Common
+
+   Interactive mode:
+
+     perl cdse_client.pl --insecure -i
+
+   One-shot example (retrieve a secret):
+
+     perl cdse_client.pl --insecure \
+       --user EngineAdmin --org EngineOrg --key 0CDBB9AF76AF43BDB72E095989E612CC \
+       --storage EngineStorage get-secret my_key /path/to/output.bin
+
+
+V. Common operations
+--------------------
+
+The examples below use the default credentials.  In interactive mode the
+client will prompt for each value instead.
+
+  # Show user / organization info
+  info
+
+  # Store a secret (encrypt and upload a binary file)
+  store-secret my_key /path/to/keyfile.bin
+
+  # Retrieve a secret (download and decrypt)
+  get-secret my_key /path/to/output.bin
+
+  # List stored secrets
+  list-secrets
+
+  # Delete a secret
+  delete-secret my_key
+
+  # Create an encrypted CSV database with named columns
+  db-create contacts id,name,email,phone
+
+  # Insert a row (key=value pairs)
+  db-insert contacts id=1 name=Alice email=alice@example.com phone=555-0100
+
+  # Query all rows
+  db-query contacts
+
+  # Update a row (by row number, 1-based)
+  db-update contacts 1 email=alice@newdomain.com
+
+  # Delete a row
+  db-delete-row contacts 1
+
+  # List all databases
+  db-list
+
+  # View audit log
+  audit-log
+
+
+VI. Interactive vs. parameter mode
+-----------------------------------
+
+Interactive mode (-i / --interactive)
+
+  The client prompts for the server URL, credentials, and the command to run.
+  Sensitive values such as orgKey are not echoed.  This is the recommended
+  mode for manual use.
+
+Parameter mode
+
+  All values are supplied as command-line flags followed by the command name
+  and its arguments.  Suitable for scripting.
+
+Environment variables (all clients honor these when set):
+
+  CDSE_SERVER     Base URL of the CDSE instance  (default: https://localhost:8443)
+  CDSE_USER_ID    userId for authentication       (default: EngineAdmin)
+  CDSE_ORG_ID     orgId for authentication        (default: EngineOrg)
+  CDSE_ORG_KEY    orgKey (encryption key)         (default: none)
+  CDSE_STORAGE    storage instance name           (default: EngineStorage)
+
+Environment variables take precedence over built-in defaults but are
+overridden by explicit command-line flags.
+
+
+VII. Security notes
+-------------------
+
+  * orgKey is the organization encryption key.  Treat it as a secret.
+    Passing it on the command line exposes it in shell history and process
+    listings.  Prefer interactive mode or the CDSE_ORG_KEY environment
+    variable set for the session only (export in a subshell or prefix the
+    command).
+
+  * The --insecure flag disables TLS certificate verification.  Use it only
+    in development against a local CDSE instance.  In any other environment
+    supply the CA certificate so that the server identity is verified.
+
+  * The default credentials (EngineAdmin / 0CDBB9AF76AF43BDB72E095989E612CC)
+    are publicly documented.  Change them before deploying CDSE in any
+    environment that handles real data.
+
+
+VIII. API mapping
+-----------------
+
+Each client command maps to a CDSE REST endpoint as follows.  The path
+prefix /organizations/{orgId}/storage/{storage}/documentTypes is abbreviated
+as .../documentTypes below.
+
+  Command         Method   CDSE Endpoint
+  --------------- -------- -------------------------------------------------------
+  info            GET      /organizations/{orgId}/users/{userId}
+  list-secrets    GET      .../documentTypes/file.raw/documents
+  store-secret    POST     .../documentTypes/file.raw/documents/{name}
+  get-secret      GET      .../documentTypes/file.raw/documents/{name}/content
+  delete-secret   DELETE   .../documentTypes/file.raw/documents/{name}
+  db-list         GET      .../documentTypes/file.csv/documents
+  db-create       POST     .../documentTypes/file.csv/documents/{name}
+  db-insert       POST     .../documentTypes/file.csv/documents/{name}/contentRows/{N}
+  db-query        GET      .../documentTypes/file.csv/documents/{name}/content
+  db-update       PUT      .../documentTypes/file.csv/documents/{name}/contentRows/{N}
+  db-delete-row   DELETE   .../documentTypes/file.csv/documents/{name}/contentRows/{N}
+  audit-log       GET      /transactions
+
+All requests are authenticated via the orgKey, which CDSE uses both to
+identify the organization and as the root from which document encryption keys
+are derived.  No key material is stored inside the engine.

--- a/samples/hsm-db-crypto/a-web/index.html
+++ b/samples/hsm-db-crypto/a-web/index.html
@@ -1,0 +1,1183 @@
+<!DOCTYPE html>
+<!--
+  CaumeDSE Web Client — HSM / DB / Crypto
+  =========================================
+  Self-contained single-page application (no external dependencies).
+  Run via proxy.py, which serves this file and forwards /cdse/* to the
+  CDSE HTTPS API (default: https://localhost:8443).
+
+  CORS note: All API calls go through the /cdse/ proxy prefix so the browser
+  treats them as same-origin requests.  Direct access to https://localhost:8443
+  from a browser would be blocked by CORS unless the CDSE server is configured
+  with permissive CORS headers.
+
+  TLS note: If the CDSE server uses a self-signed certificate, start proxy.py
+  with --insecure.  Alternatively, visit https://localhost:8443 once in the
+  browser and accept the security exception before using this client.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CaumeDSE Client — HSM / DB / Crypto</title>
+<style>
+  /* ── Reset & base ── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg:        #1a1a2e;
+    --bg2:       #16213e;
+    --bg3:       #0f3460;
+    --accent:    #4ecca3;
+    --accent2:   #38b48b;
+    --text:      #e0e0e0;
+    --text-dim:  #8888aa;
+    --error:     #e94560;
+    --error-bg:  #2a0a14;
+    --ok-bg:     #0a2a20;
+    --border:    #2a2a4a;
+    --input-bg:  #0d1b2a;
+    --radius:    6px;
+    --font-mono: 'Courier New', Courier, monospace;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+  }
+
+  /* ── Header ── */
+  header {
+    background: var(--bg3);
+    padding: 14px 24px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-bottom: 2px solid var(--accent);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+  }
+  header h1 {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--accent);
+    letter-spacing: 0.03em;
+  }
+  header .badge {
+    font-size: 0.72rem;
+    background: var(--bg2);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 2px 8px;
+    border-radius: 20px;
+    margin-left: auto;
+  }
+
+  /* ── Layout ── */
+  main { max-width: 960px; margin: 0 auto; padding: 20px 16px 60px; }
+
+  /* ── Connection panel ── */
+  .conn-panel {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-bottom: 20px;
+  }
+  .conn-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    cursor: pointer;
+    user-select: none;
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .conn-toggle:hover { background: rgba(78,204,163,0.06); }
+  .conn-toggle .arrow { transition: transform 0.2s; }
+  .conn-toggle.open .arrow { transform: rotate(180deg); }
+  .conn-body {
+    display: none;
+    padding: 12px 16px 16px;
+    border-top: 1px solid var(--border);
+  }
+  .conn-body.open { display: block; }
+  .conn-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+  }
+
+  /* ── Form controls ── */
+  label { display: block; font-size: 0.82rem; color: var(--text-dim); margin-bottom: 4px; }
+  input[type=text], input[type=password], textarea, select {
+    width: 100%;
+    background: var(--input-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    padding: 7px 10px;
+    font-size: 0.9rem;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  input[type=text]:focus, input[type=password]:focus,
+  textarea:focus, select:focus {
+    border-color: var(--accent);
+  }
+  textarea { resize: vertical; font-family: var(--font-mono); min-height: 64px; }
+  input[type=file] {
+    color: var(--text);
+    font-size: 0.88rem;
+  }
+  input[type=file]::file-selector-button {
+    background: var(--bg3);
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius);
+    padding: 4px 10px;
+    cursor: pointer;
+    margin-right: 8px;
+    font-size: 0.85rem;
+  }
+
+  /* ── Buttons ── */
+  button, .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg3);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 7px 16px;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 0.88rem;
+    font-weight: 600;
+    transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+  }
+  button:hover, .btn:hover {
+    background: var(--accent);
+    color: var(--bg);
+  }
+  button:active { opacity: 0.8; }
+  button.danger { border-color: var(--error); color: var(--error); }
+  button.danger:hover { background: var(--error); color: #fff; }
+  button.primary { background: var(--accent); color: var(--bg); }
+  button.primary:hover { background: var(--accent2); }
+
+  /* ── Tabs ── */
+  .tabs { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 2px solid var(--border); }
+  .tab-btn {
+    background: transparent;
+    border: none;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    padding: 8px 18px;
+    color: var(--text-dim);
+    font-size: 0.92rem;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: 0;
+    transition: color 0.15s;
+  }
+  .tab-btn:hover { color: var(--text); background: transparent; }
+  .tab-btn.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+    background: transparent;
+  }
+  .tab-pane { display: none; }
+  .tab-pane.active { display: block; }
+
+  /* ── Sub-panels (cards) ── */
+  .card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    margin-bottom: 14px;
+  }
+  .card h3 {
+    font-size: 0.9rem;
+    color: var(--accent);
+    font-weight: 700;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .form-row { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+  .form-row .field { flex: 1 1 150px; }
+  .form-row .field-wide { flex: 2 1 240px; }
+  .form-row .actions { flex: 0 0 auto; }
+
+  /* ── Output area ── */
+  .result-area {
+    margin-top: 16px;
+    background: var(--input-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 14px;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    min-height: 48px;
+    max-height: 400px;
+    overflow-y: auto;
+    color: var(--text-dim);
+  }
+  .result-area.ok  { border-color: var(--accent); color: var(--accent); background: var(--ok-bg); }
+  .result-area.err { border-color: var(--error);  color: var(--error);  background: var(--error-bg); }
+
+  /* ── Tables ── */
+  .csv-table-wrap { overflow-x: auto; margin-top: 12px; }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+    font-family: var(--font-mono);
+  }
+  th {
+    background: var(--bg3);
+    color: var(--accent);
+    text-align: left;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  td {
+    padding: 5px 10px;
+    border: 1px solid var(--border);
+    vertical-align: top;
+    word-break: break-word;
+  }
+  tr:nth-child(even) td { background: rgba(255,255,255,0.03); }
+  tr:hover td { background: rgba(78,204,163,0.06); }
+
+  /* ── Download link ── */
+  .dl-link { display: inline-block; margin-top: 8px; color: var(--accent); text-decoration: none; }
+  .dl-link:hover { text-decoration: underline; }
+
+  /* ── Spinner ── */
+  .spinner {
+    display: inline-block;
+    width: 14px; height: 14px;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    vertical-align: middle;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* ── Misc ── */
+  hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+  .section-actions { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 14px; }
+  .help-text { font-size: 0.78rem; color: var(--text-dim); margin-top: 4px; }
+  @media (max-width: 600px) {
+    header h1 { font-size: 1rem; }
+    .form-row { flex-direction: column; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════════ HEADER ═══════════════════════════════ -->
+<header>
+  <h1>CaumeDSE Client — HSM / DB / Crypto</h1>
+  <span class="badge">REST Sample</span>
+</header>
+
+<main>
+
+  <!-- ═══════════════════════ CONNECTION PANEL ═══════════════════════════ -->
+  <div class="conn-panel">
+    <div class="conn-toggle open" id="connToggle" onclick="toggleConn()">
+      <span>Connection Settings</span>
+      <span class="arrow">▼</span>
+    </div>
+    <div class="conn-body open" id="connBody">
+      <div class="conn-grid">
+        <div>
+          <label for="userId">User ID</label>
+          <input type="text" id="userId" value="User123" placeholder="e.g. User123">
+        </div>
+        <div>
+          <label for="orgId">Organisation ID</label>
+          <input type="text" id="orgId" value="CaumeDSE" placeholder="e.g. CaumeDSE">
+        </div>
+        <div>
+          <label for="orgKey">Organisation Key</label>
+          <input type="password" id="orgKey" value="" placeholder="password / org key">
+        </div>
+        <div>
+          <label for="storage">Storage Name</label>
+          <input type="text" id="storage" value="EngineStorage" placeholder="e.g. EngineStorage">
+        </div>
+      </div>
+      <p class="help-text" style="margin-top:10px;">
+        Requests go to <code>/cdse/</code> — the proxy.py script forwards them to the CDSE HTTPS server.
+        If using a self-signed certificate run <code>proxy.py --insecure</code>.
+      </p>
+    </div>
+  </div>
+
+  <!-- ════════════════════════════ TABS ═══════════════════════════════════ -->
+  <div class="tabs">
+    <button class="tab-btn active" onclick="switchTab('secrets',this)">Secrets</button>
+    <button class="tab-btn"        onclick="switchTab('database',this)">Database</button>
+    <button class="tab-btn"        onclick="switchTab('auditlog',this)">Audit Log</button>
+    <button class="tab-btn"        onclick="switchTab('info',this)">Info</button>
+  </div>
+
+  <!-- ══════════════════════════ SECRETS TAB ══════════════════════════════ -->
+  <div class="tab-pane active" id="tab-secrets">
+
+    <!-- Upload -->
+    <div class="card">
+      <h3>Upload Secret</h3>
+      <div class="form-row">
+        <div class="field">
+          <label for="sec-upload-name">Secret Name (document ID)</label>
+          <input type="text" id="sec-upload-name" placeholder="e.g. mySecret.bin">
+        </div>
+        <div class="field">
+          <label for="sec-upload-file">File</label>
+          <input type="file" id="sec-upload-file">
+        </div>
+        <div class="field">
+          <label for="sec-upload-info">Resource Info</label>
+          <input type="text" id="sec-upload-info" placeholder="Optional description">
+        </div>
+        <div class="actions">
+          <button onclick="uploadSecret()">Upload</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Retrieve -->
+    <div class="card">
+      <h3>Retrieve Secret</h3>
+      <div class="form-row">
+        <div class="field-wide">
+          <label for="sec-get-name">Secret Name</label>
+          <input type="text" id="sec-get-name" placeholder="e.g. mySecret.bin">
+        </div>
+        <div class="actions">
+          <button onclick="retrieveSecret()">Retrieve</button>
+        </div>
+      </div>
+      <div id="sec-get-download"></div>
+    </div>
+
+    <!-- Delete -->
+    <div class="card">
+      <h3>Delete Secret</h3>
+      <div class="form-row">
+        <div class="field-wide">
+          <label for="sec-del-name">Secret Name</label>
+          <input type="text" id="sec-del-name" placeholder="e.g. mySecret.bin">
+        </div>
+        <div class="actions">
+          <button class="danger" onclick="deleteSecret()">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- List -->
+    <div class="section-actions">
+      <button onclick="listSecrets()">List All Secrets</button>
+    </div>
+
+    <div class="result-area" id="result-secrets">Results appear here…</div>
+  </div><!-- /tab-secrets -->
+
+  <!-- ══════════════════════════ DATABASE TAB ══════════════════════════════ -->
+  <div class="tab-pane" id="tab-database">
+
+    <!-- Create DB -->
+    <div class="card">
+      <h3>Create Database</h3>
+      <div class="form-row">
+        <div class="field">
+          <label for="db-create-name">Database Name</label>
+          <input type="text" id="db-create-name" placeholder="e.g. MyDB.csv">
+        </div>
+        <div class="field">
+          <label for="db-create-cols">Columns (comma-separated)</label>
+          <input type="text" id="db-create-cols" placeholder="e.g. name,age,email">
+        </div>
+        <div class="actions">
+          <button onclick="createDatabase()">Create</button>
+        </div>
+      </div>
+      <p class="help-text">
+        The database is stored as a CSV-format secure document.
+        The first row of the file contains the column headers.
+      </p>
+    </div>
+
+    <!-- Insert Row -->
+    <div class="card">
+      <h3>Insert Row</h3>
+      <div class="form-row">
+        <div class="field">
+          <label for="db-ins-name">Database Name</label>
+          <input type="text" id="db-ins-name" placeholder="e.g. MyDB.csv">
+        </div>
+      </div>
+      <div style="margin-top:10px;">
+        <label for="db-ins-vals">Column values (one per line: <code>colName=value</code>)</label>
+        <textarea id="db-ins-vals" rows="4" placeholder="name=Alice&#10;age=30&#10;email=alice@example.com"></textarea>
+      </div>
+      <div style="margin-top:10px;">
+        <button onclick="insertRow()">Insert Row</button>
+      </div>
+    </div>
+
+    <!-- Query -->
+    <div class="card">
+      <h3>Query Database</h3>
+      <div class="form-row">
+        <div class="field">
+          <label for="db-q-name">Database Name</label>
+          <input type="text" id="db-q-name" placeholder="e.g. MyDB.csv">
+        </div>
+        <div class="field">
+          <label for="db-q-row">Row Number (blank = all rows)</label>
+          <input type="text" id="db-q-row" placeholder="e.g. 2">
+        </div>
+        <div class="actions">
+          <button onclick="queryDatabase()">Query</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Update Row -->
+    <div class="card">
+      <h3>Update Row</h3>
+      <div class="form-row">
+        <div class="field">
+          <label for="db-upd-name">Database Name</label>
+          <input type="text" id="db-upd-name" placeholder="e.g. MyDB.csv">
+        </div>
+        <div class="field">
+          <label for="db-upd-row">Row Number</label>
+          <input type="text" id="db-upd-row" placeholder="e.g. 2">
+        </div>
+      </div>
+      <div style="margin-top:10px;">
+        <label for="db-upd-vals">New values (one per line: <code>colName=value</code>)</label>
+        <textarea id="db-upd-vals" rows="4" placeholder="name=Bob&#10;age=31"></textarea>
+      </div>
+      <div style="margin-top:10px;">
+        <button onclick="updateRow()">Update Row</button>
+      </div>
+    </div>
+
+    <!-- Delete Row -->
+    <div class="card">
+      <h3>Delete Row</h3>
+      <div class="form-row">
+        <div class="field">
+          <label for="db-delrow-name">Database Name</label>
+          <input type="text" id="db-delrow-name" placeholder="e.g. MyDB.csv">
+        </div>
+        <div class="field">
+          <label for="db-delrow-num">Row Number</label>
+          <input type="text" id="db-delrow-num" placeholder="e.g. 2">
+        </div>
+        <div class="actions">
+          <button class="danger" onclick="deleteRow()">Delete Row</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete DB -->
+    <div class="card">
+      <h3>Delete Database</h3>
+      <div class="form-row">
+        <div class="field-wide">
+          <label for="db-del-name">Database Name</label>
+          <input type="text" id="db-del-name" placeholder="e.g. MyDB.csv">
+        </div>
+        <div class="actions">
+          <button class="danger" onclick="deleteDatabase()">Delete DB</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- List DBs -->
+    <div class="section-actions">
+      <button onclick="listDatabases()">List All Databases</button>
+    </div>
+
+    <div class="result-area" id="result-database">Results appear here…</div>
+  </div><!-- /tab-database -->
+
+  <!-- ══════════════════════════ AUDIT LOG TAB ═════════════════════════════ -->
+  <div class="tab-pane" id="tab-auditlog">
+    <div class="card">
+      <h3>Audit / Transaction Log</h3>
+      <p class="help-text" style="margin-bottom:12px;">
+        Loads all recorded API transactions from the CDSE engine.
+        Requires appropriate read permissions for the authenticated user/org.
+      </p>
+      <button onclick="loadAuditLog()">Load Audit Log</button>
+    </div>
+    <div class="result-area" id="result-auditlog">Results appear here…</div>
+  </div><!-- /tab-auditlog -->
+
+  <!-- ══════════════════════════ INFO TAB ═════════════════════════════════ -->
+  <div class="tab-pane" id="tab-info">
+    <div class="card">
+      <h3>User / Organisation Info</h3>
+      <p class="help-text" style="margin-bottom:12px;">
+        Retrieves metadata for the authenticated user and organisation from CDSE.
+      </p>
+      <button onclick="loadInfo()">Load Info</button>
+    </div>
+    <div class="result-area" id="result-info">Results appear here…</div>
+  </div><!-- /tab-info -->
+
+</main>
+
+<!-- ═══════════════════════════════ JAVASCRIPT ═══════════════════════════ -->
+<script>
+'use strict';
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * UI helpers
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Toggle visibility of the connection settings panel. */
+function toggleConn() {
+  const toggle = document.getElementById('connToggle');
+  const body   = document.getElementById('connBody');
+  toggle.classList.toggle('open');
+  body.classList.toggle('open');
+}
+
+/** Switch the active tab. */
+function switchTab(name, btn) {
+  document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  document.getElementById('tab-' + name).classList.add('active');
+  btn.classList.add('active');
+}
+
+/** Display a result (text or HTML) in the given result area. */
+function showResult(areaId, data, isError, isHTML) {
+  const el = document.getElementById(areaId);
+  el.classList.remove('ok', 'err');
+  el.classList.add(isError ? 'err' : 'ok');
+  if (isHTML) {
+    el.innerHTML = data;
+  } else {
+    el.textContent = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+  }
+}
+
+/** Show a spinner inside the given element while work is ongoing. */
+function setLoading(areaId) {
+  const el = document.getElementById(areaId);
+  el.className = 'result-area';
+  el.innerHTML = '<span class="spinner"></span> Loading…';
+}
+
+/** Read connection settings from the UI. */
+function connSettings() {
+  return {
+    userId:  document.getElementById('userId').value.trim(),
+    orgId:   document.getElementById('orgId').value.trim(),
+    orgKey:  document.getElementById('orgKey').value,
+    storage: document.getElementById('storage').value.trim() || 'EngineStorage',
+  };
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * API helpers
+ *
+ * All paths use the /cdse prefix so requests are forwarded by proxy.py to
+ * the actual CDSE HTTPS server.
+ *
+ * Authentication is credential-based: userId, orgId, orgKey are passed as
+ * query-string parameters on every request.  The CDSE engine validates them
+ * against its encrypted resources database.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const CDSE = '/cdse';
+
+/** Build a URLSearchParams with the mandatory auth credentials plus extras. */
+function buildParams(extra = {}) {
+  const c = connSettings();
+  return new URLSearchParams({ userId: c.userId, orgId: c.orgId, orgKey: c.orgKey, ...extra });
+}
+
+/** Base URL for document resources in a given storage bucket. */
+function docsBase(orgId, storage) {
+  return `${CDSE}/organizations/${encodeURIComponent(orgId)}/storage/${encodeURIComponent(storage)}/documentTypes/file.raw/documents`;
+}
+
+/** GET request; returns the fetch Response. */
+async function apiGet(path, params) {
+  const url = params ? `${path}?${params}` : path;
+  return fetch(url, { method: 'GET' });
+}
+
+/** DELETE request; returns the fetch Response. */
+async function apiDelete(path, params) {
+  const url = params ? `${path}?${params}` : path;
+  return fetch(url, { method: 'DELETE' });
+}
+
+/**
+ * POST request with a FormData body.
+ * Auth params are included in the query string AND inside the FormData
+ * (CDSE expects them in the multipart body for document creation).
+ */
+async function apiPost(path, params, formData) {
+  const url = params ? `${path}?${params}` : path;
+  return fetch(url, { method: 'POST', body: formData });
+}
+
+/** PUT request; all parameters go in the query string. */
+async function apiPut(path, params) {
+  const url = params ? `${path}?${params}` : path;
+  return fetch(url, { method: 'PUT' });
+}
+
+/** Parse a CSV string into an HTML table string. */
+function parseCSVToTable(csv) {
+  if (!csv || !csv.trim()) return '<em>(empty response)</em>';
+
+  // Split into rows, handling \r\n and \n.
+  const lines = csv.trim().split(/\r?\n/);
+  if (lines.length === 0) return '<em>(empty)</em>';
+
+  // Simple CSV split — handles basic quoting.
+  function splitCSVRow(row) {
+    const cells = [];
+    let cur = '', inQ = false;
+    for (let i = 0; i < row.length; i++) {
+      const ch = row[i];
+      if (ch === '"') {
+        if (inQ && row[i + 1] === '"') { cur += '"'; i++; }
+        else inQ = !inQ;
+      } else if (ch === ',' && !inQ) {
+        cells.push(cur); cur = '';
+      } else {
+        cur += ch;
+      }
+    }
+    cells.push(cur);
+    return cells;
+  }
+
+  function esc(s) {
+    return String(s)
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;')
+      .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+
+  const headers = splitCSVRow(lines[0]);
+  let html = '<div class="csv-table-wrap"><table><thead><tr>';
+  headers.forEach(h => { html += `<th>${esc(h)}</th>`; });
+  html += '</tr></thead><tbody>';
+
+  for (let r = 1; r < lines.length; r++) {
+    if (!lines[r].trim()) continue;
+    const cells = splitCSVRow(lines[r]);
+    html += '<tr>';
+    cells.forEach(c => { html += `<td>${esc(c)}</td>`; });
+    html += '</tr>';
+  }
+  html += '</tbody></table></div>';
+  return html;
+}
+
+/** Format an HTTP response as readable text for the result area. */
+async function formatResponse(resp, preferBinary) {
+  const ct = resp.headers.get('Content-Type') || '';
+  if (preferBinary || (!ct.includes('text') && !ct.includes('csv') && !ct.includes('json'))) {
+    // Return raw bytes as a Blob URL for download.
+    const blob = await resp.blob();
+    return { text: `Binary response (${blob.size} bytes, type: ${blob.type || 'unknown'})`, blob };
+  }
+  const text = await resp.text();
+  return { text };
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Secrets tab actions
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Upload a secret (arbitrary binary or text file) to CDSE.
+ *
+ * API: POST /organizations/{orgId}/storage/{storage}/documentTypes/file.raw/documents/{name}
+ *   Body: multipart/form-data with fields:
+ *     file        — the file content
+ *     userId      — authenticating user
+ *     orgId       — authenticating org
+ *     orgKey      — org password/key
+ *     *resourceInfo — optional metadata string
+ */
+async function uploadSecret() {
+  const area   = 'result-secrets';
+  const name   = document.getElementById('sec-upload-name').value.trim();
+  const fileEl = document.getElementById('sec-upload-file');
+  const info   = document.getElementById('sec-upload-info').value.trim();
+
+  if (!name) { showResult(area, 'Error: Secret Name is required.', true); return; }
+  if (!fileEl.files.length) { showResult(area, 'Error: Please select a file to upload.', true); return; }
+
+  setLoading(area);
+  const c = connSettings();
+  const base = docsBase(c.orgId, c.storage);
+
+  // CDSE expects auth credentials in the FormData body for POST requests.
+  const fd = new FormData();
+  fd.append('file', fileEl.files[0], name);
+  fd.append('userId', c.userId);
+  fd.append('orgId',  c.orgId);
+  fd.append('orgKey', c.orgKey);
+  if (info) fd.append('*resourceInfo', info);
+
+  try {
+    const resp = await apiPost(`${base}/${encodeURIComponent(name)}`, null, fd);
+    const text = await resp.text();
+    const ok   = resp.ok || resp.status === 201;
+    showResult(area, `HTTP ${resp.status}\n\n${text}`, !ok);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Retrieve a secret's raw content from CDSE.
+ *
+ * API: GET /organizations/{orgId}/storage/{storage}/documentTypes/file.raw/documents/{name}/content
+ *   Params: userId, orgId, orgKey
+ */
+async function retrieveSecret() {
+  const area = 'result-secrets';
+  const name = document.getElementById('sec-get-name').value.trim();
+  const dlArea = document.getElementById('sec-get-download');
+  dlArea.innerHTML = '';
+
+  if (!name) { showResult(area, 'Error: Secret Name is required.', true); return; }
+
+  setLoading(area);
+  const c    = connSettings();
+  const base = docsBase(c.orgId, c.storage);
+  const params = buildParams();
+
+  try {
+    const resp = await apiGet(`${base}/${encodeURIComponent(name)}/content`, params);
+    if (!resp.ok) {
+      const text = await resp.text();
+      showResult(area, `HTTP ${resp.status}\n\n${text}`, true);
+      return;
+    }
+    const ct = resp.headers.get('Content-Type') || '';
+    // If content is text, display inline; otherwise offer a download link.
+    if (ct.includes('text') || ct.includes('csv') || ct.includes('json') || ct.includes('xml')) {
+      const text = await resp.text();
+      showResult(area, text, false);
+    } else {
+      const blob = await resp.blob();
+      const url  = URL.createObjectURL(blob);
+      showResult(area, `Binary content received (${blob.size} bytes).`, false);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = name;
+      link.className = 'dl-link';
+      link.textContent = `Download: ${name}`;
+      dlArea.appendChild(link);
+    }
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Delete a secret document from CDSE.
+ *
+ * API: DELETE /organizations/{orgId}/storage/{storage}/documentTypes/file.raw/documents/{name}
+ *   Params: userId, orgId, orgKey
+ */
+async function deleteSecret() {
+  const area = 'result-secrets';
+  const name = document.getElementById('sec-del-name').value.trim();
+  if (!name) { showResult(area, 'Error: Secret Name is required.', true); return; }
+
+  setLoading(area);
+  const c    = connSettings();
+  const base = docsBase(c.orgId, c.storage);
+  const params = buildParams();
+
+  try {
+    const resp = await apiDelete(`${base}/${encodeURIComponent(name)}`, params);
+    const text = await resp.text();
+    showResult(area, `HTTP ${resp.status}\n\n${text}`, !resp.ok);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * List all secrets (documents of type file.raw) in the storage bucket.
+ *
+ * API: GET /organizations/{orgId}/storage/{storage}/documentTypes/file.raw/documents
+ *   Params: userId, orgId, orgKey, outputType=csv
+ */
+async function listSecrets() {
+  const area = 'result-secrets';
+  setLoading(area);
+  const c      = connSettings();
+  const base   = docsBase(c.orgId, c.storage);
+  const params = buildParams({ outputType: 'csv' });
+
+  try {
+    const resp = await apiGet(base, params);
+    const text = await resp.text();
+    if (!resp.ok) { showResult(area, `HTTP ${resp.status}\n\n${text}`, true); return; }
+    const html = `<strong>Secrets in ${c.storage}:</strong>` + parseCSVToTable(text);
+    showResult(area, html, false, true);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Database tab actions
+ *
+ * CaumeDSE stores encrypted databases as CSV-format documents.
+ * The document content is a CSV where the first row is the header (columns)
+ * and subsequent rows are data rows.  Individual rows are accessed via the
+ * .../content/contentRows/{N} sub-resource (1-based row index).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Create a new encrypted database (CSV document with header row only).
+ *
+ * API: POST .../documents/{name}  (same as upload secret)
+ *   The file content is a CSV header: "col1,col2,...\n"
+ */
+async function createDatabase() {
+  const area = 'result-database';
+  const name = document.getElementById('db-create-name').value.trim();
+  const cols = document.getElementById('db-create-cols').value.trim();
+  if (!name) { showResult(area, 'Error: Database Name is required.', true); return; }
+  if (!cols) { showResult(area, 'Error: At least one column name is required.', true); return; }
+
+  setLoading(area);
+  const c      = connSettings();
+  const base   = docsBase(c.orgId, c.storage);
+  const csvHeader = cols + '\n';
+  const blob   = new Blob([csvHeader], { type: 'text/csv' });
+
+  const fd = new FormData();
+  fd.append('file', blob, name);
+  fd.append('userId', c.userId);
+  fd.append('orgId',  c.orgId);
+  fd.append('orgKey', c.orgKey);
+  fd.append('*resourceInfo', `Database: ${name}; columns: ${cols}`);
+
+  try {
+    const resp = await apiPost(`${base}/${encodeURIComponent(name)}`, null, fd);
+    const text = await resp.text();
+    showResult(area, `HTTP ${resp.status}\n\n${text}`, !resp.ok && resp.status !== 201);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Insert a new row into an encrypted database.
+ *
+ * Strategy:
+ *   1. GET .../content?outputType=csv  to retrieve all current content.
+ *   2. Count the existing data rows (header is row 0; first data row is 1).
+ *   3. POST to .../contentRows/{newRowNum} with column=value params.
+ *
+ * API: POST .../documents/{name}/contentRows/{N}?col1=val1&col2=val2&userId=...
+ */
+async function insertRow() {
+  const area = 'result-database';
+  const name = document.getElementById('db-ins-name').value.trim();
+  const valsRaw = document.getElementById('db-ins-vals').value.trim();
+  if (!name)    { showResult(area, 'Error: Database Name is required.', true); return; }
+  if (!valsRaw) { showResult(area, 'Error: Column values are required.', true); return; }
+
+  setLoading(area);
+  const c      = connSettings();
+  const base   = docsBase(c.orgId, c.storage);
+  const params = buildParams();
+
+  // Step 1: fetch current content to count rows.
+  let rowCount = 0;
+  try {
+    const resp = await apiGet(
+      `${base}/${encodeURIComponent(name)}/content`,
+      buildParams({ outputType: 'csv' })
+    );
+    if (resp.ok) {
+      const text = await resp.text();
+      // Count non-empty lines minus header.
+      rowCount = text.trim().split(/\r?\n/).filter(l => l.trim()).length - 1;
+      if (rowCount < 0) rowCount = 0;
+    }
+    // If not found (404) we proceed with rowCount=0 (insert as row 1).
+  } catch (_) { /* ignore; proceed with row 1 */ }
+
+  const newRow = rowCount + 1;
+
+  // Step 2: parse col=value pairs from textarea.
+  const kvPairs = {};
+  valsRaw.split(/\r?\n/).forEach(line => {
+    const eq = line.indexOf('=');
+    if (eq > 0) {
+      const k = line.slice(0, eq).trim();
+      const v = line.slice(eq + 1).trim();
+      if (k) kvPairs[k] = v;
+    }
+  });
+
+  const insertParams = buildParams({ ...kvPairs });
+
+  try {
+    const resp = await apiPost(
+      `${base}/${encodeURIComponent(name)}/contentRows/${newRow}`,
+      insertParams,
+      new FormData() // empty FormData; payload is in query string
+    );
+    const text = await resp.text();
+    showResult(area, `Inserted as row ${newRow}.\nHTTP ${resp.status}\n\n${text}`, !resp.ok);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Query a database — all rows or a specific row.
+ *
+ * API (all rows):  GET .../documents/{name}/content?outputType=csv&userId=...
+ * API (one row):   GET .../documents/{name}/contentRows/{N}?outputType=csv&userId=...
+ */
+async function queryDatabase() {
+  const area   = 'result-database';
+  const name   = document.getElementById('db-q-name').value.trim();
+  const rowNum = document.getElementById('db-q-row').value.trim();
+  if (!name) { showResult(area, 'Error: Database Name is required.', true); return; }
+
+  setLoading(area);
+  const c      = connSettings();
+  const base   = docsBase(c.orgId, c.storage);
+  const params = buildParams({ outputType: 'csv' });
+
+  const path = rowNum
+    ? `${base}/${encodeURIComponent(name)}/contentRows/${encodeURIComponent(rowNum)}`
+    : `${base}/${encodeURIComponent(name)}/content`;
+
+  try {
+    const resp = await apiGet(path, params);
+    const text = await resp.text();
+    if (!resp.ok) { showResult(area, `HTTP ${resp.status}\n\n${text}`, true); return; }
+    const label = rowNum ? `Row ${rowNum} of <strong>${name}</strong>:` : `Contents of <strong>${name}</strong>:`;
+    showResult(area, label + parseCSVToTable(text), false, true);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Update an existing row in an encrypted database.
+ *
+ * API: PUT .../documents/{name}/contentRows/{N}?col1=val1&col2=val2&userId=...
+ */
+async function updateRow() {
+  const area   = 'result-database';
+  const name   = document.getElementById('db-upd-name').value.trim();
+  const rowNum = document.getElementById('db-upd-row').value.trim();
+  const valsRaw = document.getElementById('db-upd-vals').value.trim();
+  if (!name)    { showResult(area, 'Error: Database Name is required.', true); return; }
+  if (!rowNum)  { showResult(area, 'Error: Row Number is required.', true); return; }
+  if (!valsRaw) { showResult(area, 'Error: Column values are required.', true); return; }
+
+  setLoading(area);
+  const c    = connSettings();
+  const base = docsBase(c.orgId, c.storage);
+
+  const kvPairs = {};
+  valsRaw.split(/\r?\n/).forEach(line => {
+    const eq = line.indexOf('=');
+    if (eq > 0) {
+      const k = line.slice(0, eq).trim();
+      const v = line.slice(eq + 1).trim();
+      if (k) kvPairs[k] = v;
+    }
+  });
+
+  const params = buildParams({ ...kvPairs });
+
+  try {
+    const resp = await apiPut(
+      `${base}/${encodeURIComponent(name)}/contentRows/${encodeURIComponent(rowNum)}`,
+      params
+    );
+    const text = await resp.text();
+    showResult(area, `HTTP ${resp.status}\n\n${text}`, !resp.ok);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Delete a specific row from an encrypted database.
+ *
+ * API: DELETE .../documents/{name}/contentRows/{N}?userId=...&orgId=...&orgKey=...
+ */
+async function deleteRow() {
+  const area   = 'result-database';
+  const name   = document.getElementById('db-delrow-name').value.trim();
+  const rowNum = document.getElementById('db-delrow-num').value.trim();
+  if (!name)   { showResult(area, 'Error: Database Name is required.', true); return; }
+  if (!rowNum) { showResult(area, 'Error: Row Number is required.', true); return; }
+
+  setLoading(area);
+  const c    = connSettings();
+  const base = docsBase(c.orgId, c.storage);
+  const params = buildParams();
+
+  try {
+    const resp = await apiDelete(
+      `${base}/${encodeURIComponent(name)}/contentRows/${encodeURIComponent(rowNum)}`,
+      params
+    );
+    const text = await resp.text();
+    showResult(area, `HTTP ${resp.status}\n\n${text}`, !resp.ok);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * Delete an entire encrypted database document.
+ *
+ * API: DELETE .../documents/{name}?userId=...&orgId=...&orgKey=...
+ */
+async function deleteDatabase() {
+  const area = 'result-database';
+  const name = document.getElementById('db-del-name').value.trim();
+  if (!name) { showResult(area, 'Error: Database Name is required.', true); return; }
+
+  setLoading(area);
+  const c    = connSettings();
+  const base = docsBase(c.orgId, c.storage);
+  const params = buildParams();
+
+  try {
+    const resp = await apiDelete(`${base}/${encodeURIComponent(name)}`, params);
+    const text = await resp.text();
+    showResult(area, `HTTP ${resp.status}\n\n${text}`, !resp.ok);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/**
+ * List all database documents (same endpoint as listSecrets — both are
+ * documents of type file.raw in the storage bucket; databases are
+ * distinguished by their CSV content and naming convention).
+ */
+async function listDatabases() {
+  const area = 'result-database';
+  setLoading(area);
+  const c      = connSettings();
+  const base   = docsBase(c.orgId, c.storage);
+  const params = buildParams({ outputType: 'csv' });
+
+  try {
+    const resp = await apiGet(base, params);
+    const text = await resp.text();
+    if (!resp.ok) { showResult(area, `HTTP ${resp.status}\n\n${text}`, true); return; }
+    const html = `<strong>Documents in ${c.storage}:</strong>` + parseCSVToTable(text);
+    showResult(area, html, false, true);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Audit Log tab actions
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Load the CDSE transaction / audit log.
+ *
+ * API: GET /cdse/transactions?userId=...&orgId=...&orgKey=...&outputType=csv
+ *
+ * The transactions table records every API request processed by the engine,
+ * including method, URL, timestamp, and response code.
+ */
+async function loadAuditLog() {
+  const area   = 'result-auditlog';
+  setLoading(area);
+  const params = buildParams({ outputType: 'csv' });
+
+  try {
+    const resp = await apiGet(`${CDSE}/transactions`, params);
+    const text = await resp.text();
+    if (!resp.ok) { showResult(area, `HTTP ${resp.status}\n\n${text}`, true); return; }
+    showResult(area, '<strong>Audit / Transaction Log:</strong>' + parseCSVToTable(text), false, true);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Info tab actions
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Load user and organisation metadata from CDSE.
+ *
+ * APIs used:
+ *   GET /cdse/organizations/{orgId}?userId=...&orgId=...&orgKey=...&outputType=csv
+ *
+ * Returns metadata (resourceInfo, certificate, publicKey, etc.) registered
+ * for the authenticating organisation.
+ */
+async function loadInfo() {
+  const area = 'result-info';
+  setLoading(area);
+  const c      = connSettings();
+  const params = buildParams({ outputType: 'csv' });
+
+  try {
+    const resp = await apiGet(
+      `${CDSE}/organizations/${encodeURIComponent(c.orgId)}`,
+      params
+    );
+    const text = await resp.text();
+    if (!resp.ok) { showResult(area, `HTTP ${resp.status}\n\n${text}`, true); return; }
+    const html = `<strong>Organisation info for <em>${c.orgId}</em>:</strong>`
+               + parseCSVToTable(text);
+    showResult(area, html, false, true);
+  } catch (e) {
+    showResult(area, `Network error: ${e.message}`, true);
+  }
+}
+</script>
+</body>
+</html>

--- a/samples/hsm-db-crypto/a-web/proxy.py
+++ b/samples/hsm-db-crypto/a-web/proxy.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+CaumeDSE CORS Proxy
+===================
+Serves index.html at http://localhost:8080 and proxies /cdse/* requests
+to https://localhost:8443/* (or a configurable CDSE server).
+
+This proxy is required because browsers enforce the Same-Origin Policy,
+preventing JavaScript in index.html from calling the CDSE HTTPS API
+directly from a file:// URL or a different origin.
+
+Usage:
+    python3 proxy.py [--port 8080] [--cdse-server localhost:8443] [--insecure]
+
+NOTE: Use --insecure only in development/testing when the CDSE server uses
+a self-signed TLS certificate. Do NOT use --insecure in production.
+"""
+
+import argparse
+import http.server
+import os
+import ssl
+import sys
+import urllib.request
+import urllib.error
+
+
+def make_handler(cdse_server, ssl_context):
+    """Factory that creates a request handler class bound to the given CDSE server."""
+
+    class ProxyHandler(http.server.BaseHTTPRequestHandler):
+        log_message_format = '%s - - [%s] %s'
+
+        def _proxy(self, method):
+            """Forward any request (except GET /) to the CDSE server."""
+            # Strip the /cdse prefix; pass everything else verbatim.
+            path = self.path
+            if path.startswith('/cdse'):
+                target_path = path[len('/cdse'):]
+                if not target_path:
+                    target_path = '/'
+            else:
+                # Unrecognised path — return 404.
+                self.send_error(404, 'Not found (use /cdse/... to reach CDSE)')
+                return
+
+            url = f'https://{cdse_server}{target_path}'
+
+            # Collect request body if present.
+            length = int(self.headers.get('Content-Length', 0) or 0)
+            body = self.rfile.read(length) if length > 0 else None
+
+            # Build forwarded headers (skip hop-by-hop headers).
+            hop_by_hop = {
+                'connection', 'keep-alive', 'proxy-authenticate',
+                'proxy-authorization', 'te', 'trailers', 'transfer-encoding',
+                'upgrade', 'host',
+            }
+            fwd_headers = {
+                k: v for k, v in self.headers.items()
+                if k.lower() not in hop_by_hop
+            }
+
+            req = urllib.request.Request(url, data=body, headers=fwd_headers,
+                                         method=method)
+            try:
+                with urllib.request.urlopen(req, context=ssl_context) as resp:
+                    self.send_response(resp.status)
+                    for k, v in resp.headers.items():
+                        if k.lower() not in hop_by_hop:
+                            self.send_header(k, v)
+                    self.end_headers()
+                    self.wfile.write(resp.read())
+            except urllib.error.HTTPError as exc:
+                self.send_response(exc.code)
+                for k, v in exc.headers.items():
+                    if k.lower() not in hop_by_hop:
+                        self.send_header(k, v)
+                self.end_headers()
+                self.wfile.write(exc.read())
+            except urllib.error.URLError as exc:
+                msg = f'Proxy error: {exc.reason}'.encode()
+                self.send_response(502)
+                self.send_header('Content-Type', 'text/plain')
+                self.send_header('Content-Length', str(len(msg)))
+                self.end_headers()
+                self.wfile.write(msg)
+
+        def do_GET(self):
+            # Serve index.html for the root path; proxy everything else.
+            if self.path == '/' or self.path == '/index.html':
+                here = os.path.dirname(os.path.abspath(__file__))
+                index_path = os.path.join(here, 'index.html')
+                try:
+                    with open(index_path, 'rb') as f:
+                        data = f.read()
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'text/html; charset=utf-8')
+                    self.send_header('Content-Length', str(len(data)))
+                    self.end_headers()
+                    self.wfile.write(data)
+                except FileNotFoundError:
+                    self.send_error(404, 'index.html not found')
+            else:
+                self._proxy('GET')
+
+        def do_POST(self):
+            self._proxy('POST')
+
+        def do_PUT(self):
+            self._proxy('PUT')
+
+        def do_DELETE(self):
+            self._proxy('DELETE')
+
+        def do_HEAD(self):
+            self._proxy('HEAD')
+
+        def log_message(self, fmt, *args):
+            print(fmt % args)
+
+    return ProxyHandler
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='CaumeDSE CORS proxy — serves the web client and forwards '
+                    '/cdse/* to the CDSE HTTPS server.')
+    parser.add_argument('--port', type=int, default=8080,
+                        help='Local port to listen on (default: 8080)')
+    parser.add_argument('--cdse-server', default='localhost:8443',
+                        metavar='HOST:PORT',
+                        help='CDSE server address (default: localhost:8443)')
+    parser.add_argument('--insecure', action='store_true',
+                        help='Skip TLS certificate verification for the CDSE '
+                             'server (development/self-signed certs only)')
+    args = parser.parse_args()
+
+    # Build the SSL context used when contacting the CDSE server.
+    if args.insecure:
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+        print('WARNING: TLS certificate verification disabled (--insecure).')
+    else:
+        ssl_context = ssl.create_default_context()
+
+    handler = make_handler(args.cdse_server, ssl_context)
+    server = http.server.HTTPServer(('', args.port), handler)
+    print(f'CaumeDSE proxy running.')
+    print(f'  Open: http://localhost:{args.port}/')
+    print(f'  Forwarding /cdse/* -> https://{args.cdse_server}/*')
+    print('Press Ctrl+C to stop.')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print('\nStopped.')
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/hsm-db-crypto/b-python/cdse_client.py
+++ b/samples/hsm-db-crypto/b-python/cdse_client.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""
+cdse_client.py — CaumeDSE REST API sample client
+
+CaumeDSE (Caume Data Security Engine) is a REST API that provides an
+HSM-like interface for encrypted secrets storage, an encrypted CSV
+database engine, and a general cryptographic services layer.
+
+This client supports two usage modes:
+
+  1. Interactive mode (-i / --interactive):
+     Prompts for credentials once (org key is hidden via getpass),
+     then enters a 'cdse> ' REPL accepting commands with readline
+     line-editing support.
+
+  2. One-shot / parameter mode (default):
+     Credentials are supplied as CLI flags or environment variables.
+     The command and its arguments follow the options positionally.
+
+Environment variables (used when CLI flags are omitted):
+  CDSE_SERVER    — host:port  (default: localhost:8443)
+  CDSE_USER_ID   — userId
+  CDSE_ORG_ID    — orgId
+  CDSE_ORG_KEY   — orgKey     (avoid; prefer interactive or --org-key)
+  CDSE_STORAGE   — storage bucket name (default: EngineStorage)
+
+Commands:
+  info                              — show user/org info
+  list-secrets                      — list raw-file documents
+  store-secret NAME FILE [INFO]     — upload FILE as encrypted secret NAME
+  get-secret NAME [OUTPUT_FILE]     — retrieve secret (prints if no output)
+  delete-secret NAME                — delete a secret
+  db-list                           — list CSV documents
+  db-create NAME col1,col2,...      — create CSV DB with given column headers
+  db-insert NAME col=val ...        — append a row
+  db-query NAME [ROW]               — show all rows or a specific row N
+  db-update NAME ROW col=val ...    — update columns in row N
+  db-delete-row NAME ROW            — delete row N
+  db-delete NAME                    — delete entire CSV document
+  audit-log                         — show the transaction audit log
+
+Usage examples:
+
+  # One-shot — store a secret
+  python3 cdse_client.py --server localhost:8443 --user-id alice \\
+      --org-id acme --org-key s3cr3t \\
+      store-secret mykey /tmp/key.pem "RSA private key"
+
+  # One-shot — retrieve a secret to file
+  CDSE_SERVER=localhost:8443 CDSE_USER_ID=alice CDSE_ORG_ID=acme \\
+  CDSE_ORG_KEY=s3cr3t python3 cdse_client.py get-secret mykey /tmp/out.pem
+
+  # Interactive session
+  python3 cdse_client.py -i --server localhost:8443 --user-id alice \\
+      --org-id acme
+"""
+
+import argparse
+import csv
+import getpass
+import io
+import os
+import sys
+import textwrap
+import warnings
+
+try:
+    import readline  # noqa: F401 — imported for side-effect (line editing)
+except ImportError:
+    pass  # readline not available on all platforms (e.g. Windows)
+
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+except ImportError:
+    sys.exit("Error: the 'requests' library is required.  "
+             "Install it with:  pip install requests")
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(ca_cert=None, insecure=False):
+    """Return a configured requests.Session."""
+    session = requests.Session()
+    if insecure:
+        warnings.warn(
+            "TLS verification is DISABLED (--insecure).  "
+            "This is unsafe outside of development/testing.",
+            stacklevel=2,
+        )
+        session.verify = False
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    elif ca_cert:
+        session.verify = ca_cert
+    return session
+
+
+def _base_url(server):
+    """Normalise the server string to a full HTTPS base URL."""
+    server = server.strip().rstrip("/")
+    if not server.startswith("http"):
+        server = "https://" + server
+    return server
+
+
+def _auth_params(cfg):
+    """Return the mandatory authentication query-parameters dict."""
+    return {
+        "userId": cfg["user_id"],
+        "orgId":  cfg["org_id"],
+        "orgKey": cfg["org_key"],
+    }
+
+
+def _check(resp):
+    """
+    Print a human-readable error and return False if the response is not 2xx.
+    Returns True on success.
+    """
+    if resp.ok:
+        return True
+    print(f"[ERROR] HTTP {resp.status_code} {resp.reason}")
+    body = resp.text.strip()
+    if body:
+        print(body)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Command implementations
+# ---------------------------------------------------------------------------
+
+def cmd_info(session, cfg):
+    """GET /organizations/{orgId}/users/{userId}"""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/users/{cfg['user_id']}")
+    resp = session.get(url, params=_auth_params(cfg))
+    if _check(resp):
+        print(resp.text.strip())
+
+
+def cmd_list_secrets(session, cfg):
+    """List raw-file documents in storage."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.raw/documents")
+    resp = session.get(url, params=_auth_params(cfg))
+    if _check(resp):
+        print(resp.text.strip())
+
+
+def cmd_store_secret(session, cfg, name, filepath, info=None):
+    """Upload FILE as an AES-encrypted secret stored under NAME."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.raw/documents/{name}")
+    params = dict(_auth_params(cfg))
+    if info:
+        params["*resourceInfo"] = info
+    try:
+        with open(filepath, "rb") as fh:
+            files = {"file": (os.path.basename(filepath), fh)}
+            resp = session.post(url, params=params, files=files)
+    except FileNotFoundError:
+        print(f"[ERROR] File not found: {filepath}")
+        return
+    if _check(resp):
+        print(f"Stored secret '{name}'.")
+
+
+def cmd_get_secret(session, cfg, name, output_file=None):
+    """Retrieve (decrypt) secret NAME; write to OUTPUT_FILE or stdout."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.raw/documents/{name}/content")
+    resp = session.get(url, params=_auth_params(cfg))
+    if not _check(resp):
+        return
+    if output_file:
+        try:
+            with open(output_file, "wb") as fh:
+                fh.write(resp.content)
+            print(f"Written to '{output_file}'.")
+        except OSError as exc:
+            print(f"[ERROR] Could not write output file: {exc}")
+    else:
+        # Best-effort text decode; fall back to a hex summary for binary data.
+        try:
+            print(resp.content.decode("utf-8"))
+        except UnicodeDecodeError:
+            print(f"<binary content, {len(resp.content)} bytes — "
+                  "use get-secret NAME OUTPUT_FILE to save>")
+
+
+def cmd_delete_secret(session, cfg, name):
+    """Delete a single raw-file secret."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.raw/documents/{name}")
+    resp = session.delete(url, params=_auth_params(cfg))
+    if _check(resp):
+        print(f"Deleted secret '{name}'.")
+
+
+# --- CSV / encrypted-database commands -------------------------------------
+
+def cmd_db_list(session, cfg):
+    """List CSV documents in storage."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents")
+    resp = session.get(url, params=_auth_params(cfg))
+    if _check(resp):
+        print(resp.text.strip())
+
+
+def cmd_db_create(session, cfg, name, columns_str):
+    """
+    Create a new encrypted CSV document with the given comma-separated
+    column headers.  Uploads a header-only CSV file via multipart POST.
+    """
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents/{name}")
+    # Build an in-memory CSV containing only the header row.
+    header_csv = columns_str.strip() + "\r\n"
+    files = {"file": (f"{name}.csv", io.BytesIO(header_csv.encode()), "text/csv")}
+    resp = session.post(url, params=_auth_params(cfg), files=files)
+    if _check(resp):
+        print(f"Created CSV document '{name}' with columns: {columns_str}")
+
+
+def _count_rows(session, cfg, name):
+    """
+    Return the number of data rows currently stored in CSV document NAME.
+    Fetches all content as CSV and counts non-header lines.
+    Returns None on error.
+    """
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents/{name}/content")
+    params = dict(_auth_params(cfg))
+    params["outputType"] = "csv"
+    resp = session.get(url, params=params)
+    if not resp.ok:
+        return None
+    lines = [l for l in resp.text.splitlines() if l.strip()]
+    # First line is the header; remaining lines are data rows.
+    return max(0, len(lines) - 1)
+
+
+def cmd_db_insert(session, cfg, name, col_val_pairs):
+    """
+    Append a row to CSV document NAME.
+    col_val_pairs is a list of "col=val" strings.
+    Automatically determines the next row index (current count + 1).
+    """
+    row_count = _count_rows(session, cfg, name)
+    if row_count is None:
+        print(f"[ERROR] Could not determine row count for '{name}'.")
+        return
+    next_row = row_count + 1
+
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents/{name}"
+           f"/contentRows/{next_row}")
+    params = dict(_auth_params(cfg))
+    for pair in col_val_pairs:
+        if "=" not in pair:
+            print(f"[ERROR] Expected col=val, got: {pair!r}")
+            return
+        col, _, val = pair.partition("=")
+        params[f"[{col.strip()}]"] = val
+    resp = session.post(url, params=params)
+    if _check(resp):
+        print(f"Inserted row {next_row} into '{name}'.")
+
+
+def cmd_db_query(session, cfg, name, row=None):
+    """
+    Show all rows (row=None) or a specific row number from CSV document NAME.
+    """
+    if row is None:
+        url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+               f"/storage/{cfg['storage']}"
+               f"/documentTypes/file.csv/documents/{name}/content")
+        params = dict(_auth_params(cfg))
+        params["outputType"] = "csv"
+    else:
+        url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+               f"/storage/{cfg['storage']}"
+               f"/documentTypes/file.csv/documents/{name}"
+               f"/contentRows/{row}")
+        params = _auth_params(cfg)
+    resp = session.get(url, params=params)
+    if _check(resp):
+        print(resp.text.strip())
+
+
+def cmd_db_update(session, cfg, name, row, col_val_pairs):
+    """Update columns in row ROW of CSV document NAME."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents/{name}"
+           f"/contentRows/{row}")
+    params = dict(_auth_params(cfg))
+    for pair in col_val_pairs:
+        if "=" not in pair:
+            print(f"[ERROR] Expected col=val, got: {pair!r}")
+            return
+        col, _, val = pair.partition("=")
+        params[f"[{col.strip()}]"] = val
+    resp = session.put(url, params=params)
+    if _check(resp):
+        print(f"Updated row {row} in '{name}'.")
+
+
+def cmd_db_delete_row(session, cfg, name, row):
+    """Delete row ROW from CSV document NAME."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents/{name}"
+           f"/contentRows/{row}")
+    resp = session.delete(url, params=_auth_params(cfg))
+    if _check(resp):
+        print(f"Deleted row {row} from '{name}'.")
+
+
+def cmd_db_delete(session, cfg, name):
+    """Delete an entire CSV document (all rows and the document itself)."""
+    url = (f"{cfg['base']}/organizations/{cfg['org_id']}"
+           f"/storage/{cfg['storage']}"
+           f"/documentTypes/file.csv/documents/{name}")
+    resp = session.delete(url, params=_auth_params(cfg))
+    if _check(resp):
+        print(f"Deleted CSV document '{name}'.")
+
+
+def cmd_audit_log(session, cfg):
+    """Retrieve the transaction audit log as CSV."""
+    url = f"{cfg['base']}/transactions"
+    params = dict(_auth_params(cfg))
+    params["outputType"] = "csv"
+    resp = session.get(url, params=params)
+    if _check(resp):
+        print(resp.text.strip())
+
+
+# ---------------------------------------------------------------------------
+# Command dispatcher
+# ---------------------------------------------------------------------------
+
+COMMANDS = {
+    "info":           ("info",
+                       "Show user/org info."),
+    "list-secrets":   ("list-secrets",
+                       "List raw-file (secret) documents."),
+    "store-secret":   ("store-secret NAME FILE [INFO]",
+                       "Upload FILE as encrypted secret NAME."),
+    "get-secret":     ("get-secret NAME [OUTPUT_FILE]",
+                       "Retrieve and decrypt secret NAME."),
+    "delete-secret":  ("delete-secret NAME",
+                       "Delete secret NAME."),
+    "db-list":        ("db-list",
+                       "List CSV documents."),
+    "db-create":      ("db-create NAME col1,col2,...",
+                       "Create encrypted CSV DB with given column headers."),
+    "db-insert":      ("db-insert NAME col=val ...",
+                       "Append a row to CSV document NAME."),
+    "db-query":       ("db-query NAME [ROW]",
+                       "Show all rows, or row ROW, from CSV document NAME."),
+    "db-update":      ("db-update NAME ROW col=val ...",
+                       "Update columns in row ROW of CSV document NAME."),
+    "db-delete-row":  ("db-delete-row NAME ROW",
+                       "Delete row ROW from CSV document NAME."),
+    "db-delete":      ("db-delete NAME",
+                       "Delete entire CSV document NAME."),
+    "audit-log":      ("audit-log",
+                       "Show the transaction audit log."),
+}
+
+
+def dispatch(session, cfg, args):
+    """
+    Execute a single command described by the list 'args'.
+    Returns False if the command is unrecognised.
+    """
+    if not args:
+        return False
+    cmd = args[0].lower()
+    rest = args[1:]
+
+    if cmd == "info":
+        cmd_info(session, cfg)
+    elif cmd == "list-secrets":
+        cmd_list_secrets(session, cfg)
+    elif cmd == "store-secret":
+        if len(rest) < 2:
+            print("Usage: store-secret NAME FILE [INFO]")
+        else:
+            cmd_store_secret(session, cfg, rest[0], rest[1],
+                             rest[2] if len(rest) > 2 else None)
+    elif cmd == "get-secret":
+        if len(rest) < 1:
+            print("Usage: get-secret NAME [OUTPUT_FILE]")
+        else:
+            cmd_get_secret(session, cfg, rest[0],
+                           rest[1] if len(rest) > 1 else None)
+    elif cmd == "delete-secret":
+        if len(rest) < 1:
+            print("Usage: delete-secret NAME")
+        else:
+            cmd_delete_secret(session, cfg, rest[0])
+    elif cmd == "db-list":
+        cmd_db_list(session, cfg)
+    elif cmd == "db-create":
+        if len(rest) < 2:
+            print("Usage: db-create NAME col1,col2,...")
+        else:
+            cmd_db_create(session, cfg, rest[0], rest[1])
+    elif cmd == "db-insert":
+        if len(rest) < 2:
+            print("Usage: db-insert NAME col=val ...")
+        else:
+            cmd_db_insert(session, cfg, rest[0], rest[1:])
+    elif cmd == "db-query":
+        if len(rest) < 1:
+            print("Usage: db-query NAME [ROW]")
+        else:
+            cmd_db_query(session, cfg, rest[0],
+                         rest[1] if len(rest) > 1 else None)
+    elif cmd == "db-update":
+        if len(rest) < 3:
+            print("Usage: db-update NAME ROW col=val ...")
+        else:
+            cmd_db_update(session, cfg, rest[0], rest[1], rest[2:])
+    elif cmd == "db-delete-row":
+        if len(rest) < 2:
+            print("Usage: db-delete-row NAME ROW")
+        else:
+            cmd_db_delete_row(session, cfg, rest[0], rest[1])
+    elif cmd == "db-delete":
+        if len(rest) < 1:
+            print("Usage: db-delete NAME")
+        else:
+            cmd_db_delete(session, cfg, rest[0])
+    elif cmd == "audit-log":
+        cmd_audit_log(session, cfg)
+    else:
+        return False  # unrecognised
+    return True
+
+
+def print_help():
+    """Print available commands."""
+    print("Available commands:")
+    for syntax, desc in COMMANDS.values():
+        print(f"  {syntax:<36}  {desc}")
+    print("  help                                  Show this help.")
+    print("  exit / quit                           Leave the interactive session.")
+
+
+# ---------------------------------------------------------------------------
+# Interactive REPL
+# ---------------------------------------------------------------------------
+
+def interactive_loop(session, cfg):
+    """Run the interactive command prompt."""
+    print("CaumeDSE interactive client.  Type 'help' for commands, "
+          "'exit' to quit.")
+    while True:
+        try:
+            line = input("cdse> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line:
+            continue
+        tokens = line.split()
+        cmd = tokens[0].lower()
+        if cmd in ("exit", "quit"):
+            break
+        if cmd == "help":
+            print_help()
+            continue
+        if not dispatch(session, cfg, tokens):
+            print(f"Unknown command: {tokens[0]!r}  (type 'help' for list)")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="cdse_client.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="CaumeDSE REST API client — HSM / encrypted-DB / crypto interface.",
+        epilog=textwrap.dedent("""\
+            Examples:
+              # Interactive session (org key entered securely via prompt)
+              python3 cdse_client.py -i --server localhost:8443 \\
+                  --user-id alice --org-id acme
+
+              # One-shot: store a secret
+              python3 cdse_client.py --user-id alice --org-id acme \\
+                  --org-key s3cr3t store-secret api-key /tmp/api.key "API token"
+
+              # One-shot via environment variables
+              export CDSE_USER_ID=alice CDSE_ORG_ID=acme CDSE_ORG_KEY=s3cr3t
+              python3 cdse_client.py info
+
+              # Create an encrypted CSV database
+              python3 cdse_client.py ... db-create payroll name,role,salary
+
+              # Insert a row
+              python3 cdse_client.py ... db-insert payroll name=Bob role=Eng salary=90000
+
+              # Query all rows
+              python3 cdse_client.py ... db-query payroll
+
+              # Update row 1
+              python3 cdse_client.py ... db-update payroll 1 salary=95000
+
+              # Skip TLS verification (development only)
+              python3 cdse_client.py -k --user-id alice --org-id acme \\
+                  --org-key s3cr3t info
+        """),
+    )
+
+    # Connection / TLS options
+    parser.add_argument(
+        "--server", "-s",
+        default=os.environ.get("CDSE_SERVER", "localhost:8443"),
+        metavar="HOST:PORT",
+        help="CaumeDSE server (default: localhost:8443 or $CDSE_SERVER).",
+    )
+    parser.add_argument(
+        "--ca-cert",
+        default=None,
+        metavar="FILE",
+        help="Path to CA certificate bundle for TLS verification.",
+    )
+    parser.add_argument(
+        "--insecure", "-k",
+        action="store_true",
+        help="Disable TLS certificate verification (unsafe; dev/test only).",
+    )
+
+    # Credentials
+    parser.add_argument(
+        "--user-id", "-u",
+        default=os.environ.get("CDSE_USER_ID"),
+        metavar="USER_ID",
+        help="userId credential (or set $CDSE_USER_ID).",
+    )
+    parser.add_argument(
+        "--org-id", "-o",
+        default=os.environ.get("CDSE_ORG_ID"),
+        metavar="ORG_ID",
+        help="orgId credential (or set $CDSE_ORG_ID).",
+    )
+    parser.add_argument(
+        "--org-key", "-p",
+        default=os.environ.get("CDSE_ORG_KEY"),
+        metavar="ORG_KEY",
+        help="orgKey (organisation encryption key).  Prefer $CDSE_ORG_KEY or "
+             "the interactive prompt to avoid exposure in shell history.",
+    )
+    parser.add_argument(
+        "--storage",
+        default=os.environ.get("CDSE_STORAGE", "EngineStorage"),
+        metavar="STORAGE",
+        help="Storage bucket name (default: EngineStorage or $CDSE_STORAGE).",
+    )
+
+    # Mode
+    parser.add_argument(
+        "--interactive", "-i",
+        action="store_true",
+        help="Start an interactive command session.",
+    )
+
+    # Positional command (one-shot mode)
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        metavar="COMMAND [ARGS...]",
+        help="Command to execute (one-shot mode).",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # Validate required credentials.
+    missing = []
+    if not args.user_id:
+        missing.append("--user-id / $CDSE_USER_ID")
+    if not args.org_id:
+        missing.append("--org-id / $CDSE_ORG_ID")
+    if missing:
+        parser.error("Missing required credentials: " + ", ".join(missing))
+
+    # Obtain org key: CLI arg > env var > interactive prompt.
+    org_key = args.org_key
+    if not org_key:
+        if args.interactive or not args.command:
+            # Prompt securely so the key does not echo to the terminal.
+            org_key = getpass.getpass(
+                prompt=f"orgKey for org '{args.org_id}': "
+            )
+        else:
+            parser.error(
+                "orgKey is required.  Supply --org-key, set $CDSE_ORG_KEY, "
+                "or use -i for an interactive session with a secure prompt."
+            )
+
+    # Build shared configuration dict.
+    cfg = {
+        "base":    _base_url(args.server),
+        "user_id": args.user_id,
+        "org_id":  args.org_id,
+        "org_key": org_key,
+        "storage": args.storage,
+    }
+
+    session = _make_session(ca_cert=args.ca_cert, insecure=args.insecure)
+
+    if args.interactive:
+        interactive_loop(session, cfg)
+    elif args.command:
+        if not dispatch(session, cfg, args.command):
+            print(f"Unknown command: {args.command[0]!r}")
+            print_help()
+            sys.exit(1)
+    else:
+        # No command given in one-shot mode: show help.
+        parser.print_help()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/hsm-db-crypto/c-golang/cdse_client.go
+++ b/samples/hsm-db-crypto/c-golang/cdse_client.go
@@ -1,0 +1,775 @@
+// cdse_client.go — Sample CLI client for the CaumeDSE (Caume Data Security Engine) REST API.
+//
+// CaumeDSE simulates an HSM + encrypted-database + general crypto interface exposed over HTTPS.
+// This client covers secrets management, encrypted CSV databases, and the audit-log endpoint.
+//
+// Usage (one-shot):
+//
+//	cdse_client -userId user1 -orgId org1 -orgKey secret info
+//	cdse_client -userId user1 -orgId org1 -orgKey secret store-secret mykey /path/to/file "my info"
+//	cdse_client -userId user1 -orgId org1 -orgKey secret get-secret mykey
+//
+// Usage (interactive):
+//
+//	cdse_client -userId user1 -orgId org1 -i
+//
+// Environment variables: CDSE_USER_ID, CDSE_ORG_ID, CDSE_ORG_KEY, CDSE_SERVER, CDSE_STORAGE
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// CDSEClient holds connection settings and credentials for all API calls.
+type CDSEClient struct {
+	Server  string // host:port, e.g. "localhost:8443"
+	UserID  string
+	OrgID   string
+	OrgKey  string
+	Storage string // logical storage name, e.g. "EngineStorage"
+	HTTP    *http.Client
+}
+
+// baseURL constructs the HTTPS base URL for this client.
+func (c *CDSEClient) baseURL() string {
+	return "https://" + c.Server
+}
+
+// orgPath returns the path prefix for the current org+storage.
+func (c *CDSEClient) orgPath() string {
+	return fmt.Sprintf("/organizations/%s/storage/%s", c.OrgID, c.Storage)
+}
+
+// commonParams returns the mandatory query parameters for every request.
+func (c *CDSEClient) commonParams() url.Values {
+	v := url.Values{}
+	v.Set("userId", c.UserID)
+	v.Set("orgId", c.OrgID)
+	v.Set("orgKey", c.OrgKey)
+	return v
+}
+
+// get performs an authenticated GET request and returns the raw body.
+func (c *CDSEClient) get(path string, extra url.Values) ([]byte, error) {
+	params := c.commonParams()
+	for k, vs := range extra {
+		for _, v := range vs {
+			params.Add(k, v)
+		}
+	}
+	u := c.baseURL() + path + "?" + params.Encode()
+	resp, err := c.HTTP.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET %s: HTTP %d — %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// del performs an authenticated DELETE request.
+func (c *CDSEClient) del(path string) ([]byte, error) {
+	params := c.commonParams()
+	u := c.baseURL() + path + "?" + params.Encode()
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("DELETE %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("DELETE %s: HTTP %d — %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// postMultipart performs an authenticated multipart/form-data POST request.
+// fields is a map of text fields; filePath is an optional file to attach under "file".
+func (c *CDSEClient) postMultipart(path string, fields map[string]string, filePath string, extra url.Values) ([]byte, error) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	// Write credential fields first (required by CaumeDSE).
+	for _, k := range []string{"userId", "orgId", "orgKey"} {
+		var v string
+		switch k {
+		case "userId":
+			v = c.UserID
+		case "orgId":
+			v = c.OrgID
+		case "orgKey":
+			v = c.OrgKey
+		}
+		if err := mw.WriteField(k, v); err != nil {
+			return nil, err
+		}
+	}
+
+	// Write any additional text fields (e.g. resourceInfo).
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			return nil, err
+		}
+	}
+
+	// Attach the file part if provided.
+	if filePath != "" {
+		fw, err := mw.CreateFormFile("file", filepath.Base(filePath))
+		if err != nil {
+			return nil, err
+		}
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", filePath, err)
+		}
+		defer f.Close()
+		if _, err := io.Copy(fw, f); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := mw.Close(); err != nil {
+		return nil, err
+	}
+
+	// Append common params as query string and any caller extras.
+	params := c.commonParams()
+	for k, vs := range extra {
+		for _, v := range vs {
+			params.Add(k, v)
+		}
+	}
+	u := c.baseURL() + path + "?" + params.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u, &buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("POST %s: HTTP %d — %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// putForm performs an authenticated PUT request with URL-encoded form values.
+func (c *CDSEClient) putForm(path string, extra url.Values) ([]byte, error) {
+	params := c.commonParams()
+	for k, vs := range extra {
+		for _, v := range vs {
+			params.Add(k, v)
+		}
+	}
+	u := c.baseURL() + path + "?" + params.Encode()
+	req, err := http.NewRequest(http.MethodPut, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("PUT %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("PUT %s: HTTP %d — %s", path, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// ─── Command implementations ────────────────────────────────────────────────
+
+// cmdInfo prints user/org information.
+func (c *CDSEClient) cmdInfo() error {
+	path := fmt.Sprintf("/organizations/%s/users/%s", c.OrgID, c.UserID)
+	body, err := c.get(path, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdListSecrets lists all raw-file documents in the storage.
+func (c *CDSEClient) cmdListSecrets() error {
+	path := c.orgPath() + "/documentTypes/file.raw/documents"
+	body, err := c.get(path, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdStoreSecret uploads a local file as an encrypted secret.
+// name is the document name; filePath is the local file; resourceInfo is optional metadata.
+func (c *CDSEClient) cmdStoreSecret(name, filePath, resourceInfo string) error {
+	path := c.orgPath() + "/documentTypes/file.raw/documents/" + url.PathEscape(name)
+	fields := map[string]string{}
+	if resourceInfo != "" {
+		fields["*resourceInfo"] = resourceInfo
+	}
+	body, err := c.postMultipart(path, fields, filePath, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdGetSecret retrieves a secret and writes it to outFile (or stdout if empty).
+func (c *CDSEClient) cmdGetSecret(name, outFile string) error {
+	path := c.orgPath() + "/documentTypes/file.raw/documents/" + url.PathEscape(name) + "/content"
+	body, err := c.get(path, nil)
+	if err != nil {
+		return err
+	}
+	if outFile != "" {
+		if err := os.WriteFile(outFile, body, 0600); err != nil {
+			return fmt.Errorf("write %s: %w", outFile, err)
+		}
+		fmt.Printf("Secret '%s' saved to %s (%d bytes)\n", name, outFile, len(body))
+	} else {
+		os.Stdout.Write(body)
+	}
+	return nil
+}
+
+// cmdDeleteSecret deletes a single secret document.
+func (c *CDSEClient) cmdDeleteSecret(name string) error {
+	path := c.orgPath() + "/documentTypes/file.raw/documents/" + url.PathEscape(name)
+	body, err := c.del(path)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdDeleteAllSecrets deletes all raw-file documents in the storage.
+func (c *CDSEClient) cmdDeleteAllSecrets() error {
+	path := c.orgPath() + "/documentTypes/file.raw/documents"
+	body, err := c.del(path)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdDBList lists all CSV database documents in the storage.
+func (c *CDSEClient) cmdDBList() error {
+	path := c.orgPath() + "/documentTypes/file.csv/documents"
+	body, err := c.get(path, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdDBCreate creates a new encrypted CSV database with the given column headers.
+// cols is a comma-separated list such as "name,value,notes".
+func (c *CDSEClient) cmdDBCreate(name, cols string) error {
+	// Build a temporary CSV file containing only the header row.
+	tmp, err := os.CreateTemp("", "cdse_db_*.csv")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := fmt.Fprintf(tmp, "%s\n", cols); err != nil {
+		tmp.Close()
+		return err
+	}
+	tmp.Close()
+
+	path := c.orgPath() + "/documentTypes/file.csv/documents/" + url.PathEscape(name)
+	body, err := c.postMultipart(path, nil, tmp.Name(), nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// csvRowCount retrieves the CSV document and returns the number of data rows (excluding header).
+func (c *CDSEClient) csvRowCount(name string) (int, error) {
+	path := c.orgPath() + "/documentTypes/file.csv/documents/" + url.PathEscape(name) + "/content"
+	extra := url.Values{"outputType": {"csv"}}
+	body, err := c.get(path, extra)
+	if err != nil {
+		return 0, err
+	}
+	r := csv.NewReader(bytes.NewReader(body))
+	records, err := r.ReadAll()
+	if err != nil {
+		return 0, fmt.Errorf("parse CSV: %w", err)
+	}
+	if len(records) == 0 {
+		return 0, nil
+	}
+	// First record is the header; the rest are data rows.
+	return len(records) - 1, nil
+}
+
+// cmdDBInsert appends a row to the CSV database. kvPairs is a slice of "col=val" strings.
+func (c *CDSEClient) cmdDBInsert(name string, kvPairs []string) error {
+	count, err := c.csvRowCount(name)
+	if err != nil {
+		return fmt.Errorf("count rows: %w", err)
+	}
+	newRow := count + 1
+
+	path := fmt.Sprintf("%s/documentTypes/file.csv/documents/%s/contentRows/%d",
+		c.orgPath(), url.PathEscape(name), newRow)
+
+	extra := url.Values{}
+	for _, kv := range kvPairs {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid key=value pair: %q", kv)
+		}
+		extra.Set("["+parts[0]+"]", parts[1])
+	}
+
+	body, err := c.postMultipart(path, nil, "", extra)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Inserted row %d\n%s\n", newRow, string(body))
+	return nil
+}
+
+// cmdDBQuery retrieves all rows, or a specific row, from a CSV database.
+func (c *CDSEClient) cmdDBQuery(name string, row int) error {
+	extra := url.Values{"outputType": {"csv"}}
+	var path string
+	if row > 0 {
+		path = fmt.Sprintf("%s/documentTypes/file.csv/documents/%s/contentRows/%d",
+			c.orgPath(), url.PathEscape(name), row)
+	} else {
+		path = c.orgPath() + "/documentTypes/file.csv/documents/" + url.PathEscape(name) + "/content"
+	}
+	body, err := c.get(path, extra)
+	if err != nil {
+		return err
+	}
+	fmt.Print(string(body))
+	return nil
+}
+
+// cmdDBUpdate updates a specific row in a CSV database.
+func (c *CDSEClient) cmdDBUpdate(name string, row int, kvPairs []string) error {
+	path := fmt.Sprintf("%s/documentTypes/file.csv/documents/%s/contentRows/%d",
+		c.orgPath(), url.PathEscape(name), row)
+
+	extra := url.Values{}
+	for _, kv := range kvPairs {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid key=value pair: %q", kv)
+		}
+		extra.Set("["+parts[0]+"]", parts[1])
+	}
+
+	body, err := c.putForm(path, extra)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdDBDeleteRow deletes a specific row from a CSV database.
+func (c *CDSEClient) cmdDBDeleteRow(name string, row int) error {
+	path := fmt.Sprintf("%s/documentTypes/file.csv/documents/%s/contentRows/%d",
+		c.orgPath(), url.PathEscape(name), row)
+	body, err := c.del(path)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdDBDelete deletes an entire CSV database document.
+func (c *CDSEClient) cmdDBDelete(name string) error {
+	path := c.orgPath() + "/documentTypes/file.csv/documents/" + url.PathEscape(name)
+	body, err := c.del(path)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(body))
+	return nil
+}
+
+// cmdAuditLog retrieves the transaction/audit log and prints it as CSV.
+func (c *CDSEClient) cmdAuditLog() error {
+	extra := url.Values{"outputType": {"csv"}}
+	body, err := c.get("/transactions", extra)
+	if err != nil {
+		return err
+	}
+	fmt.Print(string(body))
+	return nil
+}
+
+// ─── Help ───────────────────────────────────────────────────────────────────
+
+func printHelp() {
+	fmt.Print(`cdse_client — CaumeDSE REST API CLI
+
+USAGE
+  cdse_client [FLAGS] COMMAND [ARGS...]
+
+FLAGS
+  -server   <host:port>   CaumeDSE server (default: localhost:8443)
+  -userId   <id>          User ID            (env: CDSE_USER_ID)
+  -orgId    <id>          Organisation ID    (env: CDSE_ORG_ID)
+  -orgKey   <key>         Organisation key   (env: CDSE_ORG_KEY)
+  -storage  <name>        Storage name       (env: CDSE_STORAGE, default: EngineStorage)
+  -insecure               Skip TLS certificate verification
+  -ca-cert  <path>        Path to custom CA certificate (PEM)
+  -i                      Interactive mode (prompt for credentials once, then loop)
+
+COMMANDS
+  info                              Show user/org info
+  list-secrets                      List all raw-file secrets
+  store-secret  NAME FILE [INFO]    Upload FILE as secret NAME (INFO = optional metadata)
+  get-secret    NAME [OUTFILE]      Download secret (write to OUTFILE or stdout)
+  delete-secret NAME                Delete a single secret
+  db-list                           List CSV databases
+  db-create     NAME col1,col2,...  Create CSV database with given columns
+  db-insert     NAME col=val ...    Append a row (key=value pairs)
+  db-query      NAME [ROW]          Get all rows or specific row number
+  db-update     NAME ROW col=val .. Update a row
+  db-delete-row NAME ROW            Delete a row
+  db-delete     NAME                Delete an entire CSV database
+  audit-log                         Print the audit / transaction log (CSV)
+  help                              Show this help
+
+EXAMPLES
+  # One-shot: store a secret, retrieve it, then delete it
+  cdse_client -userId alice -orgId acme -orgKey s3cr3t \
+      store-secret mypassword /etc/passwd "system passwords"
+  cdse_client -userId alice -orgId acme -orgKey s3cr3t get-secret mypassword
+  cdse_client -userId alice -orgId acme -orgKey s3cr3t delete-secret mypassword
+
+  # One-shot: create a CSV DB, insert and query rows
+  cdse_client -userId alice -orgId acme -orgKey s3cr3t \
+      db-create tokens id,token,label
+  cdse_client -userId alice -orgId acme -orgKey s3cr3t \
+      db-insert tokens id=1 token=abc123 label=dev
+  cdse_client -userId alice -orgId acme -orgKey s3cr3t db-query tokens
+
+  # Interactive mode (org key entered without echo)
+  cdse_client -userId alice -orgId acme -i
+
+  # Using environment variables
+  export CDSE_USER_ID=alice CDSE_ORG_ID=acme CDSE_ORG_KEY=s3cr3t
+  cdse_client audit-log
+`)
+}
+
+// ─── Credential helpers ─────────────────────────────────────────────────────
+
+// envOr returns the value of env variable key, or fallback if the variable is unset/empty.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// readPasswordNoEcho prints prompt and reads a line with terminal echo suppressed.
+// Falls back to normal ReadString if stty is unavailable (e.g. non-TTY).
+func readPasswordNoEcho(prompt string) (string, error) {
+	fmt.Print(prompt)
+
+	// Attempt to disable echo via stty (Linux/macOS).
+	disableEcho := exec.Command("stty", "-echo")
+	disableEcho.Stdin = os.Stdin
+	if err := disableEcho.Run(); err == nil {
+		// Re-enable echo when done, even on error.
+		defer func() {
+			enableEcho := exec.Command("stty", "echo")
+			enableEcho.Stdin = os.Stdin
+			_ = enableEcho.Run()
+			fmt.Println() // newline after hidden input
+		}()
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+// ─── Interactive mode ────────────────────────────────────────────────────────
+
+// runInteractive prompts for any missing credentials then enters a REPL loop.
+func runInteractive(client *CDSEClient) {
+	reader := bufio.NewReader(os.Stdin)
+
+	if client.UserID == "" {
+		fmt.Print("userId: ")
+		line, _ := reader.ReadString('\n')
+		client.UserID = strings.TrimRight(line, "\r\n")
+	}
+	if client.OrgID == "" {
+		fmt.Print("orgId: ")
+		line, _ := reader.ReadString('\n')
+		client.OrgID = strings.TrimRight(line, "\r\n")
+	}
+	if client.OrgKey == "" {
+		key, err := readPasswordNoEcho("orgKey: ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error reading orgKey:", err)
+			os.Exit(1)
+		}
+		client.OrgKey = key
+	}
+
+	fmt.Printf("Connected to %s  org=%s  user=%s  storage=%s\n",
+		client.Server, client.OrgID, client.UserID, client.Storage)
+
+	for {
+		fmt.Print("cdse> ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			// EOF (Ctrl-D) — clean exit.
+			fmt.Println()
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
+		args := strings.Fields(line)
+		if len(args) == 0 {
+			continue
+		}
+		if args[0] == "exit" || args[0] == "quit" {
+			break
+		}
+		if err := dispatch(client, args); err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+		}
+	}
+}
+
+// ─── Dispatcher ─────────────────────────────────────────────────────────────
+
+// dispatch routes a command (slice of strings starting with the verb) to the
+// appropriate CDSEClient method.
+func dispatch(c *CDSEClient, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no command provided; run 'help' for usage")
+	}
+	cmd := args[0]
+	rest := args[1:]
+
+	switch cmd {
+	case "help":
+		printHelp()
+
+	case "info":
+		return c.cmdInfo()
+
+	case "list-secrets":
+		return c.cmdListSecrets()
+
+	case "store-secret":
+		if len(rest) < 2 {
+			return fmt.Errorf("store-secret requires NAME and FILE")
+		}
+		info := ""
+		if len(rest) >= 3 {
+			info = rest[2]
+		}
+		return c.cmdStoreSecret(rest[0], rest[1], info)
+
+	case "get-secret":
+		if len(rest) < 1 {
+			return fmt.Errorf("get-secret requires NAME")
+		}
+		outFile := ""
+		if len(rest) >= 2 {
+			outFile = rest[1]
+		}
+		return c.cmdGetSecret(rest[0], outFile)
+
+	case "delete-secret":
+		if len(rest) < 1 {
+			return fmt.Errorf("delete-secret requires NAME")
+		}
+		return c.cmdDeleteSecret(rest[0])
+
+	case "db-list":
+		return c.cmdDBList()
+
+	case "db-create":
+		if len(rest) < 2 {
+			return fmt.Errorf("db-create requires NAME and col1,col2,...")
+		}
+		return c.cmdDBCreate(rest[0], rest[1])
+
+	case "db-insert":
+		if len(rest) < 2 {
+			return fmt.Errorf("db-insert requires NAME and at least one col=val pair")
+		}
+		return c.cmdDBInsert(rest[0], rest[1:])
+
+	case "db-query":
+		if len(rest) < 1 {
+			return fmt.Errorf("db-query requires NAME")
+		}
+		row := 0
+		if len(rest) >= 2 {
+			n, err := strconv.Atoi(rest[1])
+			if err != nil {
+				return fmt.Errorf("ROW must be an integer: %w", err)
+			}
+			row = n
+		}
+		return c.cmdDBQuery(rest[0], row)
+
+	case "db-update":
+		if len(rest) < 3 {
+			return fmt.Errorf("db-update requires NAME ROW col=val ...")
+		}
+		row, err := strconv.Atoi(rest[1])
+		if err != nil {
+			return fmt.Errorf("ROW must be an integer: %w", err)
+		}
+		return c.cmdDBUpdate(rest[0], row, rest[2:])
+
+	case "db-delete-row":
+		if len(rest) < 2 {
+			return fmt.Errorf("db-delete-row requires NAME and ROW")
+		}
+		row, err := strconv.Atoi(rest[1])
+		if err != nil {
+			return fmt.Errorf("ROW must be an integer: %w", err)
+		}
+		return c.cmdDBDeleteRow(rest[0], row)
+
+	case "db-delete":
+		if len(rest) < 1 {
+			return fmt.Errorf("db-delete requires NAME")
+		}
+		return c.cmdDBDelete(rest[0])
+
+	case "audit-log":
+		return c.cmdAuditLog()
+
+	default:
+		return fmt.Errorf("unknown command %q — run 'help' for usage", cmd)
+	}
+	return nil
+}
+
+// ─── main ────────────────────────────────────────────────────────────────────
+
+func main() {
+	// ── Flag definitions ──────────────────────────────────────────────────
+	serverFlag := flag.String("server", envOr("CDSE_SERVER", "localhost:8443"), "CaumeDSE host:port")
+	userFlag := flag.String("userId", envOr("CDSE_USER_ID", ""), "User ID")
+	orgFlag := flag.String("orgId", envOr("CDSE_ORG_ID", ""), "Organisation ID")
+	keyFlag := flag.String("orgKey", envOr("CDSE_ORG_KEY", ""), "Organisation encryption key")
+	storageFlag := flag.String("storage", envOr("CDSE_STORAGE", "EngineStorage"), "Storage name")
+	insecureFlag := flag.Bool("insecure", false, "Skip TLS certificate verification")
+	caCertFlag := flag.String("ca-cert", "", "Path to CA certificate (PEM)")
+	interactiveFlag := flag.Bool("i", false, "Interactive mode")
+
+	flag.Usage = func() { printHelp() }
+	flag.Parse()
+
+	// ── Build HTTP client ─────────────────────────────────────────────────
+	tlsCfg := &tls.Config{}
+
+	if *insecureFlag {
+		tlsCfg.InsecureSkipVerify = true //nolint:gosec // intentional dev-mode flag
+	} else if *caCertFlag != "" {
+		pem, err := os.ReadFile(*caCertFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading CA cert %s: %v\n", *caCertFlag, err)
+			os.Exit(1)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			fmt.Fprintln(os.Stderr, "Error: no valid certificates found in CA cert file")
+			os.Exit(1)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+
+	// ── Build CDSEClient ──────────────────────────────────────────────────
+	client := &CDSEClient{
+		Server:  *serverFlag,
+		UserID:  *userFlag,
+		OrgID:   *orgFlag,
+		OrgKey:  *keyFlag,
+		Storage: *storageFlag,
+		HTTP:    httpClient,
+	}
+
+	// ── Dispatch ──────────────────────────────────────────────────────────
+	if *interactiveFlag {
+		runInteractive(client)
+		return
+	}
+
+	// One-shot mode: command comes from positional arguments.
+	args := flag.Args()
+	if len(args) == 0 {
+		printHelp()
+		os.Exit(0)
+	}
+
+	// Ensure credentials are present for non-help commands.
+	if args[0] != "help" {
+		if client.UserID == "" || client.OrgID == "" || client.OrgKey == "" {
+			fmt.Fprintln(os.Stderr,
+				"Error: -userId, -orgId, and -orgKey (or CDSE_USER_ID/CDSE_ORG_ID/CDSE_ORG_KEY) are required")
+			os.Exit(1)
+		}
+	}
+
+	if err := dispatch(client, args); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+}

--- a/samples/hsm-db-crypto/c-golang/go.mod
+++ b/samples/hsm-db-crypto/c-golang/go.mod
@@ -1,0 +1,3 @@
+module cdse_client
+
+go 1.21

--- a/samples/hsm-db-crypto/d-perl/cdse_client.pl
+++ b/samples/hsm-db-crypto/d-perl/cdse_client.pl
@@ -1,0 +1,563 @@
+#!/usr/bin/perl
+###############################################################################
+# cdse_client.pl - Caume Data Security Engine (CaumeDSE) REST API client
+#
+# Copyright 2010-2026 by Omar Alejandro Herrera Reyna
+#
+#   CaumeDSE is free software: you can redistribute it and/or modify it under
+#   the terms of the GNU General Public License (v3 or later).
+#   See <http://www.gnu.org/licenses/> for details.
+#
+# SYNOPSIS
+#   cdse_client.pl [OPTIONS] COMMAND [ARGS...]
+#
+# DESCRIPTION
+#   Sample client simulating an HSM + encrypted database + general crypto
+#   interface via the CaumeDSE HTTPS REST API.
+#
+# OPTIONS
+#   --server HOST:PORT   CaumeDSE server (default: localhost:8443)
+#   --userId  ID         User ID (or env CDSE_USER_ID)
+#   --orgId   ID         Organization ID (or env CDSE_ORG_ID)
+#   --orgKey  KEY        Organization encryption key (or env CDSE_ORG_KEY)
+#   --storage NAME       Storage name (default: EngineStorage or CDSE_STORAGE)
+#   --insecure           Disable TLS certificate verification
+#   --ca-cert FILE       PEM CA certificate file for TLS verification
+#   --interactive / -i   Interactive prompt mode (prompts for credentials)
+#
+# COMMANDS
+#   info                            Show user/org info
+#   list-secrets                    List stored raw file secrets
+#   store-secret NAME FILE [INFO]   Upload FILE as encrypted secret NAME
+#   get-secret NAME [OUTFILE]       Retrieve secret (print or write to OUTFILE)
+#   delete-secret NAME              Delete a secret
+#   db-list                         List CSV databases
+#   db-create NAME col1,col2,...    Create a new CSV database
+#   db-insert NAME col=val ...      Append a row to CSV database
+#   db-query NAME [ROW]             Query all rows or a specific row number
+#   db-update NAME ROW col=val ...  Update row ROW in CSV database
+#   db-delete-row NAME ROW          Delete row ROW from CSV database
+#   db-delete NAME                  Delete entire CSV database
+#   audit-log                       Show transaction audit log
+#   help                            Show this help
+#
+# EXAMPLES
+#   # One-shot mode using env vars:
+#   export CDSE_USER_ID=admin CDSE_ORG_ID=MyOrg CDSE_ORG_KEY=s3cr3t
+#   export CDSE_SERVER=myserver:8443 CDSE_STORAGE=EngineStorage
+#   cdse_client.pl --ca-cert /etc/cdse/ca.pem info
+#   cdse_client.pl store-secret mykey /tmp/keyfile.bin "My AES key"
+#   cdse_client.pl get-secret mykey /tmp/keyfile-out.bin
+#   cdse_client.pl db-create payroll "name,salary,dept"
+#   cdse_client.pl db-insert payroll name=Alice salary=90000 dept=Engineering
+#   cdse_client.pl db-query payroll
+#   cdse_client.pl db-update payroll 1 salary=95000
+#   cdse_client.pl db-delete-row payroll 1
+#   cdse_client.pl audit-log
+#
+#   # Interactive mode:
+#   cdse_client.pl --interactive --server myserver:8443 --ca-cert /etc/cdse/ca.pem
+#
+###############################################################################
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case bundling);
+use File::Basename;
+use LWP::UserAgent;
+use HTTP::Request::Common;
+use URI::Escape;
+
+###############################################################################
+# Optional: Term::ReadKey for hidden password entry
+###############################################################################
+my $have_readkey = 0;
+eval {
+    require Term::ReadKey;
+    Term::ReadKey->import();
+    $have_readkey = 1;
+};
+
+###############################################################################
+# Global configuration
+###############################################################################
+my %cfg = (
+    server      => $ENV{CDSE_SERVER}   || 'localhost:8443',
+    userId      => $ENV{CDSE_USER_ID}  || '',
+    orgId       => $ENV{CDSE_ORG_ID}   || '',
+    orgKey      => $ENV{CDSE_ORG_KEY}  || '',
+    storage     => $ENV{CDSE_STORAGE}  || 'EngineStorage',
+    insecure    => 0,
+    ca_cert     => '',
+    interactive => 0,
+);
+
+###############################################################################
+# Parse command-line options
+###############################################################################
+GetOptions(
+    'server=s'      => \$cfg{server},
+    'userId=s'      => \$cfg{userId},
+    'orgId=s'       => \$cfg{orgId},
+    'orgKey=s'      => \$cfg{orgKey},
+    'storage=s'     => \$cfg{storage},
+    'insecure'      => \$cfg{insecure},
+    'ca-cert=s'     => \$cfg{ca_cert},
+    'interactive|i' => \$cfg{interactive},
+) or die "Error parsing options. Run '$0 help' for usage.\n";
+
+###############################################################################
+# Build LWP::UserAgent with appropriate TLS settings
+###############################################################################
+sub make_ua {
+    my %ssl_opts = ( verify_hostname => 1 );
+    if ($cfg{insecure}) {
+        $ssl_opts{verify_hostname} = 0;
+        $ssl_opts{SSL_verify_mode} = 0;
+    }
+    elsif ($cfg{ca_cert}) {
+        $ssl_opts{SSL_ca_file} = $cfg{ca_cert};
+    }
+    return LWP::UserAgent->new(
+        ssl_opts => \%ssl_opts,
+        timeout  => 60,
+    );
+}
+
+###############################################################################
+# Helpers: URL building and request execution
+###############################################################################
+
+# Base URL for the API
+sub base_url { "https://$cfg{server}" }
+
+# Auth query parameters (always required)
+sub auth_params {
+    return (
+        userId => $cfg{userId},
+        orgId  => $cfg{orgId},
+        orgKey => $cfg{orgKey},
+    );
+}
+
+# Append a hash of params as a query string to a URL
+sub append_query {
+    my ($url, %params) = @_;
+    my @pairs;
+    for my $k (sort keys %params) {
+        push @pairs, uri_escape($k) . '=' . uri_escape($params{$k});
+    }
+    return $url . '?' . join('&', @pairs);
+}
+
+# Execute a prepared HTTP::Response and print result or die on error
+sub do_request {
+    my ($ua, $req) = @_;
+    my $res = $ua->request($req);
+    unless ($res->is_success) {
+        warn "HTTP error: " . $res->status_line . "\n";
+        warn $res->decoded_content . "\n" if $res->decoded_content;
+        return undef;
+    }
+    return $res->decoded_content;
+}
+
+# Simple GET request
+sub do_get {
+    my ($ua, $path, %extra_params) = @_;
+    my %params = (auth_params(), %extra_params);
+    my $url = append_query(base_url() . $path, %params);
+    my $req = HTTP::Request->new(GET => $url);
+    return do_request($ua, $req);
+}
+
+# Simple DELETE request
+sub do_delete {
+    my ($ua, $path, %extra_params) = @_;
+    my %params = (auth_params(), %extra_params);
+    my $url = append_query(base_url() . $path, %params);
+    my $req = HTTP::Request->new(DELETE => $url);
+    return do_request($ua, $req);
+}
+
+# PUT request with all params in query string
+sub do_put {
+    my ($ua, $path, %extra_params) = @_;
+    my %params = (auth_params(), %extra_params);
+    my $url = append_query(base_url() . $path, %params);
+    my $req = HTTP::Request->new(PUT => $url);
+    return do_request($ua, $req);
+}
+
+# POST request for contentRows (params in query string, no body)
+sub do_post_params {
+    my ($ua, $path, %extra_params) = @_;
+    my %params = (auth_params(), %extra_params);
+    my $url = append_query(base_url() . $path, %params);
+    my $req = HTTP::Request->new(POST => $url);
+    return do_request($ua, $req);
+}
+
+# Multipart POST for file upload
+sub do_post_multipart {
+    my ($ua, $path, $file_path, $resource_info, %extra_params) = @_;
+    my $url = base_url() . $path;
+    my @content = (
+        file     => [$file_path],
+        userId   => $cfg{userId},
+        orgId    => $cfg{orgId},
+        orgKey   => $cfg{orgKey},
+    );
+    push @content, '*resourceInfo', $resource_info if defined $resource_info && $resource_info ne '';
+    for my $k (sort keys %extra_params) {
+        push @content, $k, $extra_params{$k};
+    }
+    my $req = POST($url,
+        Content_Type => 'form-data',
+        Content      => \@content,
+    );
+    return do_request($ua, $req);
+}
+
+# Multipart POST for CSV DB creation (upload a CSV header string as a file)
+sub do_post_csv_create {
+    my ($ua, $path, $csv_header) = @_;
+    my $url = base_url() . $path;
+
+    # Build a temporary in-memory "file" from the CSV header line
+    require HTTP::Request::Common;
+    my @content = (
+        file   => [undef, 'schema.csv',
+                   'Content-Type'        => 'text/csv',
+                   'Content-Disposition' => 'form-data; name="file"; filename="schema.csv"',
+                   Content => $csv_header],
+        userId => $cfg{userId},
+        orgId  => $cfg{orgId},
+        orgKey => $cfg{orgKey},
+    );
+    my $req = POST($url,
+        Content_Type => 'form-data',
+        Content      => \@content,
+    );
+    return do_request($ua, $req);
+}
+
+###############################################################################
+# Credential prompting (interactive mode)
+###############################################################################
+sub prompt_credentials {
+    print "CaumeDSE Interactive Client\n";
+    print "============================\n";
+
+    print "Server [localhost:8443]: ";
+    chomp(my $srv = <STDIN>);
+    $cfg{server} = $srv if $srv;
+
+    print "Storage [EngineStorage]: ";
+    chomp(my $st = <STDIN>);
+    $cfg{storage} = $st if $st;
+
+    print "User ID: ";
+    chomp($cfg{userId} = <STDIN>);
+
+    print "Org ID: ";
+    chomp($cfg{orgId} = <STDIN>);
+
+    if ($have_readkey) {
+        print "Org Key (hidden): ";
+        Term::ReadKey::ReadMode('noecho');
+        chomp($cfg{orgKey} = <STDIN>);
+        Term::ReadKey::ReadMode('restore');
+        print "\n";
+    }
+    else {
+        warn "Warning: Term::ReadKey not available; org key will be visible.\n";
+        print "Org Key: ";
+        chomp($cfg{orgKey} = <STDIN>);
+    }
+}
+
+###############################################################################
+# Command implementations
+###############################################################################
+
+sub cmd_info {
+    my ($ua) = @_;
+    my $path = "/organizations/$cfg{orgId}/users/$cfg{userId}";
+    my $out = do_get($ua, $path);
+    print $out if defined $out;
+}
+
+sub cmd_list_secrets {
+    my ($ua) = @_;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.raw/documents";
+    my $out = do_get($ua, $path, outputType => 'csv');
+    print $out if defined $out;
+}
+
+sub cmd_store_secret {
+    my ($ua, $name, $file, $info) = @_;
+    die "Usage: store-secret NAME FILE [INFO]\n"
+        unless defined $name && defined $file;
+    die "File not found: $file\n" unless -r $file;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.raw/documents/$name";
+    my $out = do_post_multipart($ua, $path, $file, $info);
+    print $out if defined $out;
+}
+
+sub cmd_get_secret {
+    my ($ua, $name, $outfile) = @_;
+    die "Usage: get-secret NAME [OUTFILE]\n" unless defined $name;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.raw/documents/$name/content";
+    my %params = (auth_params());
+    my $url = append_query(base_url() . $path, %params);
+    my $req = HTTP::Request->new(GET => $url);
+    my $res = make_ua()->request($req);
+    unless ($res->is_success) {
+        warn "HTTP error: " . $res->status_line . "\n";
+        warn $res->decoded_content . "\n" if $res->decoded_content;
+        return;
+    }
+    if (defined $outfile) {
+        open(my $fh, '>', $outfile) or die "Cannot write $outfile: $!\n";
+        binmode $fh;
+        print $fh $res->content;
+        close $fh;
+        print "Secret saved to: $outfile\n";
+    }
+    else {
+        print $res->decoded_content;
+    }
+}
+
+sub cmd_delete_secret {
+    my ($ua, $name) = @_;
+    die "Usage: delete-secret NAME\n" unless defined $name;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.raw/documents/$name";
+    my $out = do_delete($ua, $path);
+    print $out if defined $out;
+}
+
+sub cmd_db_list {
+    my ($ua) = @_;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.csv/documents";
+    my $out = do_get($ua, $path, outputType => 'csv');
+    print $out if defined $out;
+}
+
+sub cmd_db_create {
+    my ($ua, $name, $columns) = @_;
+    die "Usage: db-create NAME col1,col2,...\n"
+        unless defined $name && defined $columns;
+    # The CSV header is just the column names followed by a newline
+    my $csv_header = $columns . "\n";
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.csv/documents/$name";
+    my $out = do_post_csv_create($ua, $path, $csv_header);
+    print $out if defined $out;
+}
+
+sub cmd_db_insert {
+    my ($ua, $name, @col_vals) = @_;
+    die "Usage: db-insert NAME col=val ...\n"
+        unless defined $name && @col_vals;
+
+    # Parse col=val pairs
+    my %row;
+    for my $pair (@col_vals) {
+        my ($col, $val) = split /=/, $pair, 2;
+        die "Bad col=val pair: $pair\n" unless defined $col && defined $val;
+        $row{$col} = $val;
+    }
+
+    # First GET current content to count existing rows (determines next row index)
+    my $content_path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+                     . "/documentTypes/file.csv/documents/$name/content";
+    my $content = do_get($ua, $content_path, outputType => 'csv');
+    return unless defined $content;
+
+    # Count non-empty, non-header lines (header is line 1)
+    my @lines = grep { /\S/ } split /\n/, $content;
+    my $row_count = scalar(@lines) > 0 ? scalar(@lines) - 1 : 0;
+    my $next_row  = $row_count + 1;
+
+    my $post_path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+                  . "/documentTypes/file.csv/documents/$name"
+                  . "/contentRows/$next_row";
+    my $out = do_post_params($ua, $post_path, %row);
+    print $out if defined $out;
+}
+
+sub cmd_db_query {
+    my ($ua, $name, $row) = @_;
+    die "Usage: db-query NAME [ROW]\n" unless defined $name;
+    my $path;
+    if (defined $row) {
+        $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+              . "/documentTypes/file.csv/documents/$name"
+              . "/contentRows/$row";
+    }
+    else {
+        $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+              . "/documentTypes/file.csv/documents/$name/content";
+    }
+    my $out = do_get($ua, $path, outputType => 'csv');
+    print $out if defined $out;
+}
+
+sub cmd_db_update {
+    my ($ua, $name, $row, @col_vals) = @_;
+    die "Usage: db-update NAME ROW col=val ...\n"
+        unless defined $name && defined $row && @col_vals;
+
+    my %params;
+    for my $pair (@col_vals) {
+        my ($col, $val) = split /=/, $pair, 2;
+        die "Bad col=val pair: $pair\n" unless defined $col && defined $val;
+        $params{$col} = $val;
+    }
+
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.csv/documents/$name"
+             . "/contentRows/$row";
+    my $out = do_put($ua, $path, %params);
+    print $out if defined $out;
+}
+
+sub cmd_db_delete_row {
+    my ($ua, $name, $row) = @_;
+    die "Usage: db-delete-row NAME ROW\n"
+        unless defined $name && defined $row;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.csv/documents/$name"
+             . "/contentRows/$row";
+    my $out = do_delete($ua, $path);
+    print $out if defined $out;
+}
+
+sub cmd_db_delete {
+    my ($ua, $name) = @_;
+    die "Usage: db-delete NAME\n" unless defined $name;
+    my $path = "/organizations/$cfg{orgId}/storage/$cfg{storage}"
+             . "/documentTypes/file.csv/documents/$name";
+    my $out = do_delete($ua, $path);
+    print $out if defined $out;
+}
+
+sub cmd_audit_log {
+    my ($ua) = @_;
+    my $out = do_get($ua, '/transactions', outputType => 'csv');
+    print $out if defined $out;
+}
+
+sub cmd_help {
+    # Print the POD/comment usage block from the top of this file
+    open(my $fh, '<', $0) or die "Cannot read $0: $!\n";
+    my $in_header = 0;
+    while (<$fh>) {
+        if (/^###/) { $in_header = !$in_header; next; }
+        print if $in_header;
+    }
+    close $fh;
+}
+
+###############################################################################
+# Command dispatch
+###############################################################################
+my %COMMANDS = (
+    'info'           => sub { my $ua = shift; cmd_info($ua) },
+    'list-secrets'   => sub { my $ua = shift; cmd_list_secrets($ua) },
+    'store-secret'   => sub { my ($ua, @a) = @_; cmd_store_secret($ua, @a) },
+    'get-secret'     => sub { my ($ua, @a) = @_; cmd_get_secret($ua, @a) },
+    'delete-secret'  => sub { my ($ua, @a) = @_; cmd_delete_secret($ua, @a) },
+    'db-list'        => sub { my $ua = shift; cmd_db_list($ua) },
+    'db-create'      => sub { my ($ua, @a) = @_; cmd_db_create($ua, @a) },
+    'db-insert'      => sub { my ($ua, @a) = @_; cmd_db_insert($ua, @a) },
+    'db-query'       => sub { my ($ua, @a) = @_; cmd_db_query($ua, @a) },
+    'db-update'      => sub { my ($ua, @a) = @_; cmd_db_update($ua, @a) },
+    'db-delete-row'  => sub { my ($ua, @a) = @_; cmd_db_delete_row($ua, @a) },
+    'db-delete'      => sub { my ($ua, @a) = @_; cmd_db_delete($ua, @a) },
+    'audit-log'      => sub { my $ua = shift; cmd_audit_log($ua) },
+    'help'           => sub { cmd_help() },
+);
+
+###############################################################################
+# Interactive REPL
+###############################################################################
+sub run_interactive {
+    my ($ua) = @_;
+    print "CaumeDSE interactive shell. Type 'help' for commands, 'quit' to exit.\n";
+    while (1) {
+        print "cdse> ";
+        my $line = <STDIN>;
+        last unless defined $line;
+        chomp $line;
+        $line =~ s/^\s+|\s+$//g;
+        next unless length $line;
+        last if $line eq 'quit' || $line eq 'exit' || $line eq 'q';
+
+        # Simple shell-like tokenization (handles single/double quotes)
+        my @tokens;
+        while ($line =~ /("([^"]*)")|('([^']*)')|(\S+)/g) {
+            if    (defined $2) { push @tokens, $2 }
+            elsif (defined $4) { push @tokens, $4 }
+            elsif (defined $5) { push @tokens, $5 }
+        }
+        next unless @tokens;
+
+        my $cmd = shift @tokens;
+        if (exists $COMMANDS{$cmd}) {
+            eval { $COMMANDS{$cmd}->($ua, @tokens) };
+            warn $@ if $@;
+        }
+        else {
+            warn "Unknown command: $cmd  (type 'help' for list)\n";
+        }
+    }
+    print "\nBye.\n";
+}
+
+###############################################################################
+# Main entry point
+###############################################################################
+
+if ($cfg{interactive}) {
+    # Interactive mode: prompt for credentials, then enter REPL
+    prompt_credentials();
+    die "userId, orgId and orgKey are required.\n"
+        unless $cfg{userId} && $cfg{orgId} && $cfg{orgKey};
+    my $ua = make_ua();
+    run_interactive($ua);
+}
+else {
+    # One-shot mode: command and args from ARGV
+    my $cmd = shift @ARGV // 'help';
+
+    if ($cmd eq 'help') {
+        cmd_help();
+        exit 0;
+    }
+
+    die "userId is required (--userId or CDSE_USER_ID).\n"  unless $cfg{userId};
+    die "orgId is required (--orgId or CDSE_ORG_ID).\n"     unless $cfg{orgId};
+    die "orgKey is required (--orgKey or CDSE_ORG_KEY).\n"  unless $cfg{orgKey};
+
+    unless (exists $COMMANDS{$cmd}) {
+        warn "Unknown command: $cmd\n";
+        cmd_help();
+        exit 1;
+    }
+
+    my $ua = make_ua();
+    eval { $COMMANDS{$cmd}->($ua, @ARGV) };
+    if ($@) {
+        chomp(my $err = $@);
+        die "$err\n";
+    }
+}
+
+__END__


### PR DESCRIPTION
## Summary

New `samples/hsm-db-crypto/` directory providing four independent client implementations that demonstrate the CDSE REST API as a hybrid HSM / encrypted database / general crypto command interface.

### Applications

| Dir | Language | File | Notes |
|-----|----------|------|-------|
| `a-web/` | HTML5 + JS | `index.html` | SPA, no external deps; dark-themed tabbed UI |
| `a-web/` | Python 3 | `proxy.py` | CORS proxy (stdlib only); serves HTML, forwards `/cdse/*` to CDSE HTTPS |
| `b-python/` | Python 3 | `cdse_client.py` | Requires: `requests` |
| `c-golang/` | Go | `cdse_client.go` | Standard library only; no external dependencies |
| `d-perl/` | Perl | `cdse_client.pl` | Requires: `LWP::UserAgent`, `HTTP::Request::Common` |

### Operations covered by all CLI clients

- `info` — user/org info
- `list-secrets` / `store-secret` / `get-secret` / `delete-secret` — encrypted file.raw storage
- `db-list` / `db-create` / `db-insert` / `db-query` / `db-update` / `db-delete-row` / `db-delete` — encrypted CSV (file.csv) CRUD
- `audit-log` — transaction log

### Modes

All CLI clients support:
- **Interactive mode** (`-i`): credentials entered once (orgKey hidden); `cdse>` prompt loop
- **One-shot/parameter mode**: all credentials per call via flags or env vars (`CDSE_SERVER`, `CDSE_USER_ID`, `CDSE_ORG_ID`, `CDSE_ORG_KEY`, `CDSE_STORAGE`)

## Test plan

- [x] Python: `python3 -c "import ast; ast.parse(...)"` — syntax OK
- [x] Go: `go build ./...` — compiles cleanly (standard library only)
- [x] proxy.py: `python3 -c "import ast; ast.parse(...)"` — syntax OK
- [x] Main CDSE `make` — clean build, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)