### PR TITLE
Avoid repeated DB pragma setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,9 +22,10 @@
   - Keep shared Perl interpreter calls serialized.
   - Move DB/file work, secure DB reconstruction, response construction, and cleanup outside the global Perl lock where possible.
 
-- [ ] #5 Avoid reapplying SQLite PRAGMAs on every DB open.
+- [x] #5 Avoid reapplying SQLite PRAGMAs on every DB open.
   - Split memory DB and file DB open setup.
   - Apply WAL/synchronous/cache settings only where they are useful and check PRAGMA errors.
+  - Done: memory DB opens now bypass file-backed PRAGMAs, file create/open setup checks PRAGMA errors, and regular DB opens no longer reapply WAL mode.
 
 - [ ] #6 Cache logs table schema validation.
   - Validate/create the transactions table at startup or first use under a mutex.

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,10 @@
   - Done: `db.c` memory table insert and secure DB protect/unprotect update loops now use prepared statements.
   - Done: `filehandling.c` CSV and memory-table import insert builders for `meta` and `data` tables now use prepared statements.
 
-- [ ] #3 Replace request spin/yield waits with event-driven synchronization.
+- [x] #3 Replace request spin/yield waits with event-driven synchronization.
   - Current `sleep(cmeDefaultThreadWaitSeconds)` loops can become busy-yield loops when the wait value is zero.
   - Prefer libmicrohttpd request lifecycle handling or `pthread_cond_t` signaling.
+  - Done: POST request status handoff now uses per-connection `pthread_cond_t` signaling instead of `sleep(0)` loops.
 
 - [ ] #4 Narrow the parser script Perl mutex.
   - Keep shared Perl interpreter calls serialized.

--- a/db.c
+++ b/db.c
@@ -44,6 +44,25 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 ***/
 #include "common.h"
 
+static int cmeDBApplyPragmas(sqlite3 *pDB, const char *functionName, const char *filename, const char *pragmas)
+{
+    int result;
+    char *errorMessage=NULL;
+
+    result=sqlite3_exec(pDB,pragmas,NULL,NULL,&errorMessage);
+    if (result!=SQLITE_OK)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: %s(), sqlite3_exec() PRAGMA error for database '%s': %s\n",
+                functionName,filename,(errorMessage)?errorMessage:sqlite3_errmsg(pDB));
+#endif
+        sqlite3_free(errorMessage);
+        return(1);
+    }
+    sqlite3_free(errorMessage);
+    return(0);
+}
+
 //TODO (OHR#5#):create and call function to sanitize all input that will be included in DB queries!
 int cmeDBCreateOpen (const char *filename, sqlite3 **ppDB)
 {
@@ -62,10 +81,40 @@ int cmeDBCreateOpen (const char *filename, sqlite3 **ppDB)
     }
     else
     {
-        sqlite3_exec(*ppDB,"PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA cache_size=-8000;",
-                     NULL,NULL,NULL); //Enable WAL for concurrent readers + writer; NORMAL avoids double-fsync.
+        if (strcmp(filename,":memory:") &&
+            cmeDBApplyPragmas(*ppDB,"cmeDBCreateOpen",filename,
+                              "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA cache_size=-8000;"))
+        {
+            sqlite3_close(*ppDB);
+            *ppDB=NULL;
+            return(2);
+        }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeDBCreateOpen(), Created/opened sqlite3 database file: %s.\n",filename);
+#endif
+        return(0);
+    }
+}
+
+int cmeMemDBCreateOpen (sqlite3 **ppDB)
+{
+    int result;
+
+    result = sqlite3_open_v2(":memory:", ppDB,SQLITE_OPEN_READWRITE|
+                             SQLITE_OPEN_CREATE|SQLITE_OPEN_FULLMUTEX, NULL);
+    if (result!=SQLITE_OK)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeMemDBCreateOpen(), sqlite_open_v2() error: %s\n",
+                sqlite3_errmsg(*ppDB));
+#endif
+        sqlite3_close(*ppDB);
+        return(1);
+    }
+    else
+    {
+#ifdef DEBUG
+        fprintf(stdout,"CaumeDSE Debug: cmeMemDBCreateOpen(), Created/opened sqlite3 memory database.\n");
 #endif
         return(0);
     }
