### PR TITLE
Add protected lookup indexes for document resources

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,60 @@
+2026-06-10 Omar A. Herrera Reyna <0h3rr3r4@gmail.com>
+
+	* engine_interface.c, webservice_interface.c: Mitigate SQL
+	injection risk in protected insert paths by replacing generated SQL
+	value lists with sqlite3 prepared statements and bound parameters
+	for protected register writes and multipart POST parameter handling.
+
+	* filehandling.c: Replace generated file-import INSERT statements
+	with reusable sqlite3 prepared statements for secure CSV and memory
+	table imports, preserving existing protection behavior while
+	removing ad hoc value interpolation.
+
+	* webservice_interface.h, webservice_interface.c: Replace POST
+	processing spin waits with condition-variable signaling.  Track POST
+	terminal states explicitly so worker threads can sleep until upload
+	processing, abort, or response readiness changes.
+
+	* webservice_interface.c: Signal terminal POST status on abort paths
+	so waiting request handlers do not remain blocked after parser or
+	connection failures.
+
+	* db.h, db.c, engine_admin.c, engine_interface.c, filehandling.c,
+	function_tests.c: Avoid repeated database PRAGMA setup on already
+	open sqlite3 handles by centralizing post-open tuning in
+	cmeDBApplyPragmas().
+
+	* db.c (cmeMemSecureDBReintegrate): Batch duplicate-column
+	reintegration with a prepared INSERT inside one in-memory
+	transaction instead of rebuilding SQL per row.
+
+	* common.h: Add ResourcesDB document lookup column identifiers and a
+	fixed lookup salt for deterministic protected lookup generation.
+
+	* db.h, db.c (cmeGetProtectDBLookupValue,
+	cmeEnsureResourcesDBDocumentLookups): Add field-separated keyed HMAC
+	lookup values for documentId, storageId and orgResourceId, plus
+	migration support for nullable lookup columns and indexes on
+	existing ResourcesDB documents tables.
+
+	* engine_admin.c: Create and populate documentIdLookup,
+	storageIdLookup and orgResourceIdLookup columns when registering
+	secure documents, and include those appended columns when saving the
+	shuffled ResourcesDB document index.
+
+	* engine_interface.c: Use protected lookup columns to narrow
+	exact-match ResourcesDB document queries and deletes for documentId,
+	storageId and orgResourceId when the columns are present, while
+	still decrypting and verifying protected values and retaining
+	fallback support for legacy rows with NULL lookup values.
+
+	* README: Document protected lookup indexes, their scope, fallback
+	behavior, and the fact that lookup filtering does not replace
+	encrypted/MAC-protected value verification.
+
+	* TODO.md: Mark the safer default lookup item complete and record
+	the duplicate-column reintegration prepared-statement batch.
+
 2026-06-07 Omar A. Herrera Reyna <0h3rr3r4@gmail.com>
 
 	* common.h: Increase default POST processing and response callback

--- a/README
+++ b/README
@@ -269,6 +269,20 @@ The architecture of CaumeDSE is composed of several layers:
 	   Scripts should therefore access columns by name and not by their
 	   position).
 
+	   ResourcesDB document indexes also keep deterministic protected
+	   lookup values for documentId, storageId and orgResourceId.  These
+	   lookup values are keyed HMACs with field-specific domain
+	   separation, and are used only to narrow exact-match searches on
+	   these high-cardinality identifiers.  They do not replace the
+	   encrypted and MAC-protected register values: matching registers
+	   are still decrypted and verified before being returned or
+	   deleted.  Lookup values are intentionally not generated for
+	   low-cardinality or arbitrary document attributes, preserving the
+	   protection provided by encrypted values and column shuffling.
+	   Older databases are migrated with nullable lookup columns, and
+	   registers without lookup values remain readable through the
+	   normal protected-value verification path.
+
 	6. Resource processing - All data processing including encryption
 	   and decryption takes place in memory (with a few exceptions, such
 	   as file uploads that are stored in a specific directory before
@@ -493,7 +507,9 @@ orgResourceId
 	Stores the identifier of an {organization} resource. For
 	transactions, if the user was correctly authenticated, then this
 	value will be protected (indicated by the 'authenticated'
-	parameter).
+	parameter).  For ResourcesDB document registers, exact-match
+	queries may use the protected orgResourceIdLookup index as a
+	candidate filter before normal protected-value verification.
 
 basicAuthPwdHash
 	Resources/ResourceTypes: users, {user}
@@ -539,6 +555,9 @@ documentId
 	taken from the URI.
 
 	Stores the identifier of a {document} resource.
+	For ResourcesDB document registers, exact-match queries may use the
+	protected documentIdLookup index as a candidate filter before normal
+	protected-value verification.
 
 storageId
 	Resources/ResourceTypes: storage
@@ -547,6 +566,9 @@ storageId
 	taken from the URI.
 
 	Stores the identifier of a {storage} resource.
+	For ResourcesDB document registers, exact-match queries may use the
+	protected storageIdLookup index as a candidate filter before normal
+	protected-value verification.
 
 partHash
 	Resources/ResourceTypes: documents, {document}
@@ -1295,6 +1317,12 @@ documents
 			Engine-results: <number of matching registers>
 		RESPONSE BODY:
 			<Attribute table for matching resources>
+
+	Exact-match filters for _documentId, _storageId and _orgResourceId
+	may use protected lookup indexes when available.  These indexes only
+	narrow the candidate set; CaumeDSE still decrypts and verifies the
+	protected document attributes before returning, updating or deleting
+	registers.  Legacy registers without lookup values remain supported.
 
 	Example 1) 	List attribute table for all document resources of
 			type file.raw

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,11 @@
 
 ## Speed Optimizations That Preserve Security and Integrity
 
-- [ ] #1 Add deterministic protected lookup columns for searchable encrypted fields.
+- [x] #1 Add deterministic protected lookup columns for searchable encrypted fields.
   - Target fields include `documentId`, `orgResourceId`, `storageId`, `type`, and user/organization identifiers used in filters.
   - Use a keyed blind index such as `HMAC(searchKey, fieldName || "\0" || plaintext)` and add SQLite indexes over those lookup columns.
   - Keep encrypted values, salts, and MAC verification unchanged.
