### PR TITLE
Harden legacy SQL input handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -63,3 +63,165 @@
   - Keep command examples copy/paste-safe and annotate shell, SQL, C, JSON, Perl, or configuration snippets with fenced-code language tags when known.
   - Rename to `README.md` only after checking build, packaging, and distribution references that may still point to `README`.
   - Done: `README.md` is now the canonical Markdown README, `README` remains as a compatibility pointer, and distribution metadata includes the Markdown file.
+
+- [ ] #12 Finish and verify `/organizations/{organization}/users/{user}/roleTables` resources.
+  - Review the existing `roleTables` URL routing and RolesDB table handling to identify whether the README marker is stale or the feature is only partially implemented.
+  - Define the supported methods for the `roleTables` collection and `{roleTable}` resource, including exact-match filters, update parameters, and response formats.
+  - Add or complete handlers for create, read, update, delete, head, and options behavior while preserving encrypted role-table storage and authorization checks.
+  - Add DEBUG/component tests that create a role table, query it, update permissions, verify enforcement, and reject unauthorized access.
+  - Update `README.md` to remove the `[not implemented]` marker once the behavior is verified.
+
+- [ ] #13 Implement `/organizations/{organization}/users/{user}/filterWhitelist` resources.
+  - Define the whitelist data model on top of the existing ResourcesDB/AdminDB `filterWhitelist` tables, including filter attributes, allowed methods, and ownership fields.
+  - Add request parsing and handlers for whitelist collection and item resources under the user resource hierarchy.
+  - Enforce whitelist checks in request authorization or filtering paths before resource operations are executed.
+  - Preserve encrypted internal database values, MAC verification, and existing role-table authorization semantics.
+  - Add tests covering allowlisted filters, missing whitelist entries, malformed filters, and interaction with role-table permissions.
+  - Document the API and remove the README hierarchy `[not implemented]` marker after verification.
+
+- [ ] #14 Implement `/organizations/{organization}/users/{user}/filterBlacklist` resources.
+  - Define the blacklist data model on top of the existing ResourcesDB/AdminDB `filterBlacklist` tables, mirroring whitelist ownership and filter attributes where appropriate.
+  - Add request parsing and handlers for blacklist collection and item resources under the user resource hierarchy.
+  - Enforce blacklist checks before resource operations, with deny behavior taking precedence over whitelist or role-table allows when both apply.
+  - Preserve encrypted internal database values, MAC verification, and existing role-table authorization semantics.
+  - Add tests covering denied filters, non-matching blacklist entries, whitelist/blacklist conflicts, malformed filters, and unauthorized updates.
+  - Document the API and remove the README hierarchy `[not implemented]` marker after verification.
+
+- [ ] #15 Finish and verify `/organizations/{organization}/storage/{storage}/documentTypes` resources.
+  - Review existing `documentTypes` routing and ResourcesDB table definitions to determine whether the README marker is stale or the feature is partial.
+  - Define supported document type names, allowed methods, options responses, and validation rules for `{documentType}`.
+  - Complete handlers so document type discovery and validation behave consistently for `file.raw`, `file.csv`, and `script.perl`.
+  - Add tests for listing supported types, requesting a valid type, rejecting unsupported types, and preserving existing document upload/query behavior.
+  - Update `README.md` to remove the `[not implemented]` marker once verified.
+
+- [ ] #16 Finish and verify `/documents/{document}/parserScripts` resources.
+  - Review existing `parserScripts` routing and script execution paths to determine whether the README marker is stale or the feature is partial.
+  - Define the supported methods for parser script collections and `{parserScript}` resources, including script type restrictions and output formats.
+  - Ensure script resources are loaded, decrypted, MAC-verified, and executed only after authorization succeeds.
+  - Keep embedded Perl interpreter access serialized while moving file/DB work outside the Perl mutex where possible.
+  - Add tests for valid script execution, missing scripts, unsupported script types, parser errors, and unauthorized access.
+  - Document the API and remove the README hierarchy `[not implemented]` marker after verification.
+
+- [ ] #17 Finish and verify `/documents/{document}/contentRows` resources for `file.csv`.
+  - Review existing `contentRows` routing and CSV row manipulation paths to determine whether the README marker is stale or the feature is partial.
+  - Define row numbering, append behavior, update semantics, delete behavior, and error codes for out-of-range rows.
+  - Implement or complete handlers using in-memory transformations followed by immediate durable secure-DB/file saves.
+  - Preserve CSV column integrity, encrypted part MAC verification, and column-shuffling security behavior.
+  - Add tests for get, append, update, delete, invalid row indexes, missing documents, non-CSV documents, and unauthorized access.
+  - Document the API and remove the README hierarchy `[not implemented]` marker after verification.
+
+- [ ] #18 Finish and verify `/documents/{document}/contentColumns` resources for `file.csv`.
+  - Review existing `contentColumns` routing and CSV column manipulation paths to determine whether the README marker is stale or the feature is partial.
+  - Define column creation, retrieval, deletion, empty-document creation, duplicate-column handling, and error behavior for missing columns.
+  - Implement or complete handlers using in-memory transformations followed by immediate durable secure-DB/file saves.
+  - Preserve encrypted part MAC verification and the security goal of column shuffling, including safe behavior when duplicate column names exist.
+  - Add tests for get, create, delete, duplicate names, last-column deletion, missing documents, non-CSV documents, and unauthorized access.
+  - Document the API and remove the README hierarchy `[not implemented]` marker after verification.
+
+- [ ] #19 Implement direct encrypted DB browsing resources under `/dbNames`.
+  - Define the scope and security model for `/dbNames`, `{dbName}`, `/dbTables`, `{dbTable}`, `/tableRows`, `{tableRow}`, `/tableColumns`, and `{tableColumn}`.
+  - Decide whether this hierarchy exposes only internal/admin databases, user data databases, or a restricted diagnostics view, and document the decision.
+  - Add route parsing and handlers that never expose decrypted protected values unless the caller is authorized and supplies the required organization key.
+  - Use prepared statements and strict identifier validation for database/table/row/column selectors.
+  - Add tests for listing databases, listing tables, reading rows/columns, rejecting invalid identifiers, authorization failures, and SQL injection attempts.
+  - Document the API and remove the README hierarchy `[not implemented]` marker after verification.
+
+## Source Code TODO/FIXME Markers
+
+- [ ] #20 Replace `main` placeholders in Autoconf library checks with real function probes.
+  - Source: `configure.ac:42`, `configure.ac:44`, `configure.ac:46`, `configure.ac:48`, `configure.ac:50`, `configure.ac:52`, `configure.ac:54`, `configure.ac:56`, `configure.ac:58`, `configure.ac:60`, `configure.ac:62`, `configure.ac:64`.
+
+- [ ] #21 Add cloud storage wrappers for file handling.
+  - Source: `filehandling.c:53`.
+
+- [ ] #22 Factor common in-memory DB creation for CSV and memory-table imports.
+  - Source: `filehandling.c:649`, `filehandling.c:1687`.
+
+- [ ] #23 Add SQL DB filename collision handling.
+  - Source: `filehandling.c:678`, `filehandling.c:1727`.
+
+- [ ] #24 Factor secure DB import insertion logic into a shared helper.
+  - Source: `filehandling.c:799`, `filehandling.c:1848`.
+
+- [ ] #25 Implement MAC and protected MAC calculation during secure DB import.
+  - Source: `filehandling.c:840`, `filehandling.c:1889`.
+
+- [ ] #26 Verify locale settings for `printf`, including UTF-8 behavior.
+  - Source: `main.c:66`.
+
+- [ ] #27 Move DEBUG tests into a dedicated executable or test harness.
+  - Source: `main.c:136`.
+  - Related roadmap item: `#9`.
+
+- [ ] #28 Improve administrator key screen cleanup or use a sensitive terminal I/O library.
+  - Source: `engine_admin.c:424`.
+
+- [ ] #29 Add basic error handling for certificate file loading.
+  - Source: `engine_admin.c:803`.
+
+- [ ] #30 Replace temporary web-service `getchar()` waits with an exception/stop handler.
+  - Source: `engine_admin.c:872`.
+
+- [ ] #31 Process whitelist and blacklist regex filter lists in ResourcesDB.
+  - Source: `engine_admin.c:1126`.
+  - Related roadmap items: `#13`, `#14`.
+
+- [x] #32 Sanitize variables used in string handling and generated queries.
+  - Source: `strhandling.c:292`, `strhandling.c:309`, `db.c:66`, `webservice_interface.c:544`.
+  - Done: added shared SQL identifier and unsafe input checks, sanitized legacy INSERT/UPDATE builder values, and rejected unsafe web-service route/query tokens before DB processing.
+
+- [x] #33 Verify `WHERE` usage that may not match `userId`.
+  - Source: `strhandling.c:308`.
+  - Done: `cmeStrSqlUPDATEConstruct()` has no current call sites and builds its `WHERE` clause from the explicit `matchColumn`/`matchValue` arguments, with identifier validation and value sanitization from item `#32`; documented that it must not assume `userId`.
+
+- [ ] #34 Add response formatting support for HTML, CSV, and other requested output types.
+  - Source: `strhandling.c:376`, `webservice_interface.c:2444`, `webservice_interface.c:4113`, `webservice_interface.c:5343`.
+
+- [ ] #35 Add OAuth authentication or document the required external manager layer.
+  - Source: `webservice_interface.c:615`.
+
+- [ ] #36 Process storage `documentTypes` and `documents` resource tree requests.
+  - Source: `webservice_interface.c:1015`.
+  - Related roadmap item: `#15`.
+
+- [ ] #37 Move temporary POST attributes for `shuffle` and `protect` into API parameters.
+  - Source: `webservice_interface.c:6256`, `webservice_interface.c:9605`, `webservice_interface.c:10686`.
+
+- [ ] #38 Ensure CSV upload parameters come from the API instead of predefined test values.
+  - Source: `webservice_interface.c:6438`.
+
+- [ ] #39 Add handlers for additional file document types.
+  - Source: `webservice_interface.c:6546`.
+
+- [ ] #40 Add an optional multi-round secure overwrite scheme.
+  - Source: `webservice_interface.c:7307`, `filehandling.h:83`.
+
+- [ ] #41 Vacuum memory DBs before durable saves when requested.
+  - Source: `db.c:201`.
+
+- [ ] #42 Implement signing and protected signing for protected DB values.
+  - Source: `db.c:1253`, `db.c:1259`, `db.c:2225`, `db.c:2231`.
+
+- [ ] #43 Replace direct DB protect/unprotect call sites with wrapper functions.
+  - Source: `db.c:2355`, `db.c:2383`.
+
+- [ ] #44 Replace direct salt/protect and unprotect/unsalt call sites with wrapper functions.
+  - Source: `db.c:2420`, `db.c:2461`.
+
+- [ ] #45 Replace direct `malloc` calls with an audited allocation wrapper.
+  - Source: `common.h:50`.
+
+- [ ] #46 Read globals from a configuration file.
+  - Source: `common.h:51`.
+
+- [ ] #47 Standardize IDD usage and avoid direct use of numeric IDs and column names.
+  - Source: `common.h:132`.
+
+- [ ] #48 Research secure memory clearing and memory locking for sensitive data.
+  - Source: `engine_interface.c:310`, `engine_interface.c:1583`.
+
+- [ ] #49 Verify salt requirements and fail on invalid salts.
+  - Source: `engine_interface.c:1053`.
+
+- [ ] #50 Evaluate whether another random source is needed for systems without `/dev/random` or `/dev/urandom`.
+  - Source: `crypto.c:436`.