@@ -88,8 +137,13 @@ int cmeDBOpen (const char *filename, sqlite3 **ppDB)
     }
     else
     {
-        sqlite3_exec(*ppDB,"PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA cache_size=-8000;",
-                     NULL,NULL,NULL); //Enable WAL for concurrent readers + writer; NORMAL avoids double-fsync.
+        if (cmeDBApplyPragmas(*ppDB,"cmeDBOpen",filename,
+                              "PRAGMA synchronous=NORMAL; PRAGMA cache_size=-8000;"))
+        {
+            sqlite3_close(*ppDB);
+            *ppDB=NULL;
+            return(2);
+        }
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Debug: cmeDBOpen(), Opened sqlite3 database file: %s.\n",filename);
 #endif

--- a/db.h
+++ b/db.h
@@ -48,6 +48,8 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 
 // Wrapper function for sqlite3_open_v2() to create a new database file
 int cmeDBCreateOpen (const char *filename, sqlite3 **ppDB);
+// Wrapper function for sqlite3_open_v2() to create a new memory database
+int cmeMemDBCreateOpen (sqlite3 **ppDB);
 // Wrapper function for sqlite3_open_v2() to open an esisting database file for R/W
 int cmeDBOpen (const char *filename, sqlite3 **ppDB);
 // Wrapper function for sqlite3_close()

--- a/engine_admin.c
+++ b/engine_admin.c
@@ -614,7 +614,7 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
             }
         }
     }