+  - Done: safer default lookup columns are applied only to `documentId`, `orgResourceId`, and `storageId` in ResourcesDB documents.
 
 - [x] #2 Replace generated hot-loop INSERT/UPDATE SQL strings with prepared statements.
   - Use `sqlite3_prepare_v2`, `sqlite3_bind_*`, `sqlite3_step`, and `sqlite3_reset` in bulk insert/update loops.
@@ -38,6 +39,7 @@
 - [ ] #8 Batch only in-memory transformations before immediate durable saves.
   - Combine related temporary memory DB updates with prepared statements or a transaction.
   - Do not defer protected file/resources DB writes after a logical change.
+  - Done: duplicate-column reintegration now copies rows with a prepared statement inside one in-memory transaction.
 
 - [x] #9 Add an independent component verification script for DEBUG builds.
   - Create a script such as `TEST/run_debug_components.sh` that configures a DEBUG/TESTDATABASE install under `/tmp`, builds, installs, runs the engine non-interactively, and writes one log per component.

--- a/common.h
+++ b/common.h
@@ -98,6 +98,7 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #define cmeDefaultSecureDBSaltLen 16    //Default salt length for meta and data salts within secure databases.
 #define cmeDefaultValueSaltLen 16        //Default size for prep-ended bytes for internal databases' encrypted values.
 #define cmeDefaultValueSaltCharLen 2*cmeDefaultValueSaltLen             //Default size for CaumeDSE ByteHexStr value salts used in protected DBs.
+#define cmeDefaultLookupSalt "4361756d654453454c6f6f6b75703121"        //Fixed 16-byte hex salt for deterministic protected lookup HMAC derivation.
 #define cmeDefaultSqlBufferLen 8192         //Default size of Buffer for SQL queries. {8192}
 extern char cmeDefaultEncAlg[];             //Default algorithm for symmetric encryption in engine admin. databases.
 void cmeInitDefaultEncAlg();                //Initialize default algorithm from environment
@@ -164,7 +165,7 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #define cmeIDDColumnFileMeta_attribute_4 "signProtected"        //Column value {0 based} for WSID column digital signature after protection attribute
 #define cmeIDDColumnFileMeta_attribute_5 "MAC"                  //Column value {0 based} for WSID column MAC before protection attribute
 #define cmeIDDColumnFileMeta_attribute_6 "MACProtected"         //Column value {0 based} for WSID column MAC after protection attribute
-#define cmeIDDResourcesDBDocumentsNumCols 15                            //# of columns for User tables in ResourceDB databases
+#define cmeIDDResourcesDBDocumentsNumCols 18                            //# of columns for User tables in ResourceDB databases
 #define cmeIDDResourcesDBDocuments_resourceInfo 4                       //Column index {0 based} for WSID column resource information
 #define cmeIDDResourcesDBDocuments_resourceInfo_name "resourceInfo"     //Column name for WSID column resource information
 #define cmeIDDResourcesDBDocuments_columnFile 5                         //Column index {0 based} for WSID column column file
@@ -187,6 +188,12 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #define cmeIDDResourcesDBDocuments_lastModified_name "lastModified"     //Column name for WSID column last modified date {UNIX/POSIX time}
 #define cmeIDDResourcesDBDocuments_columnId 14                          //Column index {0 based} for WSID column column id
 #define cmeIDDResourcesDBDocuments_columnId_name "columnId"             //Column name for WSID column column id
+#define cmeIDDResourcesDBDocuments_documentIdLookup 15                  //Column index {0 based} for protected lookup of document id
+#define cmeIDDResourcesDBDocuments_documentIdLookup_name "documentIdLookup" //Column name for protected lookup of document id
+#define cmeIDDResourcesDBDocuments_storageIdLookup 16                   //Column index {0 based} for protected lookup of storage id
+#define cmeIDDResourcesDBDocuments_storageIdLookup_name "storageIdLookup" //Column name for protected lookup of storage id
+#define cmeIDDResourcesDBDocuments_orgResourceIdLookup 17               //Column index {0 based} for protected lookup of organization resource id
+#define cmeIDDResourcesDBDocuments_orgResourceIdLookup_name "orgResourceIdLookup" //Column name for protected lookup of organization resource id
 #define cmeIDDResourcesDBUsersNumCols 12                                //# of columns for User tables in ResourceDB databases
 #define cmeIDDResourcesDBUsers_resourceInfo 4                           //Column index {0 based} for WSID column resource information
 #define cmeIDDResourcesDBUsers_resourceInfo_name "resourceInfo"         //Column name for WSID column resource information

--- a/db.c
+++ b/db.c
@@ -2512,6 +2512,131 @@ int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const c
     return (0);
 }
 