--- a/db.c
+++ b/db.c
@@ -63,7 +63,6 @@ static int cmeDBApplyPragmas(sqlite3 *pDB, const char *functionName, const char 
     return(0);
 }
 
-//TODO (OHR#5#):create and call function to sanitize all input that will be included in DB queries!
 int cmeDBCreateOpen (const char *filename, sqlite3 **ppDB)
 {
     int result;
@@ -2950,22 +2949,76 @@ int cmeMemTableWithTableColumnNames (sqlite3 *db, const char *tableName)
     return (0);
 }
 
+int cmeIsSafeSQLIdentifier(const char *identifier)
+{
+    int cont;
+
+    if ((!identifier)||(!identifier[0]))
+    {
+        return(0);
+    }
+    for (cont=0;identifier[cont];cont++)
+    {
+        if ((!isalnum((unsigned char)identifier[cont]))&&(identifier[cont]!='_'))
+        {
+            return(0);
+        }
+    }
+    return(1);
+}
+
+int cmeHasUnsafeSQLInputChars(const char *sourceString)
+{
+    int cont;
+
+    if (!sourceString)
+    {
+        return(1);
+    }
+    for (cont=0;sourceString[cont];cont++)
+    {
+        switch (sourceString[cont])
+        {
+            case '"':
+            case '\'':
+            case ';':
+            case '=':
+            case '`':
+                return(1);
+            default:
+                break;
+        }
+    }
+    return(0);
+}
+
 int cmeSanitizeStrForSQL (const char *sourceString, char **sanitizedString)
 {
     int cont,cont2;
     int sourceStringLen=0;
     int sanitizedStringLen=0;
 
-    if (!sourceString) //Error, source string can't be NULL
+    if ((!sourceString)||(!sanitizedString)) //Error, source string or output pointer can't be NULL
     {
 #ifdef ERROR_LOG
-        fprintf(stderr,"CaumeDSE Error: cmeSanitizeStrForSQL(), Error, source string can't be NULL!\n");
+        fprintf(stderr,"CaumeDSE Error: cmeSanitizeStrForSQL(), Error, source string or output pointer can't be NULL!\n");
 #endif
         return(1);
     }
     sourceStringLen=strlen(sourceString);
     sanitizedStringLen=sourceStringLen;
+    if (*sanitizedString)
+    {
+        cmeFree(*sanitizedString);
+    }
     *sanitizedString=(char *)malloc(sizeof(char)*(sanitizedStringLen+1)); //Set length of sanitized string = length of source string to start.
+    if (!(*sanitizedString))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeSanitizeStrForSQL(), malloc() Error!\n");
+#endif
+        return(2);
+    }
     cont2=0;
     for (cont=0;cont<sourceStringLen;cont++)
     {
@@ -2975,6 +3028,13 @@ int cmeSanitizeStrForSQL (const char *sourceString, char **sanitizedString)
             cont2++;
             sanitizedStringLen++;
             *sanitizedString=(char *)realloc(*sanitizedString, sizeof(char)*(sanitizedStringLen+1)); //Add 1 character to the sanitized string.
+            if (!(*sanitizedString))
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeSanitizeStrForSQL(), realloc() Error!\n");
+#endif
+                return(3);
+            }
         }
         (*sanitizedString)[cont2]=sourceString[cont];
         cont2++;