-    result=cmeDBCreateOpen(":memory:",&saveDB);
+    result=cmeMemDBCreateOpen(&saveDB);
     if (result) //Error
     {
 #ifdef ERROR_LOG

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -158,7 +158,7 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
 
     *resultDB=NULL;  //Pointer to results must not point to anything previously! (Caller responsibility).
     //Open empty result DB (we must return at least an empty database in case of error). Caller must close it.
-    if (cmeDBCreateOpen(":memory:",resultDB))
+    if (cmeMemDBCreateOpen(resultDB))
     {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeSecureSQLToMemDB(), cmeDBCreateOpen() Error, can't "
@@ -321,7 +321,7 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
         }
         else //MAC OK; load column file.
         {
-            if (cmeDBCreateOpen(":memory:",&(memDBcol[cont])))
+            if (cmeMemDBCreateOpen(&(memDBcol[cont])))
             {
 #ifdef ERROR_LOG
                 fprintf(stderr,"CaumeDSE Error: cmeSecureSQLToMemDB(), cmeDBCreateOpen() Error, can't "

--- a/filehandling.c
+++ b/filehandling.c
@@ -676,7 +676,7 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
             {
                 cmeGetRndSalt(&(SQLDBfNames[cont]));
                 //TODO (OHR#8#): Create SQLDBfNames collision handling routine. Just in case.
-                if (cmeDBCreateOpen(":memory:",&(ppDB[cont])))
+                if (cmeMemDBCreateOpen(&(ppDB[cont])))
                 {
 #ifdef ERROR_LOG
                     fprintf(stderr,"CaumeDSE Error: cmeCVSFileToSecureSQL(), cmeDBCreateOpen() Error, can't "
@@ -1725,7 +1725,7 @@ void cmeContentReaderFreeCallback (void *cls)
         {
             cmeGetRndSalt(&(SQLDBfNames[cont]));
             //TODO (OHR#8#): Create SQLDBfNames collision handling routine. Just in case.
-            if (cmeDBCreateOpen(":memory:",&(ppDB[cont])))
+            if (cmeMemDBCreateOpen(&(ppDB[cont])))
             {
 #ifdef ERROR_LOG
                 fprintf(stderr,"CaumeDSE Error: cmeMemTableToSecureDB(), cmeDBCreateOpen() Error, can't "

--- a/function_tests.c
+++ b/function_tests.c
@@ -504,7 +504,7 @@ void testDB (PerlInterpreter* myPerl)
     sqlite3 *DB;
     char **pQueryResult;        //Important: do not declare it as char ***
 
-    cmeDBCreateOpen (":memory:",&DB);       //Create memory DB
+    cmeMemDBCreateOpen(&DB);       //Create memory DB
     cmeSQLRows(DB,"BEGIN TRANSACTION; CREATE TABLE table1 (key INTEGER PRIMARY KEY,"
                "nombre TEXT, apellido TEXT, salario FLOAT);"
                "INSERT INTO table1 (nombre,apellido,salario) VALUES('Enrique','Sorcia',10011);"
@@ -530,7 +530,7 @@ void testDB (PerlInterpreter* myPerl)
     ilist[0]="cdse";
     ilist[1]=testScriptPath;
     result=cmePerlParserCmdLineInit(2,ilist,myPerl);    //initialize Parser and script's global variables
-    cmeDBCreateOpen (":memory:",&DB);       //Create memory DB
+    cmeMemDBCreateOpen(&DB);       //Create memory DB
     cmeSQLRows(DB,"BEGIN TRANSACTION; CREATE TABLE table1 (key INTEGER PRIMARY KEY,"
                "nombre TEXT, apellido TEXT, salario FLOAT);"
                "INSERT INTO table1 (nombre,apellido,salario) VALUES('Enrique','Sorcia',10011);"

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -82,6 +82,16 @@ static void cmeWebServiceWaitThreadStatus(struct cmeWebServiceConnectionInfoStru
     pthread_mutex_unlock(&(con_info->threadStatusMutex));
 }
 
+static void cmeWebServiceAbortPOST(struct cmeWebServiceConnectionInfoStruct *con_info)
+{
+    if (con_info->filePointer)
+    {
+        fclose(con_info->filePointer);
+        con_info->filePointer=NULL;
+    }
+    cmeWebServiceSetThreadStatus(con_info,2);
+}
+
 int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection, const char *url,
                                    const char *method, const char *version, const char *upload_data,
                                    size_t *upload_data_size, void **con_cls)
@@ -259,7 +269,12 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
     {
         if (*upload_data_size != 0) //If data is available, retrieve it and exit function for another iteration.
         {
-            MHD_post_process (con_info->postProcessor, upload_data,*upload_data_size);
+            if (MHD_NO == MHD_post_process (con_info->postProcessor, upload_data,*upload_data_size))
+            {
+                *upload_data_size = 0;
+                cmeWebServiceAbortPOST(con_info);
+                return MHD_NO;
+            }
             *upload_data_size = 0;
             return MHD_YES;
         }
@@ -7185,6 +7200,7 @@ int cmeWebServicePOSTIteration (void *coninfo_cls, enum MHD_ValueKind kind, cons
             cmeStrConstrAppend(&(con_info->answerString),"<b>403 ERROR Forbidden request.</b><br><br>"
                                "Physical temporary file already exists.<br>METHOD: 'POST' - message chunk iteration<br>");
             con_info->answerCode = MHD_HTTP_FORBIDDEN;
+            cmeWebServiceAbortPOST(con_info);
             cmeWebServicePOSTIterationFree();
             return MHD_NO;
         }
@@ -7199,6 +7215,7 @@ int cmeWebServicePOSTIteration (void *coninfo_cls, enum MHD_ValueKind kind, cons
             cmeStrConstrAppend(&(con_info->answerString),"<b>500 ERROR Internal server error.</b><br><br>"
                                "Can't create local copy of file.<br>METHOD: 'POST' - message chunk iteration<br>");
             con_info->answerCode = MHD_HTTP_INTERNAL_SERVER_ERROR;
+            cmeWebServiceAbortPOST(con_info);
             cmeWebServicePOSTIterationFree();
             return MHD_NO;
         }
@@ -7225,6 +7242,7 @@ int cmeWebServicePOSTIteration (void *coninfo_cls, enum MHD_ValueKind kind, cons
             cmeStrConstrAppend(&(con_info->answerString),"<b>500 ERROR Internal server error.</b><br><br>"
                                "Can't append data to local file.<br>METHOD: 'POST' - message chunk iteration<br>");
             con_info->answerCode = MHD_HTTP_INTERNAL_SERVER_ERROR;
+            cmeWebServiceAbortPOST(con_info);
             cmeWebServicePOSTIterationFree();
             return MHD_NO;
         }

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -44,6 +44,44 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 ***/
 #include "common.h"
 
+static void cmeWebServiceSetThreadStatus(struct cmeWebServiceConnectionInfoStruct *con_info, int threadStatus)
+{
+    pthread_mutex_lock(&(con_info->threadStatusMutex));
+    con_info->threadStatus=threadStatus;
+    pthread_cond_broadcast(&(con_info->threadStatusCond));
+    pthread_mutex_unlock(&(con_info->threadStatusMutex));
+}
+
+static int cmeWebServiceGetThreadStatus(struct cmeWebServiceConnectionInfoStruct *con_info)
+{
+    int threadStatus;
+
+    pthread_mutex_lock(&(con_info->threadStatusMutex));
+    threadStatus=con_info->threadStatus;
+    pthread_mutex_unlock(&(con_info->threadStatusMutex));
+    return(threadStatus);
+}
+
+static void cmeWebServiceWaitThreadStatusNot(struct cmeWebServiceConnectionInfoStruct *con_info, int threadStatus)
+{
+    pthread_mutex_lock(&(con_info->threadStatusMutex));
+    while (con_info->threadStatus==threadStatus)
+    {
+        pthread_cond_wait(&(con_info->threadStatusCond),&(con_info->threadStatusMutex));
+    }
+    pthread_mutex_unlock(&(con_info->threadStatusMutex));
+}
+
+static void cmeWebServiceWaitThreadStatus(struct cmeWebServiceConnectionInfoStruct *con_info, int threadStatus)
+{
+    pthread_mutex_lock(&(con_info->threadStatusMutex));
+    while (con_info->threadStatus!=threadStatus)
+    {
+        pthread_cond_wait(&(con_info->threadStatusCond),&(con_info->threadStatusMutex));
+    }
+    pthread_mutex_unlock(&(con_info->threadStatusMutex));
+}
+
 int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection, const char *url,
                                    const char *method, const char *version, const char *upload_data,
                                    size_t *upload_data_size, void **con_cls)
@@ -142,6 +180,25 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
         con_info->connectionStartTime=time(NULL);
         con_info->requestDataSize=(long int)*upload_data_size;
         con_info->threadStatus=0;
+        if (pthread_mutex_init(&(con_info->threadStatusMutex),NULL))
+        {
+#ifdef ERROR_LOG
+            fprintf(stderr,"CaumeDSE Error: cmeWebServiceAnswerConnection(), pthread_mutex_init() failed."
+                    " Method: '%s', url: '%s'!\n",method,url);
+#endif
+            cmeFree(con_info);
+            return MHD_NO;
+        }
+        if (pthread_cond_init(&(con_info->threadStatusCond),NULL))
+        {
+#ifdef ERROR_LOG
+            fprintf(stderr,"CaumeDSE Error: cmeWebServiceAnswerConnection(), pthread_cond_init() failed."
+                    " Method: '%s', url: '%s'!\n",method,url);
+#endif
+            pthread_mutex_destroy(&(con_info->threadStatusMutex));
+            cmeFree(con_info);
+            return MHD_NO;
+        }
         con_info->answerString=NULL;
         con_info->answerCode=0;
         con_info->filePointer=NULL;
@@ -169,7 +226,7 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
 #endif
                 //cmeFree(con_info);
                 con_info->connectionType=GET; //Don't reject a POST with parameters in the URI, process as a GET request
-                con_info->threadStatus=2;
+                cmeWebServiceSetThreadStatus(con_info,2);
                 //return MHD_NO;
             }
             else
@@ -188,7 +245,7 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
                     "Method: %s, url: %s.\n", method, url);
 #endif
             con_info->connectionType=GET;
-            con_info->threadStatus=2;
+            cmeWebServiceSetThreadStatus(con_info,2);
         }
         *con_cls=(void *)con_info;
         return MHD_YES;
@@ -206,20 +263,17 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
             *upload_data_size = 0;
             return MHD_YES;
         }
-        else if (NULL != con_info->answerString) //If no data is available but we have an answer, signal job is done.
-        {
-            con_info->threadStatus=1; //Signal: POST iterator job is done, waiting...
-        }
         if (con_info->filePointer) //We need to close the file before cmeWebServiceRequestCompleted() is called, since cmeWebServiceProcessRequest() will use it.
         {
             fclose (con_info->filePointer);
             con_info->filePointer=NULL;
         }
+        if (*upload_data_size == 0) //No more data is available; signal that POST parsing is done.
+        {
+            cmeWebServiceSetThreadStatus(con_info,1);
+        }
     }
-    do  //Wait until the POST processor has collected all data.
-    {
-        sleep(cmeDefaultThreadWaitSeconds);
-    } while (con_info->threadStatus==0);
+    cmeWebServiceWaitThreadStatusNot(con_info,0); //Wait until the POST processor has collected all data.
     //Allocate space for headers and response headers:
     headerElements=(char **)malloc((sizeof (char *))*cmeWSHTTPMaxHeaders*2); //*2 since headers consist of headerElements PAIRS.
     responseHeaders=(char **)malloc((sizeof (char *))*cmeWSHTTPMaxResponseHeaders*2); //*2 since headers consist of headerElements PAIRS.
@@ -337,7 +391,7 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
         }
         exitcode=MHD_queue_response (connection, responseCode, response);
     }
-    con_info->threadStatus=2; //Now the POST handling routing thread can free memory and finish.
+    cmeWebServiceSetThreadStatus(con_info,2); //Now the POST handling routing thread can free memory and finish.
     result=cmeWebServiceLogConnection (connection,con_info,con_info->connectionStartTime,method,url,con_info->requestDataSize,responseDataSize,
                                        (const char **)headerElements,(const char **)responseHeaders,(const char **)argumentElements,
                                        (const char **)urlElements,numUrlElements);
@@ -7071,14 +7125,8 @@ int cmeWebServicePOSTIteration (void *coninfo_cls, enum MHD_ValueKind kind, cons
             cmeFree(tmpFilename); \
         } while (0); //Local free() macro.
 
-    if (con_info->threadStatus==1) //Job is done, but we need to wait until the request has been fully processed by other parts of the program
+    if (cmeWebServiceGetThreadStatus(con_info)>=1) //Job is done; ignore any later POST iterator callbacks.
     {
-        sleep(cmeDefaultThreadWaitSeconds);
-        return MHD_YES;
-    }
-    else if (con_info->threadStatus==2) //Job is done and request processing is done as well. Finish the routine.
-    {
-        sleep(cmeDefaultThreadWaitSeconds);
         return MHD_YES;
     }
     if (0 != strcmp (key, "file"))
@@ -7206,10 +7254,7 @@ void cmeWebServiceRequestCompleted (void *cls, struct MHD_Connection *connection
     {
         return;
     }
-    do  //Wait until the POST processor has collected all data and the request has been processed.
-    {
-        sleep(cmeDefaultThreadWaitSeconds);
-    } while (con_info->threadStatus!=2);
+    cmeWebServiceWaitThreadStatus(con_info,2); //Wait until the POST processor has collected all data and the request has been processed.
     if (con_info->connectionType == POST)
     {
         if (NULL != con_info->postProcessor)
@@ -7251,6 +7296,8 @@ void cmeWebServiceRequestCompleted (void *cls, struct MHD_Connection *connection
         }
     }
     cmeFree(con_info->answerString);
+    pthread_cond_destroy(&(con_info->threadStatusCond));
+    pthread_mutex_destroy(&(con_info->threadStatusMutex));
     cmeFree(con_info);
     *coninfo_cls = NULL;
 }

--- a/webservice_interface.h
+++ b/webservice_interface.h
@@ -58,6 +58,8 @@ struct cmeWebServiceConnectionInfoStruct
     int postArgCont;
     int answerCode;
     int threadStatus;          //signal to the thread that it is ok to clean stuff here. 0=in progress, 1=thread done,waiting, 2=thread done, closing.
+    pthread_mutex_t threadStatusMutex;
+    pthread_cond_t threadStatusCond;
     time_t connectionStartTime;//Per-connection timestamp set when the connection is first seen (replaces former static local).
     long int requestDataSize;  //Per-connection accumulated POST body size (replaces former static local).
 };


### PR DESCRIPTION
## Summary
- add a checked SQLite PRAGMA helper and fail DB open/create when tuning fails
- split explicit memory DB creation into `cmeMemDBCreateOpen()` so `:memory:` opens skip file-backed PRAGMAs
- stop reapplying persistent WAL mode on every regular DB open while keeping synchronous/cache tuning per connection
- mark TODO #5 complete

## Verification
- `./configure --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP`
- `make`
- `TEST/run_debug_components.sh` (`18` passed, `0` failed)

Note: this PR also includes the two already-committed TODO #3 synchronization batches currently on `devtest` (`c536aa3`, `308ac2e`) because they had not been pushed before this branch update.