+int cmeGetProtectDBLookupValue (const char *columnName, const char *value, const char *orgKey,
+                                char **lookupValue)
+{
+    int result,written=0;
+    char *lookupInput=NULL;
+    char *lookupSalt=NULL;
+    #define cmeGetProtectDBLookupValueFree() \
+        do { \
+            cmeFree(lookupInput); \
+            cmeFree(lookupSalt); \
+        } while (0); //Local free() macro
+
+    *lookupValue=NULL;
+    if ((!columnName)||(!value)||(!orgKey))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeGetProtectDBLookupValue(), Error, NULL parameter.\n");
+#endif
+        cmeGetProtectDBLookupValueFree();
+        return(1);
+    }
+    cmeStrConstrAppend(&lookupInput,"CaumeDSE:protectedLookup:v1:%s:%lu:%s",
+                       columnName,(unsigned long)strlen(value),value);
+    cmeStrConstrAppend(&lookupSalt,"%s",cmeDefaultLookupSalt);
+    result=cmeHMACByteString((const unsigned char *)lookupInput,(unsigned char **)lookupValue,strlen(lookupInput),
+                             &written,cmeDefaultMACAlg,&lookupSalt,orgKey);
+    if (result)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeGetProtectDBLookupValue(), cmeHMACByteString() Error, can't "
+                "compute lookup value for column '%s'!\n",columnName);
+#endif
+        cmeGetProtectDBLookupValueFree();
+        return(2);
+    }
+    cmeGetProtectDBLookupValueFree();
+    return(0);
+}
+
+static int cmeDBTableHasColumn (sqlite3 *pDB, const char *tableName, const char *columnName, int *hasColumn)
+{
+    int cont,result,numRows=0,numColumns=0;
+    char *query=NULL;
+    char **queryResult=NULL;
+    #define cmeDBTableHasColumnFree() \
+        do { \
+            cmeFree(query); \
+            if (queryResult) \
+            { \
+                cmeMemTableFinal(queryResult); \
+            } \
+        } while (0); //Local free() macro
+
+    *hasColumn=0;
+    cmeStrConstrAppend(&query,"PRAGMA table_info(\"%s\");",tableName);
+    result=cmeMemTable(pDB,query,&queryResult,&numRows,&numColumns);
+    if (result)
+    {
+        cmeDBTableHasColumnFree();
+        return(1);
+    }
+    for (cont=1;cont<=numRows;cont++)
+    {
+        if (!strcmp(queryResult[(cont*numColumns)+1],columnName))
+        {
+            *hasColumn=1;
+            break;
+        }
+    }
+    cmeDBTableHasColumnFree();
+    return(0);
+}
+
+int cmeEnsureResourcesDBDocumentLookups (sqlite3 *pDB)
+{
+    int cont,result,hasColumn=0;
+    const char *lookupColumns[3]={
+        cmeIDDResourcesDBDocuments_documentIdLookup_name,
+        cmeIDDResourcesDBDocuments_storageIdLookup_name,
+        cmeIDDResourcesDBDocuments_orgResourceIdLookup_name
+    };
+    const char *lookupIndexes[3]={
+        "idx_doc_documentIdLookup",
+        "idx_doc_storageIdLookup",
+        "idx_doc_orgResourceIdLookup"
+    };
+    char *query=NULL;
+    #define cmeEnsureResourcesDBDocumentLookupsFree() \
+        do { \
+            cmeFree(query); \
+        } while (0); //Local free() macro
+
+    for (cont=0;cont<3;cont++)
+    {
+        result=cmeDBTableHasColumn(pDB,"documents",lookupColumns[cont],&hasColumn);
+        if (result)
+        {
+            cmeEnsureResourcesDBDocumentLookupsFree();
+            return(1);
+        }
+        if (!hasColumn)
+        {
+            cmeStrConstrAppend(&query,"ALTER TABLE documents ADD COLUMN %s TEXT;",lookupColumns[cont]);
+            result=cmeSQLRows(pDB,query,NULL,NULL);
+            cmeFree(query);
+            if (result)
+            {
+                cmeEnsureResourcesDBDocumentLookupsFree();
+                return(2);
+            }
+        }
+        cmeStrConstrAppend(&query,"CREATE INDEX IF NOT EXISTS %s ON documents(%s);",
+                           lookupIndexes[cont],lookupColumns[cont]);
+        result=cmeSQLRows(pDB,query,NULL,NULL);
+        cmeFree(query);
+        if (result)
+        {
+            cmeEnsureResourcesDBDocumentLookupsFree();
+            return(3);
+        }
+    }
+    cmeEnsureResourcesDBDocumentLookupsFree();
+    return(0);
+}
+
 int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
                                const int dbNumCols, int *dbNumReintegratedCols)
 {
@@ -2531,12 +2656,16 @@ int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
     char *currentMetaSalt=NULL;
     char *currentMetaUserId=NULL;
     char *currentMetaOrgId=NULL;
-    char *sqlQuery=NULL;
-    char *sanitizedStr=NULL;
+    sqlite3_stmt *insertReintegratedDataStmt=NULL;
     sqlite3 *tmpPtr=NULL;       //Just a tmp pointer; no need for cmeFree().
     //MEMORY CLEANUP MACRO for local function.
     #define cmeMemSecureDBReintegrateFree() \
         do { \
+            if (insertReintegratedDataStmt) \
+            { \
+                sqlite3_finalize(insertReintegratedDataStmt); \
+                insertReintegratedDataStmt=NULL; \
+            } \
             cmeFree(numRowsData); \
             cmeFree(currentEncData); \
             cmeFree(currentEncB64Data); \
@@ -2546,8 +2675,6 @@ int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
             cmeFree(currentMetaSalt); \
             cmeFree(currentMetaUserId); \
             cmeFree(currentMetaOrgId); \
-            cmeFree(sqlQuery); \
-            cmeFree(sanitizedStr); \
             if (memColumnName) \
             { \
                 for (cont=0;cont<dbNumCols;cont++) \
@@ -2670,63 +2797,87 @@ int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
                     {
                         if (!strcmp(memColumnName[cont3],memColumnName[cont])) //We have a duplicate!, insert data rows into first duplicate column and clear this column name.
                         {
+                            result=sqlite3_prepare_v2(memSecureDB[cont3],
+                                                      "INSERT INTO data "
+                                                      "(id,userId,orgId,salt,value,rowOrder,MAC,sign,MACProtected,signProtected,otphDkey) "
+                                                      "VALUES (NULL,?,?,?,?,?,?,?,?,?,?);",
+                                                      -1,&insertReintegratedDataStmt,NULL);
+                            if (result!=SQLITE_OK)
+                            {
+#ifdef ERROR_LOG
+                                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), sqlite3_prepare_v2() Error, can't "
+                                        "prepare reintegrated data insert in secured DB data table!\n");
+#endif
+                                cmeMemSecureDBReintegrateFree();
+                                return(5);
+                            }
+                            if (cmeSQLRows(memSecureDB[cont3],"BEGIN TRANSACTION;",NULL,NULL))
+                            {
+#ifdef ERROR_LOG
+                                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), cmeSQLRows() Error, can't "
+                                        "begin reintegrated data transaction in secured DB data table!\n");
+#endif
+                                cmeMemSecureDBReintegrateFree();
+                                return(5);
+                            }
                             for (cont4=1;cont4<=numRowsData[cont];cont4++) //Insert rows, skipping column names
                             {
-                                cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION;"
-                                                   " INSERT INTO data (id,userId,orgId,salt,value,rowOrder,MAC,sign,MACProtected,signProtected,otphDkey)"
-                                                   " VALUES (NULL"); //First part of query.
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDanydb_userId],
-                                                     &sanitizedStr);   //Sanitize parameter userId for use in SQL statement.
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDanydb_orgId],
-                                                     &sanitizedStr);   //Sanitize parameter orgId for use in SQL statement.
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDanydb_salt],
-                                                     &sanitizedStr);   //Sanitize parameter salt for use in SQL statement.
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_value],
-                                                     &sanitizedStr);   //Sanitize parameter value for use in SQL statement.
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_rowOrder],
-                                                     &sanitizedStr);   //Sanitize parameter rowOrder for use in SQL statement.
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_MAC],
-                                                     &sanitizedStr);   //Sanitize parameter MAC for use in SQL statement.
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_sign],
-                                                     &sanitizedStr);   //Sanitize parameter sign for use in SQL statement
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_MACProtected],
-                                                     &sanitizedStr);   //Sanitize parameter MACProtected for use in SQL statement
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_signProtected],
-                                                     &sanitizedStr);   //Sanitize parameter signProtected for use in SQL statement
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeFree(sanitizedStr);
-                                cmeSanitizeStrForSQL(memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_otphDKey],
-                                                     &sanitizedStr);   //Sanitize parameter otphDkey for use in SQL statement
-                                cmeStrConstrAppend(&sqlQuery,",'%s'",sanitizedStr);
-                                cmeStrConstrAppend(&sqlQuery,"); COMMIT;"); //Last part of query.
-                                if (cmeSQLRows(memSecureDB[cont3],sqlQuery,NULL,NULL)) //insert row.
+                                result=sqlite3_bind_text(insertReintegratedDataStmt,1,
+                                                         memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDanydb_userId],
+                                                         -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,2,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDanydb_orgId],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,3,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDanydb_salt],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,4,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_value],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,5,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_rowOrder],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,6,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_MAC],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,7,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_sign],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,8,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_MACProtected],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,9,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_signProtected],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_bind_text(insertReintegratedDataStmt,10,
+                                                                                memData[cont][cmeIDDColumnFileDataNumCols*cont4+cmeIDDColumnFileData_otphDKey],
+                                                                                -1,SQLITE_TRANSIENT);
+                                if (result==SQLITE_OK) result=sqlite3_step(insertReintegratedDataStmt);
+                                if (result!=SQLITE_DONE)
                                 {
 #ifdef ERROR_LOG
-                                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), cmeSQLRows() Error, can't "
+                                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), sqlite3_step() Error, can't "
                                             "insert row in secured DB data table!\n");
 #endif