--- a/db.h
+++ b/db.h
@@ -103,6 +103,10 @@ int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
 int cmeResultMemTableClean ();
 // Function to get (in cmeResultMemTable) a string array of column names for table tableName.
 int cmeMemTableWithTableColumnNames (sqlite3 *db, const char *tableName);
+// Function to validate a SQL identifier before embedding it in a query.
+int cmeIsSafeSQLIdentifier(const char *identifier);
+// Function to check for SQL metacharacters that are not accepted in direct web-service inputs.
+int cmeHasUnsafeSQLInputChars(const char *sourceString);
 // Function to sanitize an input string (doubles single quote characters) to avoid sql injection attacks in sql queries.
 int cmeSanitizeStrForSQL (const char *sourceString, char **sanitizedString);
 

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -44,24 +44,6 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 ***/
 #include "common.h"
 
-static int cmeIsSafeSQLIdentifier(const char *identifier)
-{
-    int cont;
-
-    if ((!identifier)||(!identifier[0]))
-    {
-        return(0);
-    }
-    for (cont=0; identifier[cont]; cont++)
-    {
-        if ((!isalnum((unsigned char)identifier[cont]))&&(identifier[cont]!='_'))
-        {
-            return(0);
-        }
-    }
-    return(1);
-}
-
 static int cmeIsResourcesDBDocumentLookupColumn (const char *columnName);
 static const char *cmeResourcesDBDocumentLookupColumnForMatch (const char *columnName);
 static int cmeBuildProtectedDBSelectQuery (sqlite3 *pDB, char **query, const char *tableName, const char **columnNames,

--- a/strhandling.c
+++ b/strhandling.c
@@ -270,10 +270,27 @@ int cmeStrSqlINSERTConstruct (char **resultQuery, const char *tableName, const c
                               const int numColumns)
 {
     int cont;
-    cmeStrConstrAppend(resultQuery,"BEGIN TRANSACTION; INSERT INTO %s (",tableName); //First part.
+    char *sanitizedValue=NULL;
+    #define cmeStrSqlINSERTConstructFree() \
+        do { \
+            cmeFree(sanitizedValue); \
+        } while (0); //Local free() macro.
+
+    if ((!resultQuery)||(!colNamesValuesPairs)||(!cmeIsSafeSQLIdentifier(tableName))||(numColumns<2)||(numColumns%2))
+    {
+        return(1);
+    }
+    for (cont=0;cont<numColumns;cont+=2)
+    {
+        if (!cmeIsSafeSQLIdentifier(colNamesValuesPairs[cont]))
+        {
+            return(2);
+        }
+    }
+    cmeStrConstrAppend(resultQuery,"BEGIN TRANSACTION; INSERT INTO \"%s\" (",tableName); //First part.
     for (cont=0;cont<numColumns;cont+=2)  //Add column names.
     {
-        cmeStrConstrAppend(resultQuery,"%s",colNamesValuesPairs[cont]);
+        cmeStrConstrAppend(resultQuery,"\"%s\"",colNamesValuesPairs[cont]);
         if ((cont+2)<numColumns) //still another column pending.
         {
             cmeStrConstrAppend(resultQuery,",");
@@ -282,14 +299,20 @@ int cmeStrSqlINSERTConstruct (char **resultQuery, const char *tableName, const c
     cmeStrConstrAppend(resultQuery,") VALUES(");
     for (cont=1;cont<numColumns;cont+=2)  //Add values.
     {
-        cmeStrConstrAppend(resultQuery,"'%s'",colNamesValuesPairs[cont]);
+        if (cmeSanitizeStrForSQL(colNamesValuesPairs[cont],&sanitizedValue))
+        {
+            cmeStrSqlINSERTConstructFree();
+            return(3);
+        }
+        cmeStrConstrAppend(resultQuery,"'%s'",sanitizedValue);
+        cmeFree(sanitizedValue);
         if ((cont+2)<numColumns) //still another column pending.
         {
             cmeStrConstrAppend(resultQuery,",");
         }
     }
     cmeStrConstrAppend(resultQuery,"); COMMIT;"); //Last part.
-    //TODO (OHR#3#): Sanitize variables.
+    cmeStrSqlINSERTConstructFree();
     return (0);  //Note that caller must free resultQuery!
 }
 
@@ -297,17 +320,49 @@ int cmeStrSqlUPDATEConstruct (char **resultQuery, const char *tableName, const c
                             const int numColumns, const char *matchColumn, const char *matchValue)
 {
     int cont;
-    cmeStrConstrAppend(resultQuery,"BEGIN TRANSACTION; UPDATE %s SET ",tableName); //First part.
+    char *sanitizedValue=NULL;
+    char *sanitizedMatchValue=NULL;
+    #define cmeStrSqlUPDATEConstructFree() \
+        do { \
+            cmeFree(sanitizedValue); \
+            cmeFree(sanitizedMatchValue); \
+        } while (0); //Local free() macro.
+
+    if ((!resultQuery)||(!colNamesValuesPairs)||(!cmeIsSafeSQLIdentifier(tableName))||(!cmeIsSafeSQLIdentifier(matchColumn))||
+        (numColumns<2)||(numColumns%2))
+    {
+        return(1);
+    }
+    for (cont=0;cont<numColumns;cont+=2)
+    {
+        if (!cmeIsSafeSQLIdentifier(colNamesValuesPairs[cont]))
+        {
+            return(2);
+        }
+    }
+    if (cmeSanitizeStrForSQL(matchValue,&sanitizedMatchValue))
+    {
+        cmeStrSqlUPDATEConstructFree();
+        return(3);
+    }
+    cmeStrConstrAppend(resultQuery,"BEGIN TRANSACTION; UPDATE \"%s\" SET ",tableName); //First part.
     for (cont=0;cont<numColumns;cont+=2)  //Add column names.
     {
-        cmeStrConstrAppend(resultQuery,"%s = '%s'",colNamesValuesPairs[cont],colNamesValuesPairs[cont+1]);
+        if (cmeSanitizeStrForSQL(colNamesValuesPairs[cont+1],&sanitizedValue))
+        {
+            cmeStrSqlUPDATEConstructFree();
+            return(4);
+        }
+        cmeStrConstrAppend(resultQuery,"\"%s\" = '%s'",colNamesValuesPairs[cont],sanitizedValue);
+        cmeFree(sanitizedValue);
         if ((cont+2)<numColumns) //still another column pending.
         {
             cmeStrConstrAppend(resultQuery,",");
         }
-    } //TODO (OHR#2#): Check WHERE usage; not necesarily equal to userId !!!
-    //TODO (OHR#3#): Sanitize variables.
-    cmeStrConstrAppend(resultQuery," WHERE %s = '%s'; COMMIT;",matchColumn,matchValue); //Last part.
+    }
+    // The match column is intentionally caller-selected; do not assume userId.
+    cmeStrConstrAppend(resultQuery," WHERE \"%s\" = '%s'; COMMIT;",matchColumn,sanitizedMatchValue); //Last part.
+    cmeStrSqlUPDATEConstructFree();
     return (0);  //Note that caller must free resultQuery!
 }
 

--- a/strhandling.h
+++ b/strhandling.h
@@ -70,7 +70,8 @@ int cmeStrConstrAppend (char **resultStr, const char *addString, ...);
 // Function to construct an INSERT query (SQL).
 int cmeStrSqlINSERTConstruct (char **resultQuery, const char *tableName, const char **colNamesValuesPairs,
                               const int numColumns);
-// Function to construct an UPDATE query (SQL)
+// Function to construct an UPDATE query (SQL). The WHERE column is caller-selected
+// through matchColumn and is not assumed to be userId.
 int cmeStrSqlUPDATEConstruct (char **resultQuery, const char *tableName, const char **colNamesValuesPairs,
                             const int numColumns, const char *matchColumn, const char *matchValue);
 // Function to create a string with an HTML representation of a MemTable

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -500,6 +500,33 @@ int cmeWebServiceParseKeys(void *cls, enum MHD_ValueKind kind, const char *key, 
     return MHD_YES;
 }
 
+static int cmeWebServiceHasUnsafeRequestInput(const char **urlElements, int numUrlElements,
+                                              const char **argumentElements)
+{
+    int cont;
+
+    for (cont=0;cont<numUrlElements;cont++)
+    {
+        if (cmeHasUnsafeSQLInputChars(urlElements[cont]))
+        {
+            return(1);
+        }
+    }
+    if (!argumentElements)
+    {
+        return(1);
+    }
+    for (cont=0;((cont+1)<cmeWSURIMaxArguments)&&(argumentElements[cont]);cont+=2)
+    {
+        if (cmeHasUnsafeSQLInputChars(argumentElements[cont])||
+            cmeHasUnsafeSQLInputChars(argumentElements[cont+1]))
+        {
+            return(1);
+        }
+    }
+    return(0);
+}
+
 // File-scope engine power status flag.  Access is serialised with cmePowerMutex so that
 // concurrent requests see a consistent value when the operator toggles the engine on/off.
 static int cmeEnginePowerStatus=1;
@@ -541,7 +568,17 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
     powerStatus=cmeEnginePowerStatus;
     pthread_mutex_unlock(&cmePowerMutex);
 
-    //TODO (OHR#2#): Sanitizing function for all inputs (filter:  ",',;,=,`)
+    if (cmeWebServiceHasUnsafeRequestInput(urlElements,numUrlElements,argumentElements))
+    {
+        cmeStrConstrAppend(responseText,"<b>400 ERROR Bad request.</b><br><br>"
+                           "Request contains unsupported input characters.");
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeWebServiceProcessRequest(), Error, request contains unsupported input characters.\n");
+#endif
+        *responseCode=400;
+        cmeWebServiceProcessRequestFree();
+        return(1);
+    }
     if ((numUrlElements==1)&&(strcmp("favicon.ico",urlElements[0])==0)&&(strcmp("GET",method)==0)) //Process favicon.ico; powerStatus='on' not required.
     {
 #ifdef DEBUG


### PR DESCRIPTION
## Summary
- add shared SQL identifier and unsafe request input validation helpers
- sanitize values in legacy INSERT/UPDATE SQL string builders and document caller-selected WHERE semantics
- mark TODO items #32 and #33 complete with verification notes

## Verification
- installed missing `gawk`
- ran `./configure` to refresh the local Perl 5.40 include path
- ran `make` successfully

Note: generated configure/build outputs were left out of the commit.