-                                    cmeFree(sqlQuery);
+                                    cmeSQLRows(memSecureDB[cont3],"ROLLBACK;",NULL,NULL);
+                                    cmeMemSecureDBReintegrateFree();
                                     return(5);
                                 }
-                                cmeFree(sqlQuery);
+                                sqlite3_reset(insertReintegratedDataStmt);
+                                sqlite3_clear_bindings(insertReintegratedDataStmt);
                             }
+                            if (cmeSQLRows(memSecureDB[cont3],"COMMIT;",NULL,NULL))
+                            {
+#ifdef ERROR_LOG
+                                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), cmeSQLRows() Error, can't "
+                                        "commit reintegrated data transaction in secured DB data table!\n");
+#endif
+                                cmeSQLRows(memSecureDB[cont3],"ROLLBACK;",NULL,NULL);
+                                cmeMemSecureDBReintegrateFree();
+                                return(5);
+                            }
+                            sqlite3_finalize(insertReintegratedDataStmt);
+                            insertReintegratedDataStmt=NULL;
                             (*dbNumReintegratedCols)--;
                             cmeFree(memColumnName[cont]); //clear current column name, since it was a duplicate (we copy all rows to the first col. name duplicate only)
                             //cmeStrConstrAppend(&(memColumnName[cont]),"*%d",cont); //Mark current column name, since it was a duplicate (we copy all rows to the first col. name duplicate only)

--- a/db.h
+++ b/db.h
@@ -91,6 +91,11 @@ int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const cha
 // Function to unprotect+unsalt (decodify B64, unencrypt and remove salt from value) a salt+protected text string.
 int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const char *encAlg, char **salt,
                                const char *orgKey, int *valueLen);
+// Function to compute deterministic keyed lookup values for selected protected exact-match columns.
+int cmeGetProtectDBLookupValue (const char *columnName, const char *value, const char *orgKey,
+                                char **lookupValue);
+// Function to ensure optional ResourcesDB document lookup columns and indexes exist.
+int cmeEnsureResourcesDBDocumentLookups (sqlite3 *pDB);
 // Function to reintegrate (before unprotecting) sliced DB columns of secure DB column files in memory.
 int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
                                const int dbNumCols, int *dbNumReintegratedCols);

--- a/engine_admin.c
+++ b/engine_admin.c
@@ -88,6 +88,16 @@ int cmeSetupEngineAdminDBs ()
         fprintf(stdout,"CaumeDSE Debug: cmeSetupEngineAdminDBs(), DB file %s already exists;"
                 " skipping.\n",currentDBName);
 #endif
+        result=cmeEnsureResourcesDBDocumentLookups(currentDB);
+        if (result)
+        {
+#ifdef ERROR_LOG
+            fprintf(stderr,"CaumeDSE Error: cmeSetupEngineAdminDBs(), cmeEnsureResourcesDBDocumentLookups() failed "
+                    "with Engine Admin. DB file: %s!\n",currentDBName);
+#endif
+            cmeSetupEngineAdminDBsFree();
+            return(1);
+        }
         cmeSetupEngineAdminDBsFree();
     }
     else
@@ -106,8 +116,12 @@ int cmeSetupEngineAdminDBs ()
                                     "CREATE TABLE documents (id INTEGER PRIMARY KEY,"
                                     " userId TEXT, orgId TEXT, salt TEXT, resourceInfo TEXT,"
                                     " columnFile TEXT, type TEXT, documentId TEXT, storageId TEXT, orgResourceId TEXT,"
-                                    " partMAC TEXT, totalParts TEXT, partId TEXT, lastModified TEXT, columnId TEXT); "
+                                    " partMAC TEXT, totalParts TEXT, partId TEXT, lastModified TEXT, columnId TEXT,"
+                                    " documentIdLookup TEXT, storageIdLookup TEXT, orgResourceIdLookup TEXT); "
                                     "CREATE INDEX idx_doc_uo ON documents(userId,orgId); "
+                                    "CREATE INDEX idx_doc_documentIdLookup ON documents(documentIdLookup); "
+                                    "CREATE INDEX idx_doc_storageIdLookup ON documents(storageIdLookup); "
+                                    "CREATE INDEX idx_doc_orgResourceIdLookup ON documents(orgResourceIdLookup); "
                                     "CREATE TABLE users (id INTEGER PRIMARY KEY,"
                                     " userId TEXT, orgId TEXT, salt TEXT, resourceInfo TEXT,"
                                     " certificate TEXT, publicKey TEXT, userResourceId TEXT, basicAuthPwdHash TEXT,"
@@ -422,7 +436,7 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
     int numRows=0;
     int numColumns=0;
     time_t timeStamp=0;
-    const int numDocumentDBCols=cmeIDDResourcesDBDocumentsNumCols-2;          //Number of columns to handle in the documents DB table, except ID and salt;
+    const int numDocumentDBProtectedCols=cmeIDDResourcesDBDocuments_columnId-1; //Protected document columns handled here, except ID and salt.
     const char dbFName[]="ResourcesDB";
     sqlite3 *currentDB=NULL;
     sqlite3 *saveDB=NULL;
@@ -434,6 +448,9 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
     char *totalParts=NULL;          //Will contain the text equivalent total parts per column of each column file
     char *lastModified=NULL;        //Will contain the text equivalent of current date (timestamp)
     char *columnId=NULL;            //Will contain the text equivalent of the column number, so that each part can be reassembled within the corresponding column.
+    char *documentIdLookup=NULL;
+    char *storageIdLookup=NULL;
+    char *orgResourceIdLookup=NULL;
     char **sqlTable=NULL;
     unsigned char **currentMACProtectedSaltedData=NULL;
     unsigned char *hexStrSalt=NULL;
@@ -445,12 +462,15 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
             cmeFree(totalParts); \
             cmeFree(lastModified); \
             cmeFree(columnId); \
+            cmeFree(documentIdLookup); \
+            cmeFree(storageIdLookup); \
+            cmeFree(orgResourceIdLookup); \
             cmeFree(hexStrSalt); \
             cmeFree(currentProtectedData); \
             cmeFree(currentDataMAC); \
             if (currentMACProtectedSaltedData) \
             { \
-                for (cont=0;cont<numDocumentDBCols;cont++) \
+                for (cont=0;cont<numDocumentDBProtectedCols;cont++) \
                 { \
                     cmeFree(currentMACProtectedSaltedData[cont]); \
                 } \
@@ -472,8 +492,8 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
             } \
         } //Local free() macro
 
-    currentMACProtectedSaltedData=(unsigned char **)malloc((sizeof(unsigned char *))*numDocumentDBCols);
-    for (cont=0;cont<numDocumentDBCols;cont++) //Initialize pointers.
+    currentMACProtectedSaltedData=(unsigned char **)malloc((sizeof(unsigned char *))*numDocumentDBProtectedCols);
+    for (cont=0;cont<numDocumentDBProtectedCols;cont++) //Initialize pointers.
     {
         currentMACProtectedSaltedData[cont]=NULL;
     }
@@ -488,7 +508,17 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
         cmeRegisterSecureDBFree();
         return(1);
     }
-    else  //Register rows
+    result=cmeEnsureResourcesDBDocumentLookups(currentDB);
+    if (result)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeRegisterSecureDB(), cmeEnsureResourcesDBDocumentLookups() failed "
+                "with Engine Admin. DB file: %s!\n",currentDBName);
+#endif
+        cmeRegisterSecureDBFree();
+        return(1);
+    }
+    //Register rows
     {
         cmeStrConstrAppend(&totalParts,"%d",numSQLDBparts); //Set text variable with total number of parts (i.e. column fragments)
         timeStamp=time(NULL);
@@ -587,17 +617,33 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
             cmeStrConstrAppend((char **)&currentMACProtectedSaltedData[12],"%s%s",currentDataMAC,currentProtectedData);
             cmeFree(currentDataMAC);
             cmeFree(currentProtectedData);
+            cmeFree(documentIdLookup);
+            cmeFree(storageIdLookup);
+            cmeFree(orgResourceIdLookup);
+            if (cmeGetProtectDBLookupValue(cmeIDDResourcesDBDocuments_documentId_name,documentId,orgKey,&documentIdLookup) ||
+                cmeGetProtectDBLookupValue(cmeIDDResourcesDBDocuments_storageId_name,storageId,orgKey,&storageIdLookup) ||
+                cmeGetProtectDBLookupValue(cmeIDDResourcesDBDocuments_orgResourceId_name,orgResourceId,orgKey,&orgResourceIdLookup))
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeRegisterSecureDB(), cmeGetProtectDBLookupValue() Error, can't "
+                        "compute document lookup values!\n");
+#endif
+                cmeRegisterSecureDBFree();
+                return(2);
+            }
             // Insert row in database:
             cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; " //Parameters sanitized by protection (Encryption+B64 conversion).
                                 "INSERT INTO documents (id, userId, orgId, salt, resourceInfo,"
                                 " columnFile, type, documentId, storageId, orgResourceId, partMAC,"
-                                " totalParts, partId, lastModified, columnId)"
-                                "VALUES (NULL,'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s');"
+                                " totalParts, partId, lastModified, columnId,"
+                                " documentIdLookup, storageIdLookup, orgResourceIdLookup)"
+                                "VALUES (NULL,'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s');"
                                 "COMMIT;",currentMACProtectedSaltedData[0],currentMACProtectedSaltedData[1],hexStrSalt,
                                 currentMACProtectedSaltedData[2],currentMACProtectedSaltedData[10],currentMACProtectedSaltedData[3],
                                 currentMACProtectedSaltedData[4],currentMACProtectedSaltedData[5],currentMACProtectedSaltedData[6],
                                 currentMACProtectedSaltedData[11],currentMACProtectedSaltedData[9],currentMACProtectedSaltedData[12],
-                                currentMACProtectedSaltedData[7],currentMACProtectedSaltedData[8]);
+                                currentMACProtectedSaltedData[7],currentMACProtectedSaltedData[8],
+                                documentIdLookup,storageIdLookup,orgResourceIdLookup);
             if (cmeSQLRows(currentDB,sqlQuery,NULL,NULL)) //insert row.
             {
 #ifdef ERROR_LOG
@@ -608,7 +654,7 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
                 return(2);
             }
             cmeFree(sqlQuery);
-            for (cont2=0;cont2<numDocumentDBCols;cont2++) //Clear protected values placeholders for next iteration.
+            for (cont2=0;cont2<numDocumentDBProtectedCols;cont2++) //Clear protected values placeholders for next iteration.
             {
                 cmeFree(currentMACProtectedSaltedData[cont2]);
             }
@@ -628,7 +674,8 @@ int cmeRegisterSecureDBorFile (const char **SQLDBfNames, const int numSQLDBfName
     //Process (copy+shuffle) table documents:
     result=cmeMemTable(currentDB, //cmeMemTable uses sqlite3_prepare_v2 which returns column names even for empty tables.
                        "SELECT userId, orgId, salt, resourceInfo, columnFile, type, documentId, storageId,"
-                       " orgResourceId, partMAC, totalParts, partId, lastModified, columnId FROM documents;",
+                       " orgResourceId, partMAC, totalParts, partId, lastModified, columnId,"
+                       " documentIdLookup, storageIdLookup, orgResourceIdLookup FROM documents;",
                        &sqlTable,&numRows,&numColumns); //We need to skip id, as it will be inserted by cmeMemTableToMemDB()
     if (result) //Error
     {

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -62,6 +62,12 @@ static int cmeIsSafeSQLIdentifier(const char *identifier)
     return(1);
 }
 
+static int cmeIsResourcesDBDocumentLookupColumn (const char *columnName);
+static const char *cmeResourcesDBDocumentLookupColumnForMatch (const char *columnName);
+static int cmeBuildProtectedDBSelectQuery (sqlite3 *pDB, char **query, const char *tableName, const char **columnNames,
+                                           const char **columnValues, const int numColumnValues,
+                                           const char *orgKey);
+
 int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *documentId,
                         const char *orgKey, const char *storagePath)
 {   //IDD v.1.0.21
@@ -86,6 +92,7 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
     char *currentRawFileContent=NULL;
     char *protectedValueMAC=NULL;
     char *bkpFName=NULL;
+    char *query=NULL;
     char *sqlTableName="data"; //default table name for memory databases
     unsigned char *decodedEncryptedString=NULL;
     sqlite3 **memDBcol=NULL;
@@ -97,6 +104,7 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
             cmeFree(protectedValueMAC); \
             cmeFree(resultMemTable); \
             cmeFree (bkpFName); \
+            cmeFree(query); \
             cmeFree (decodedEncryptedString); \
             if (memDBcol) \
             { \
@@ -167,7 +175,15 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
         cmeSecureDBToMemDBFree(); //CLEANUP.
         return(1);
     }
-    result=cmeMemTable(pResourcesDB,"SELECT * FROM documents",&queryResult,&numRows,&numCols);
+    result=cmeBuildProtectedDBSelectQuery(pResourcesDB,&query,"documents",
+                                          (const char *[]){cmeIDDResourcesDBDocuments_documentId_name},
+                                          (const char *[]){documentId},1,orgKey);
+    if (result)
+    {
+        cmeSecureDBToMemDBFree(); //CLEANUP.
+        return(2);
+    }
+    result=cmeMemTable(pResourcesDB,query,&queryResult,&numRows,&numCols);
     if(result) // Error
     {
         cmeSecureDBToMemDBFree(); //CLEANUP.
@@ -459,7 +475,16 @@ int cmeDeleteSecureDB (sqlite3 *pResourcesDB,const char *documentId, const char 
         fprintf(stdout,"CaumeDSE Debug: cmeDeleteSecureDB(), documentId %s already exists; "
                 "proceeding to delete it.\n",documentId);
 #endif
-        result=cmeMemTable(pResourcesDB,"SELECT * FROM documents;",&queryResult,&numRows,&numCols);
+        result=cmeBuildProtectedDBSelectQuery(pResourcesDB,&sqlQuery,"documents",
+                                              (const char *[]){cmeIDDResourcesDBDocuments_documentId_name},
+                                              (const char *[]){documentId},1,orgKey);
+        if (result)
+        {
+            cmeDeleteSecureDBFree();
+            return(1);
+        }
+        result=cmeMemTable(pResourcesDB,sqlQuery,&queryResult,&numRows,&numCols);
+        cmeFree(sqlQuery);
         if(result) // Error
         {
             cmeDeleteSecureDBFree();
@@ -587,6 +612,116 @@ int cmeDeleteSecureDB (sqlite3 *pResourcesDB,const char *documentId, const char 
     return(0);
 }
 
+static int cmeIsResourcesDBDocumentLookupColumn (const char *columnName)
+{
+    return((!strcmp(columnName,cmeIDDResourcesDBDocuments_documentIdLookup_name)) ||
+           (!strcmp(columnName,cmeIDDResourcesDBDocuments_storageIdLookup_name)) ||
+           (!strcmp(columnName,cmeIDDResourcesDBDocuments_orgResourceIdLookup_name)));
+}
+
+static const char *cmeResourcesDBDocumentLookupColumnForMatch (const char *columnName)
+{
+    if (!strcmp(columnName,cmeIDDResourcesDBDocuments_documentId_name))
+    {
+        return(cmeIDDResourcesDBDocuments_documentIdLookup_name);
+    }
+    if (!strcmp(columnName,cmeIDDResourcesDBDocuments_storageId_name))
+    {
+        return(cmeIDDResourcesDBDocuments_storageIdLookup_name);
+    }
+    if (!strcmp(columnName,cmeIDDResourcesDBDocuments_orgResourceId_name))
+    {
+        return(cmeIDDResourcesDBDocuments_orgResourceIdLookup_name);
+    }
+    return(NULL);
+}
+
+static int cmeProtectedDBTableHasColumn (sqlite3 *pDB, const char *tableName, const char *columnName, int *hasColumn)
+{
+    int cont,result,numRows=0,numColumns=0;
+    char *pragmaQuery=NULL;
+    char **queryResult=NULL;
+    #define cmeProtectedDBTableHasColumnFree() \
+        do { \
+            cmeFree(pragmaQuery); \
+            if (queryResult) \
+            { \
+                cmeMemTableFinal(queryResult); \
+            } \
+        } while (0); //Local free() macro
+
+    *hasColumn=0;
+    cmeStrConstrAppend(&pragmaQuery,"PRAGMA table_info(\"%s\");",tableName);
+    result=cmeMemTable(pDB,pragmaQuery,&queryResult,&numRows,&numColumns);
+    if (result)
+    {
+        cmeProtectedDBTableHasColumnFree();
+        return(1);
+    }
+    for (cont=1;cont<=numRows;cont++)
+    {
+        if (!strcmp(queryResult[(cont*numColumns)+1],columnName))
+        {
+            *hasColumn=1;
+            break;
+        }
+    }
+    cmeProtectedDBTableHasColumnFree();
+    return(0);
+}
+
+static int cmeBuildProtectedDBSelectQuery (sqlite3 *pDB, char **query, const char *tableName, const char **columnNames,
+                                           const char **columnValues, const int numColumnValues,
+                                           const char *orgKey)
+{
+    int cont;
+    int hasLookupColumn=0;
+    int lookupFilterAdded=0;
+    char *lookupValue=NULL;
+    const char *lookupColumnName=NULL;
+    #define cmeBuildProtectedDBSelectQueryFree() \
+        do { \
+            cmeFree(lookupValue); \
+        } while (0); //Local free() macro
+
+    cmeStrConstrAppend(query,"SELECT * FROM %s",tableName);
+    if (strcmp(tableName,"documents"))
+    {
+        cmeStrConstrAppend(query,";");
+        cmeBuildProtectedDBSelectQueryFree();
+        return(0);
+    }
+    for (cont=0;cont<numColumnValues;cont++)
+    {
+        lookupColumnName=cmeResourcesDBDocumentLookupColumnForMatch(columnNames[cont]);
+        if (lookupColumnName)
+        {
+            if (cmeProtectedDBTableHasColumn(pDB,tableName,lookupColumnName,&hasLookupColumn))
+            {
+                cmeBuildProtectedDBSelectQueryFree();
+                return(1);
+            }
+            if (!hasLookupColumn)
+            {
+                continue;
+            }
+            cmeFree(lookupValue);
+            if (cmeGetProtectDBLookupValue(columnNames[cont],columnValues[cont],orgKey,&lookupValue))
+            {
+                cmeBuildProtectedDBSelectQueryFree();
+                return(1);
+            }
+            cmeStrConstrAppend(query,"%s (%s='%s' OR %s IS NULL)",
+                               (lookupFilterAdded)?" AND":" WHERE",
+                               lookupColumnName,lookupValue,lookupColumnName);
+            lookupFilterAdded=1;
+        }
+    }
+    cmeStrConstrAppend(query,";");
+    cmeBuildProtectedDBSelectQueryFree();
+    return(0);
+}
+
 int cmeGetUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const char **columnNames,
                                 const char **columnValues,const int numColumnValues, char ***resultRegisterCols,
                                 int *numResultRegisterCols, int *numResultRegisters, const char *orgKey)
@@ -613,8 +748,12 @@ int cmeGetUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const char 
     *numResultRegisters=1; //We will reserve memory for at least one result register.
     //1st Load all encrypted registers in a memTable.
     //cmeMemTable uses sqlite3_prepare_v2 which returns column names for empty tables without PRAGMA.
-    cmeStrConstrAppend(&query,"SELECT * FROM %s;",
-                       tableName);
+    result=cmeBuildProtectedDBSelectQuery(pDB,&query,tableName,columnNames,columnValues,numColumnValues,orgKey);
+    if (result)
+    {
+        cmeGetUnprotectDBRegisterFree();
+        return(1);
+    }
     result=cmeMemTable(pDB,(const char *)query,&sqlTable,&numRows,&numColumns);
     if (result) //Error
     {
@@ -642,6 +781,7 @@ int cmeGetUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const char 
         {
             cmeFree((*resultRegisterCols)[(*numResultRegisters)*numColumns+cont2]); //Clear memory space before use.
             if ((strcmp(sqlTable[cont2],"id")!=0)&&(strcmp(sqlTable[cont2],"salt")!=0)
+                &&(!cmeIsResourcesDBDocumentLookupColumn(sqlTable[cont2]))
                 &&(sqlTable[cont*numColumns+cont2]!=NULL))  //We decrypt and compare, except if column name is 'id' or 'salt'.
             {
                 if (strlen(sqlTable[cont*numColumns+cont2])>(size_t)MACLen) //Good, protected value is longer than MAC value.
@@ -678,11 +818,12 @@ int cmeGetUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const char 
             else  //We just compare ('salt' and 'id' column names).
             {
                 cmeStrConstrAppend(&((*resultRegisterCols)[(*numResultRegisters)*numColumns+cont2]),
-                                   "%s",sqlTable[cont*numColumns+cont2]);
+                                   "%s",(sqlTable[cont*numColumns+cont2])?sqlTable[cont*numColumns+cont2]:"");
                 for (cont3=0;cont3<numColumnValues;cont3++) //Check each relevant column by name.
                 {
                     if ((strcmp(sqlTable[cont2],columnNames[cont3])==0) && //Matches column name.
-                        (strcmp(sqlTable[cont*numColumns+cont2],columnValues[cont3])==0))  //And matches value filter.
+                        (strcmp((sqlTable[cont*numColumns+cont2])?sqlTable[cont*numColumns+cont2]:"",
+                                columnValues[cont3])==0))  //And matches value filter.
                     {
                         numMatch++;
                     }
@@ -744,8 +885,12 @@ int cmeDeleteUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const ch
     *numResultRegisters=1; //We will reserve memory for at least one result register.
     //1st Load all encrypted registers in a memTable.
     //cmeMemTable uses sqlite3_prepare_v2 which returns column names for empty tables without PRAGMA.
-    cmeStrConstrAppend(&query,"SELECT * FROM %s;",
-                       tableName);
+    result=cmeBuildProtectedDBSelectQuery(pDB,&query,tableName,columnNames,columnValues,numColumnValues,orgKey);
+    if (result)
+    {
+        cmeDeleteUnprotectDBRegisterFree();
+        return(1);
+    }
     result=cmeMemTable(pDB,(const char *)query,&sqlTable,&numRows,&numColumns);
     cmeFree(query);
     if (result) //Error
@@ -775,6 +920,7 @@ int cmeDeleteUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const ch
         {
             cmeFree((*resultRegisterCols)[(*numResultRegisters)*numColumns+cont2]); //Clear memory space before use.
             if ((strcmp(sqlTable[cont2],"id")!=0)&&(strcmp(sqlTable[cont2],"salt")!=0)
+                &&(!cmeIsResourcesDBDocumentLookupColumn(sqlTable[cont2]))
                 &&(sqlTable[cont*numColumns+cont2]!=NULL))  //We decrypt and compare, except if column name is 'id' or 'salt'.
             {
                 if (strlen(sqlTable[cont*numColumns+cont2])>(size_t)MACLen) //Good, protected value is longer than MAC value.
@@ -811,11 +957,12 @@ int cmeDeleteUnprotectDBRegisters (sqlite3 *pDB, const char *tableName, const ch
             else  //We just compare ('salt' and 'id' column names).
             {
                 cmeStrConstrAppend(&((*resultRegisterCols)[(*numResultRegisters)*numColumns+cont2]),
-                                   "%s",sqlTable[cont*numColumns+cont2]);
+                                   "%s",(sqlTable[cont*numColumns+cont2])?sqlTable[cont*numColumns+cont2]:"");
                 for (cont3=0;cont3<numColumnValues;cont3++) //Check each relevant column by name.
                 {
                     if ((strcmp(sqlTable[cont2],columnNames[cont3])==0) &&      //Matches column name.
-                        (strcmp(sqlTable[cont*numColumns+cont2],columnValues[cont3])==0))  //And matches value filter.
+                        (strcmp((sqlTable[cont*numColumns+cont2])?sqlTable[cont*numColumns+cont2]:"",
+                                columnValues[cont3])==0))  //And matches value filter.
                     {
                         numMatch++;
                     }
@@ -1349,12 +1496,14 @@ int cmeExistsDocumentId (sqlite3 *pResourcesDB,const char *documentId, const cha
     char **queryResult=NULL;
     char *currentDocumentId=NULL;
     char *protectedValueMAC=NULL;
+    char *query=NULL;
     char **cmeResultMemTableBKP=NULL; //We will hold a copy of cmeResultMemTable (pointer) since we will destroy it with a query. Therefore we don't free it!
     //MEMORY CLEANUP MACRO for local function.
     #define cmeExistsDocumentIdFree() \
         do { \
             cmeFree(currentDocumentId); \
             cmeFree(protectedValueMAC); \
+            cmeFree(query); \
             cmeResultMemTableClean(); \
             if (queryResult) \
             { \
@@ -1378,7 +1527,15 @@ int cmeExistsDocumentId (sqlite3 *pResourcesDB,const char *documentId, const cha
         cmeResultMemTableBKP=cmeResultMemTable;
         cmeResultMemTable=NULL;
     }
-    result=cmeMemTable(pResourcesDB,"SELECT * FROM documents",&queryResult,&numRows,&numCols);
+    result=cmeBuildProtectedDBSelectQuery(pResourcesDB,&query,"documents",
+                                          (const char *[]){cmeIDDResourcesDBDocuments_documentId_name},
+                                          (const char *[]){documentId},1,orgKey);
+    if (result)
+    {
+        cmeExistsDocumentIdFree(); //CLEANUP.
+        return(1);
+    }
+    result=cmeMemTable(pResourcesDB,query,&queryResult,&numRows,&numCols);
     if(result) // Error
     {
         cmeExistsDocumentIdFree(); //CLEANUP.


### PR DESCRIPTION
## Summary
- Add deterministic protected lookup values and indexes for ResourcesDB document `documentId`, `storageId`, and `orgResourceId` fields.
- Use lookup values only to narrow exact-match candidates; protected values are still decrypted and verified before returning or deleting registers.
- Add migration support for existing ResourcesDBs with nullable lookup columns and fallback handling for legacy rows.
- Batch duplicate-column reintegration with a prepared insert inside one in-memory transaction.
- Update README and TODO documentation for the new behavior and security boundaries.
- Backfill `ChangeLog` for the current protected lookup work and the recent committed batches that were missing: SQL-injection prepared-statement mitigation, file-import prepared statements, POST condition signaling, POST abort signaling, and centralized DB pragma setup.

## Verification
- `./configure --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP`
- `make`
- `TEST/run_debug_components.sh` completed DB/MAC checks; first run only missed the exact webservice startup marker while the HTTPS line was present without the expected leading marker.
- `TEST/run_debug_components.sh --skip-build` passed: 14 passed, 0 failed, 4 skipped.
- ChangeLog-only amendment reviewed with `git diff`.