### PR TITLE
Complete CSV API parameters and raw document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,12 @@ protect
     and on use the default encryption algorithm; any other value is
     stored as the attribute algorithm.
 
+replaceDB
+    Optional for file.csv uploads.  If set to 1, true, yes or on, an
+    existing secure CSV database with the same documentId is replaced.
+    If omitted or set to 0, false, no, off or none, duplicate document
+    resources are rejected.
+
 #### 3.5 Optional Column index parameters for content rows (`file.csv`)
 
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ The architecture of CaumeDSE is composed of several layers:
 4. Resource access - CaumeDSE maintains internal index databases
        that map data resources to their location.  All resources and
        index database registers are encrypted with the organization's
-       key.  Currently 3 types of data resources are supported: raw
-       files, CSV files and Perl scripts.  File resources in addition
+       key.  Supported data resources include CSV files, raw-compatible
+       file document types and Perl scripts.  File resources in addition
        are split in several parts (CSV files are split in columns and
        each column in different parts of a specific size).
 
@@ -1379,7 +1379,9 @@ below).
         UPDATE:
             <NONE>
         DOCUMENT TYPES:
-            file.csv file.raw script.perl
+            file.csv file.raw file.txt file.json file.xml file.html
+            file.pdf file.png file.jpg file.gif file.zip file.bin
+            script.perl
         RESPONSE HEADERS:
             <NONE>
         RESPONSE BODY:
@@ -1691,7 +1693,8 @@ sub cmePERLProcessColumnNames       #Get (and optionally modify) column names
         UPDATE:
             <NONE>
         SUPPORTED FILE TYPES:
-            file.csv file.raw
+            file.csv file.raw file.txt file.json file.xml file.html
+            file.pdf file.png file.jpg file.gif file.zip file.bin
         RESPONSE HEADERS:
             Engine-results: <number of matching registers>
         RESPONSE BODY:

--- a/README.md
+++ b/README.md
@@ -983,6 +983,20 @@ file
     requests will contain the attribute parameters and the file contents
     encoded in multipart/form-data format within the body.
 
+shuffle
+    Optional. Enables row-order shuffling metadata for secure CSV
+    storage.  If omitted, the default encryption algorithm is used.
+    Values 0, false, no, off and none disable this attribute; values 1,
+    true, yes and on use the default encryption algorithm; any other
+    value is stored as the attribute algorithm.
+
+protect
+    Optional. Enables value protection metadata for secure CSV storage.
+    If omitted, the default encryption algorithm is used.  Values 0,
+    false, no, off and none disable this attribute; values 1, true, yes
+    and on use the default encryption algorithm; any other value is
+    stored as the attribute algorithm.
+
 #### 3.5 Optional Column index parameters for content rows (`file.csv`)
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -193,8 +193,9 @@
   - Source: `webservice_interface.c:6438`.
   - Done: CSV document uploads now take the remaining import option, `replaceDB`, from request parameters and document the accepted boolean values.
 
-- [ ] #39 Add handlers for additional file document types.
+- [x] #39 Add handlers for additional file document types.
   - Source: `webservice_interface.c:6546`.
+  - Done: added raw-compatible handlers for `file.txt`, `file.json`, `file.xml`, `file.html`, `file.pdf`, `file.png`, `file.jpg`, `file.gif`, `file.zip` and `file.bin`, while keeping `file.csv` and `script.perl` special.
 
 - [ ] #40 Add an optional multi-round secure overwrite scheme.
   - Source: `webservice_interface.c:7307`, `filehandling.h:83`.

--- a/TODO.md
+++ b/TODO.md
@@ -189,8 +189,9 @@
   - Source: `webservice_interface.c:6256`, `webservice_interface.c:9605`, `webservice_interface.c:10686`.
   - Done: document, content-row and content-column CSV imports now derive `shuffle` and `protect` secure DB attributes from request parameters, with documented defaults and disable values.
 
-- [ ] #38 Ensure CSV upload parameters come from the API instead of predefined test values.
+- [x] #38 Ensure CSV upload parameters come from the API instead of predefined test values.
   - Source: `webservice_interface.c:6438`.
+  - Done: CSV document uploads now take the remaining import option, `replaceDB`, from request parameters and document the accepted boolean values.
 
 - [ ] #39 Add handlers for additional file document types.
   - Source: `webservice_interface.c:6546`.

--- a/TODO.md
+++ b/TODO.md
@@ -185,8 +185,9 @@
   - Source: `webservice_interface.c:1015`.
   - Related roadmap item: `#15`.
 
-- [ ] #37 Move temporary POST attributes for `shuffle` and `protect` into API parameters.
+- [x] #37 Move temporary POST attributes for `shuffle` and `protect` into API parameters.
   - Source: `webservice_interface.c:6256`, `webservice_interface.c:9605`, `webservice_interface.c:10686`.
+  - Done: document, content-row and content-column CSV imports now derive `shuffle` and `protect` secure DB attributes from request parameters, with documented defaults and disable values.
 
 - [ ] #38 Ensure CSV upload parameters come from the API instead of predefined test values.
   - Source: `webservice_interface.c:6438`.

--- a/TODO.md
+++ b/TODO.md
@@ -174,8 +174,9 @@
   - Source: `strhandling.c:308`.
   - Done: `cmeStrSqlUPDATEConstruct()` has no current call sites and builds its `WHERE` clause from the explicit `matchColumn`/`matchValue` arguments, with identifier validation and value sanitization from item `#32`; documented that it must not assume `userId`.
 
-- [ ] #34 Add response formatting support for HTML, CSV, and other requested output types.
+- [x] #34 Add response formatting support for HTML, CSV, and other requested output types.
   - Source: `strhandling.c:376`, `webservice_interface.c:2444`, `webservice_interface.c:4113`, `webservice_interface.c:5343`.
+  - Done: added a shared count response formatter for DELETE results that honors `outputType=csv` and the default/explicit HTML format, and routed existing DELETE count responses through it.
 
 - [ ] #35 Add OAuth authentication or document the required external manager layer.
   - Source: `webservice_interface.c:615`.

--- a/common.h
+++ b/common.h
@@ -338,7 +338,7 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 
 #define cmeWSMsgDocumentTypeOptions  "Allowed Methods: <code>OPTIONS</code><br>" \
                                      "Syntax: <code> HTTPS:&#47;&#47;{engine}/organizations/{organization}/storage/{storage}/documentTypes/{documentType}" \
-                                     "/&lt;file.csv|file.raw|script.perl&gt;" \
+                                     "/&lt;file.csv|file.raw|file.txt|file.json|file.xml|file.html|file.pdf|file.png|file.jpg|file.gif|file.zip|file.bin|script.perl&gt;" \
                                      "?userId=&lt;userid&gt;&amp;orgId=&lt;orgid&gt;&amp;orgKey=&lt;orgKey&gt;[&amp;" \
                                      "OptionalParameters...]<br></code><br>" //Document Type resource options.
 

--- a/strhandling.c
+++ b/strhandling.c
@@ -428,7 +428,6 @@ int cmeConstructWebServiceTableResponse (const char **resultTable, const int tab
 
     if (tableCols) // If column names, print them.
     {
-        // TODO (OHR#2#): Check output type (HTML/CSV) and prepare response accordingly.
         if ((!cmeFindInArgPairList(argumentElements,"outputType",&pOutputType))&&(pOutputType))
         {
             if (!strcmp("csv",pOutputType)) // user request results in csv format.
@@ -482,6 +481,54 @@ int cmeConstructWebServiceTableResponse (const char **resultTable, const int tab
     }
     cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
     cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",tableRows);
+    return(0);
+}
+
+int cmeConstructWebServiceCountResponse (const char *resultName, const int resultCount,
+                                         const char **argumentElements, const char *method, const char *url,
+                                         char ***responseHeaders, char **resultStr, int *responseCode)
+{
+    const char *pOutputType=NULL;       //Ptr to outputType parameter within argumentElements. No need to free.
+
+    if ((!resultName)||(!responseHeaders)||(!(*responseHeaders))||(!resultStr)||(!responseCode))
+    {
+        return(1);
+    }
+    if ((argumentElements)&&(!cmeFindInArgPairList(argumentElements,"outputType",&pOutputType))&&(pOutputType))
+    {
+        if (!strcmp("csv",pOutputType))
+        {
+            cmeStrConstrAppend(resultStr,"\"%s\"\n\"%d\"\n",resultName,resultCount);
+            cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");  //Note: fields 0 & 1 are Engine-results.
+            cmeStrConstrAppend(&((*responseHeaders)[3]),"application/csv");
+        }
+        else if (!strcmp("html",pOutputType))
+        {
+            cmeStrConstrAppend(resultStr,"<p>%s: %d</p><br>",resultName,resultCount);
+            cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");  //Note: fields 0 & 1 are Engine-results.
+            cmeStrConstrAppend(&((*responseHeaders)[3]),"text/html; charset=utf-8");
+        }
+        else //Error, unknown outputType.
+        {
+            cmeStrConstrAppend(resultStr,"<b>501 ERROR Not implemented.</b><br>"
+                               "The requested functionality has not been implemented."
+                               "METHOD: '%s' URL: '%s'."
+                               "Latest IDD version: <code>%s</code>",method,url,
+                               cmeInternalDBDefinitionsVersion);
+#ifdef DEBUG
+            fprintf(stderr,"CaumeDSE Debug: cmeConstructWebServiceCountResponse(), Debug, support "
+                    "for outputType '%s' has not been implemented. Method: '%s', URL: '%s'!\n",pOutputType,method,url);
+#endif
+            *responseCode=501;
+            return(2);
+        }
+    }
+    else //No specific output type requested; use default HTML.
+    {
+        cmeStrConstrAppend(resultStr,"<p>%s: %d</p><br>",resultName,resultCount);
+    }
+    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
+    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",resultCount);
     return(0);
 }
 

--- a/strhandling.h
+++ b/strhandling.h
@@ -84,6 +84,10 @@ int cmeFindInArgPairList (const char** stringPairs, const char *key, const char 
 int cmeConstructWebServiceTableResponse (const char **resultTable, const int tableCols, const int tableRows,
                                          const char **argumentElements, const char *method, const char *url, const char *documentId,
                                          char ***responseHeaders, char **resultTableStr, int *responseCode);
+// Function to construct a count responseStr and add corresponding headers, according to an optional outputType parameter.
+int cmeConstructWebServiceCountResponse (const char *resultName, const int resultCount,
+                                         const char **argumentElements, const char *method, const char *url,
+                                         char ***responseHeaders, char **resultStr, int *responseCode);
 //Function to get an element (C, ST, L, O, OU or CN) from an x509 DN.
 int cmex509GetElementFromDN (const char* DN, const char *elementId, char **element, int *elementLen);
 // Constant-time string equality: returns 1 if equal, 0 if not (prevents timing attacks on sensitive comparisons).

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -527,6 +527,88 @@ static int cmeWebServiceHasUnsafeRequestInput(const char **urlElements, int numU
     return(0);
 }
 
+static int cmeWebServiceIsFalseValue(const char *value)
+{
+    return((value)&&((!strcmp(value,"0"))||(!strcasecmp(value,"false"))||
+                     (!strcasecmp(value,"no"))||(!strcasecmp(value,"off"))||
+                     (!strcasecmp(value,"none"))));
+}
+
+static int cmeWebServiceGetSecureDBAttributeParam(const char **argumentElements, const char *name,
+                                                  const char **value)
+{
+    char *starName=NULL;
+    int result;
+
+    if ((!argumentElements)||(!name)||(!value))
+    {
+        return(1);
+    }
+    if (!cmeFindInArgPairList(argumentElements,name,value))
+    {
+        return(0);
+    }
+    cmeStrConstrAppend(&starName,"*%s",name);
+    result=cmeFindInArgPairList(argumentElements,starName,value);
+    cmeFree(starName);
+    return(result);
+}
+
+static int cmeWebServiceBuildSecureDBAttributes(const char **argumentElements,
+                                                const char **attributes, const char **attributeData,
+                                                int maxAttributes)
+{
+    int numAttributes=0;
+    const char *shuffleValue=NULL;
+    const char *protectValue=NULL;
+
+    if ((!attributes)||(!attributeData)||(maxAttributes<2))
+    {
+        return(0);
+    }
+    if ((cmeWebServiceGetSecureDBAttributeParam(argumentElements,"shuffle",&shuffleValue))||
+        (!shuffleValue))
+    {
+        shuffleValue=cmeDefaultEncAlg;
+    }
+    if ((cmeWebServiceGetSecureDBAttributeParam(argumentElements,"protect",&protectValue))||
+        (!protectValue))
+    {
+        protectValue=cmeDefaultEncAlg;
+    }
+    if (!cmeWebServiceIsFalseValue(shuffleValue))
+    {
+        attributes[numAttributes]="shuffle";
+        if ((!strcmp(shuffleValue,"1"))||(!strcasecmp(shuffleValue,"true"))||
+            (!strcasecmp(shuffleValue,"yes"))||(!strcasecmp(shuffleValue,"on"))||
+            (!shuffleValue[0]))
+        {
+            attributeData[numAttributes]=cmeDefaultEncAlg;
+        }
+        else
+        {
+            attributeData[numAttributes]=shuffleValue;
+        }
+        numAttributes++;
+    }
+    if (!cmeWebServiceIsFalseValue(protectValue))
+    {
+        attributes[numAttributes]="protect";
+        if ((!strcmp(protectValue,"1"))||(!strcasecmp(protectValue,"true"))||
+            (!strcasecmp(protectValue,"yes"))||(!strcasecmp(protectValue,"on"))||
+            (!protectValue[0]))
+        {
+            attributeData[numAttributes]=cmeDefaultEncAlg;
+        }
+        else
+        {
+            attributeData[numAttributes]=protectValue;
+        }
+        numAttributes++;
+    }
+    return(numAttributes);
+}
+
 // File-scope engine power status flag.  Access is serialised with cmePowerMutex so that
 // concurrent requests see a consistent value when the operator toggles the engine on/off.
 static int cmeEnginePowerStatus=1;
@@ -6262,6 +6344,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
     int numResultRegisters=0;
     int processedRows=0;
     int numCols=0;
+    int numSecureDBAttributes=0;
     sqlite3 *pDB=NULL;
     char *orgKey=NULL;                  //requester orgKey.
     char *userId=NULL;                  //requester userId.
@@ -6287,8 +6370,8 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                                             "_partHash","_totalParts","_partId","_lastModified","_columnId"};
     const char *validPOSTSaveColumns[3]={"userId","orgId","*resourceInfo"};
     const char *validPUTSaveColumns[3]={"userId","orgId","*resourceInfo"};
-    const char *attributes[]={"shuffle","protect"};                           // TODO (OHR#2#): TMP attributes to test POST. We MUST take these arguments from the user, via API!
-    const char *attributesData[]={cmeDefaultEncAlg,cmeDefaultEncAlg};
+    const char *attributes[2]={NULL,NULL};
+    const char *attributesData[2]={NULL,NULL};
     #define cmeWebServiceProcessDocumentResourceFree() \
         do { \
             cmeFree(orgKey); \
@@ -6356,6 +6439,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
        columnValuesToMatch[cont]=NULL;
        columnNamesToMatch[cont]=NULL;
     }
+    numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
     cmeStrConstrAppend(&dbFilePath,"%s%s",cmeDefaultFilePath,cmeDefaultResourcesDBName);
     if(!strcmp(method,"POST")) //Method = POST is ok, process:
     {
@@ -6474,7 +6558,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         if(newOrgKey) //Create resource using newOrgKey
                         {
                             result=cmeCSVFileToSecureDB(postImportFile,1,&numCols,&processedRows,userId,orgId,newOrgKey,  //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
-                                                        attributes, attributesData,2,0,
+                                                        attributes, attributesData,numSecureDBAttributes,0,
                                                         resourceInfoText,
                                                         urlElements[5], //document type
                                                         urlElements[7], //documentId
@@ -6484,7 +6568,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         else //Create resource using orgKey
                         {
                             result=cmeCSVFileToSecureDB(postImportFile,1,&numCols,&processedRows,userId,orgId,orgKey,  //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
-                                                        attributes, attributesData,2,0,
+                                                        attributes, attributesData,numSecureDBAttributes,0,
                                                         resourceInfoText,
                                                         urlElements[5], //document type
                                                         urlElements[7], //documentId
@@ -9610,6 +9694,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
     int numMatchArgs=0;
     int numResultRegisterCols=0;
     int numResultRegisters=0;
+    int numSecureDBAttributes=0;
     sqlite3 *pDB=NULL;
     sqlite3 *resultDB=NULL;             //Result DB for unprotected DB (before parsing)
     char *orgKey=NULL;                  //requester orgKey.
@@ -9636,8 +9721,8 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
                                             "_partHash","_totalParts","_partId","_lastModified","_columnId"};
     const char *validPOSTSaveColumns[3]={"userId","orgId"};
     const char *validPUTSaveColumns[3]={"userId","orgId"};
-    const char *attributes[]={"shuffle","protect"};                           // TODO (OHR#2#): TMP attributes to test POST. We MUST take these arguments from the user, via API!
-    const char *attributesData[]={cmeDefaultEncAlg,cmeDefaultEncAlg};
+    const char *attributes[2]={NULL,NULL};
+    const char *attributesData[2]={NULL,NULL};
     #define cmeWebServiceProcessContentRowResourceFree() \
         do { \
             cmeFree(orgKey); \
@@ -9727,6 +9812,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
         *responseCode=403;
         return(1);
     }
+    numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
     columnValues=(char **)malloc(sizeof(char *)*numColumns); //Set space to store organization resource information, columns 1 to 11 (POST/PUT).
     columnNames=(char **)malloc(sizeof(char *)*numColumns); //Set space to store organization resource information, columns 1 to 11 (POST/PUT).
     columnValuesToMatch=(char **)malloc(sizeof(char *)*numColumns); //Set space to store organization resource information, column values to match (GET/PUT).
@@ -9910,7 +9996,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
             }
             //Create new secureDB (delete old secureDB if it exists):
             result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
-                                         attributes,attributesData,2,1,
+                                         attributes,attributesData,numSecureDBAttributes,1,
                                          resourceInfoText,
                                          urlElements[5], //document type
                                          urlElements[7], //documentId
@@ -10090,7 +10176,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
             }
             //Create new secureDB (delete old secureDB by using replace flag):
             result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
-                                         attributes,attributesData,2,1,
+                                         attributes,attributesData,numSecureDBAttributes,1,
                                          resourceInfoText,
                                          urlElements[5], //document type
                                          urlElements[7], //documentId
@@ -10571,7 +10657,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
             }
             //Create new secureDB (delete old secureDB by using replace flag):
             result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
-                                         attributes,attributesData,2,1,
+                                         attributes,attributesData,numSecureDBAttributes,1,
                                          resourceInfoText,
                                          urlElements[5], //document type
                                          urlElements[7], //documentId
@@ -10692,6 +10778,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
     int numResultRegisterCols=0;
     int numResultRegisters=0;
     int requestedColNameIDX=0;
+    int numSecureDBAttributes=0;
     sqlite3 *pDB=NULL;
     sqlite3 *resultDB=NULL;             //Result DB for unprotected DB (before parsing)
     char *orgKey=NULL;                  //requester orgKey.
@@ -10717,8 +10804,8 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
     const char *validGETALLMatchColumns[9]={"_userId","_orgId","_resourceInfo","_columnFile",
                                             "_partHash","_totalParts","_partId","_lastModified","_columnId"};
     const char *validPOSTSaveColumns[3]={"userId","orgId"};
-    const char *attributes[]={"shuffle","protect"};                           // TODO (OHR#2#): TMP attributes to test POST. We MUST take these arguments from the user, via API!
-    const char *attributesData[]={cmeDefaultEncAlg,cmeDefaultEncAlg};
+    const char *attributes[2]={NULL,NULL};
+    const char *attributesData[2]={NULL,NULL};
     #define cmeWebServiceProcessContentColumnResourceFree() \
         do { \
             cmeFree(orgKey); \
@@ -10807,6 +10894,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
         *responseCode=403;
         return(1);
     }
+    numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
     result=cmeSanitizeStrForSQL(urlElements[9],&sanitizedSQLStr); //Sanitize contentColumn name so that it can be used in SQL queries.
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessContentColumnResource(), Sanitized (i.e. doubled single quotes) of "
@@ -10935,7 +11023,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
                 cmeStrConstrAppend(&(cmeResultMemTable[0]),"%s",urlElements[9]);
                 //Create new secureDB:
                 result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
-                                             attributes,attributesData,2,1,
+                                             attributes,attributesData,numSecureDBAttributes,1,
                                              resourceInfoText,
                                              urlElements[5], //document type
                                              urlElements[7], //documentId
@@ -11045,7 +11133,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
                 }
                 //Create new secureDB (delete old secureDB if it exists):
                 result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
-                                             attributes,attributesData,2,1,
+                                             attributes,attributesData,numSecureDBAttributes,1,
                                              resourceInfoText,
                                              urlElements[5], //document type
                                              urlElements[7], //documentId
@@ -11802,7 +11890,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
                 }
                 //Create new secureDB (delete old secureDB if it exists):
                 result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
-                                             attributes,attributesData,2,1,
+                                             attributes,attributesData,numSecureDBAttributes,1,
                                              resourceInfoText,
                                              urlElements[5], //document type
                                              urlElements[7], //documentId

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -582,6 +582,62 @@ static int cmeWebServiceGetBooleanParam(const char **argumentElements, const cha
     return(defaultValue);
 }
 
+static const char *cmeWebServiceSupportedDocumentTypes[]={
+    "file.csv",
+    "file.raw",
+    "file.txt",
+    "file.json",
+    "file.xml",
+    "file.html",
+    "file.pdf",
+    "file.png",
+    "file.jpg",
+    "file.gif",
+    "file.zip",
+    "file.bin",
+    "script.perl"
+};
+
+static const int cmeWebServiceNumSupportedDocumentTypes=
+    sizeof(cmeWebServiceSupportedDocumentTypes)/sizeof(cmeWebServiceSupportedDocumentTypes[0]);
+
+static int cmeWebServiceIsSupportedDocumentType(const char *documentType)
+{
+    int cont;
+
+    if (!documentType)
+    {
+        return(0);
+    }
+    for (cont=0;cont<cmeWebServiceNumSupportedDocumentTypes;cont++)
+    {
+        if (!strcmp(documentType,cmeWebServiceSupportedDocumentTypes[cont]))
+        {
+            return(1);
+        }
+    }
+    return(0);
+}
+
+static int cmeWebServiceIsRawFileDocumentType(const char *documentType)
+{
+    if (!documentType)
+    {
+        return(0);
+    }
+    return((!strcmp(documentType,"file.raw"))||
+           (!strcmp(documentType,"file.txt"))||
+           (!strcmp(documentType,"file.json"))||
+           (!strcmp(documentType,"file.xml"))||
+           (!strcmp(documentType,"file.html"))||
+           (!strcmp(documentType,"file.pdf"))||
+           (!strcmp(documentType,"file.png"))||
+           (!strcmp(documentType,"file.jpg"))||
+           (!strcmp(documentType,"file.gif"))||
+           (!strcmp(documentType,"file.zip"))||
+           (!strcmp(documentType,"file.bin")));
+}
+
 static int cmeWebServiceBuildSecureDBAttributes(const char **argumentElements,
                                                 const char **attributes, const char **attributeData,
                                                 int maxAttributes)
@@ -6151,14 +6207,13 @@ int cmeWebServiceProcessDocumentTypeClass (char **responseText, int *responseCod
                                            const char **argumentElements, const char *method)
 {
     int cont;
-    const char *docTypes[3]={"file.csv","file.raw","script.perl"};
 
     if(!strcmp(method,"GET"))
     {
         cmeStrConstrAppend(responseText,"<b>200 OK - Available document types:</b><br>");
-        for (cont=0; cont<3; cont++)
+        for (cont=0;cont<cmeWebServiceNumSupportedDocumentTypes;cont++)
         {
-            cmeStrConstrAppend(responseText,"%s<br>",docTypes[cont]);
+            cmeStrConstrAppend(responseText,"%s<br>",cmeWebServiceSupportedDocumentTypes[cont]);
         }
         *responseCode=200;
         return(0);
@@ -6186,7 +6241,7 @@ int cmeWebServiceProcessDocumentTypeClass (char **responseText, int *responseCod
 int cmeWebServiceProcessDocumentTypeResource (char **responseText, char **responseFilePath, int *responseCode,
                                      const char *url, const char **urlElements, const char **argumentElements, const char *method)
 {   //IDD ver. 1.0.20 definitions.
-    int cont, cont2;
+    int cont;
     int orgArg=0;
     int usrArg=0;
     int keyArg=0;
@@ -6205,8 +6260,6 @@ int cmeWebServiceProcessDocumentTypeResource (char **responseText, char **respon
     char **columnNames=NULL;
     const int numColumns=12;            //Number of columns in corresponding resource table.
     const int numValidGETALLMatch=0;    //No matches necessary for this resource
-    const int numSupportedDocTypes=3;
-    const char *supportedDocTypes[3]={"file.csv","file.raw","script.perl"};
 
     #define cmeWebServiceProcessDocumentTypeResourceFree() \
         do { \
@@ -6287,15 +6340,7 @@ int cmeWebServiceProcessDocumentTypeResource (char **responseText, char **respon
                                           &userId, &orgId, &orgKey, &newOrgKey, &usrArg, &orgArg, &keyArg, &newKeyArg);
         if ((numMatchArgs>=2)&&(keyArg)&&(usrArg)&&(orgArg)) //Command successful; required number of arguments found (at least: orgKey, orgId userId and >=2 Match)
         {
-            cont2=0;
-            for (cont=0; cont<numSupportedDocTypes; cont++)
-            {
-                if (!strcmp(urlElements[5],supportedDocTypes[cont])) //Check for valid document type.
-                {
-                    cont2++;
-                }
-            }
-            if (cont2) //OK - Supported type.
+            if (cmeWebServiceIsSupportedDocumentType(urlElements[5])) //OK - Supported type.
             {
                 cmeStrConstrAppend(responseText,"<b>200 OK - document type %s is supported. Options for document type resources:</b><br>"
                    "%sLatest IDD version: <code>%s</code>",urlElements[5],cmeWSMsgDocumentTypeOptions,cmeInternalDBDefinitionsVersion);
@@ -6617,7 +6662,8 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                             return(4);
                         }
                     }
-                    else if(!strcmp("script.perl",urlElements[5])) //Process 'script.perl' type
+                    else if((!strcmp("script.perl",urlElements[5]))||
+                            (cmeWebServiceIsRawFileDocumentType(urlElements[5]))) //Process raw-compatible secure file types.
                     {
                         resourceInfoText = (char *) MHD_lookup_connection_value(connection,MHD_GET_ARGUMENT_KIND,"*resourceInfo");
                         if(newOrgKey) //Create resource using newOrgKey
@@ -6652,42 +6698,6 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                             return(5);
                         }
                     }
-                    else if(!strcmp("file.raw",urlElements[5])) //Process 'file.raw' type
-                    {
-                        resourceInfoText = (char *) MHD_lookup_connection_value(connection,MHD_GET_ARGUMENT_KIND,"*resourceInfo");
-                        if(newOrgKey) //Create resource using newOrgKey
-                        {
-                            result=cmeRAWFileToSecureFile (postImportFile,userId,orgId,newOrgKey,resourceInfoText, //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
-                                                            urlElements[5], //document type
-                                                            urlElements[7], //documentId
-                                                            urlElements[3], //storageId
-                                                            storagePath);   //storagePath
-                        }
-                        else //Create resource using orgKey
-                        {
-                            result=cmeRAWFileToSecureFile (postImportFile,userId,orgId,orgKey,resourceInfoText, //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
-                                                            urlElements[5], //document type
-                                                            urlElements[7], //documentId
-                                                            urlElements[3], //storageId
-                                                            storagePath);   //storagePath
-                        }
-                        if (result) //Error, File couldn't be imported
-                        {
-                            cmeStrConstrAppend(responseText,"<b>500 ERROR Internal server error.</b><br>"
-                                           "Internal server error number '%d'."
-                                           "METHOD: '%s' URL: '%s'."
-                                            "%sLatest IDD version: <code>%s</code>",result,method,url,cmeWSMsgDocumentOptions,
-                                            cmeInternalDBDefinitionsVersion);
-#ifdef ERROR_LOG
-                            fprintf(stderr,"CaumeDSE Error: cmeWebServiceProcessDocumentResource(), Error, internal server error '%d'."
-                                    " Method: '%s', URL: '%s'!\n",result,method,url);
-#endif
-                            cmeWebServiceProcessDocumentResourceFree();
-                            *responseCode=500;
-                            return(6);
-                        }
-                    }
-                    // TODO (OHR#2#): process other file types with ' else if (!strcmp("file.XXX",urlElements[5])) {  } '
                     else //Error, unsupported file type
                     {
                         cmeStrConstrAppend(responseText,"<b>501 ERROR Not implemented.</b><br>"
@@ -8370,7 +8380,7 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                         return(5);
                     }
                 }
-                else if (!strncmp(urlElements[5],"file.raw",8)) //If type of documentId to be parsed is file.raw, then...
+                else if (cmeWebServiceIsRawFileDocumentType(urlElements[5])) //Raw-compatible files are stored as secure files, but parser execution on them is not implemented.
                 {
                     cmeStrConstrAppend(responseText,"<b>501 ERROR Not implemented.</b><br>"
                                        "The requested functionality has not been implemented."
@@ -8579,7 +8589,7 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                         return(14);
                     }
                 }
-                else if (!strncmp(urlElements[5],"file.raw",8)) //If type of documentId to be parsed is file.raw, then...
+                else if (cmeWebServiceIsRawFileDocumentType(urlElements[5])) //Raw-compatible files are stored as secure files, but parser execution on them is not implemented.
                 {
 #ifdef DEBUG
                     fprintf(stderr,"CaumeDSE Debug: cmeWebServiceProcessParserScriptResource(), Debug, support "
@@ -9151,9 +9161,10 @@ int cmeWebServiceProcessContentClass (char **responseText, char **responseFilePa
                     *responseCode=200;
                     return(0);
                 }
-                else if (!strncmp(urlElements[5],"file.raw",8)) //If type of documentId to be parsed is file.raw, then...
+                else if (cmeWebServiceIsRawFileDocumentType(urlElements[5])) //If document type uses raw file storage, then...
                 {
                     fileNameValues[0]=(void*)urlElements[7]; //Just point to proper documentId for the file; no need to free it here.
+                    fileNameValues[1]=(void*)urlElements[5]; //Match against the requested raw-compatible document type.
                     //Get raw file :
                     result=cmeGetUnprotectDBRegisters(pDB,tableName,fileNameMatch,(const char **)fileNameValues,
                                                       2,&resultRegisterCols,&numResultRegisterCols,
@@ -9369,9 +9380,10 @@ int cmeWebServiceProcessContentClass (char **responseText, char **responseFilePa
                     cmeWebServiceProcessContentClassFree();
                     return(0);
                 }
-                else if (!strncmp(urlElements[5],"file.raw",8)) //If type of documentId to be parsed is file.raw, then...
+                else if (cmeWebServiceIsRawFileDocumentType(urlElements[5])) //If document type uses raw file storage, then...
                 {
                     fileNameValues[0]=(void*)urlElements[7]; //Just point to proper documentId for the file; no need to free it here.
+                    fileNameValues[1]=(void*)urlElements[5]; //Match against the requested raw-compatible document type.
                     //Get raw file :
                     result=cmeGetUnprotectDBRegisters(pDB,tableName,fileNameMatch,(const char **)fileNameValues,
                                                       2,&resultRegisterCols,&numResultRegisterCols,

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -2015,9 +2015,9 @@ int cmeWebServiceProcessUserResource (char **responseText, char **responseFilePa
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessUserResource(), DELETE successful.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessUserResourceFree();
                     return(0);
                 }
@@ -2460,9 +2460,9 @@ int cmeWebServiceProcessUserClass (char **responseText, char ***responseHeaders,
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessUserClass(), DELETE successful.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"Deleted registers: %d <br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessUserClassFree();
                     return(0);
                 }
@@ -2478,7 +2478,6 @@ int cmeWebServiceProcessUserClass (char **responseText, char ***responseHeaders,
                     fprintf(stderr,"CaumeDSE Debug: cmeWebServiceProcessUserClass(), DELETE error!, "
                             "cmeDeleteUnporotectDBRegisters error!\n");
 #endif
-                    //TODO (OHR#3#): Create a function to process results according to user requests (plaintext, html, etc.) move the above code (HTML) there.
                     cmeWebServiceProcessUserClassFree();
                     return(15);
                 }
@@ -3442,9 +3441,9 @@ int cmeWebServiceProcessRoleTableResource (char **responseText, char **responseF
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessRoleTableResource(), DELETE successful.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessRoleTableResourceFree();
                     return(0);
                 }
@@ -4146,10 +4145,9 @@ int cmeWebServiceProcessOrgResource (char **responseText, char ***responseHeader
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessOrgResource(), DELETE successful.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    //TODO (OHR#3#): Create a function to process results according to user requests (plaintext, html, etc.) move the above code (HTML) there.
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessOrgResourceFree();
                     return(0);
                 }
@@ -4585,9 +4583,9 @@ int cmeWebServiceProcessOrgClass (char **responseText, char **responseFilePath, 
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessOrgClass(), DELETE successful.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessOrgClassFree();
                     return(0);
                 }
@@ -5376,10 +5374,9 @@ int cmeWebServiceProcessStorageResource (char **responseText, char **responseFil
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessStorageResource(), DELETE successful, but resource not found.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    //TODO (OHR#3#): Create a function to process results according to user requests (plaintext, html, etc.) move tha above code (HTML) there.
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessStorageResourceFree();
                     return(0);
                 }
@@ -5840,9 +5837,9 @@ int cmeWebServiceProcessStorageClass (char **responseText, char ***responseHeade
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessStorageClass(), DELETE successful.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessStorageClassFree();
                     return(0);
                 }
@@ -7039,9 +7036,9 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessDocumentResource(), DELETE successful, but resource not found.\n");
 #endif
                     }
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessDocumentResourceFree();
                     return(0);
                 }
@@ -7862,9 +7859,9 @@ int cmeWebServiceProcessDocumentClass (char **responseText, char ***responseHead
                     }
                     cmeDBClose(pDB);
                     pDB=NULL;
-                    cmeStrConstrAppend(responseText,"<p>Deleted registers: %d</p><br>",numResultRegisters);
-                    cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
-                    cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",numResultRegisters);
+                    cmeConstructWebServiceCountResponse("Deleted registers",numResultRegisters,
+                                                        argumentElements,method,url,
+                                                        responseHeaders,responseText,responseCode);
                     cmeWebServiceProcessDocumentClassFree();
                     return(0);
                 }

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -534,6 +534,13 @@ static int cmeWebServiceIsFalseValue(const char *value)
                      (!strcasecmp(value,"none"))));
 }
 
+static int cmeWebServiceIsTrueValue(const char *value)
+{
+    return((value)&&((!strcmp(value,"1"))||(!strcasecmp(value,"true"))||
+                     (!strcasecmp(value,"yes"))||(!strcasecmp(value,"on"))||
+                     (!value[0])));
+}
+
 static int cmeWebServiceGetSecureDBAttributeParam(const char **argumentElements, const char *name,
                                                   const char **value)
 {
@@ -552,6 +559,27 @@ static int cmeWebServiceGetSecureDBAttributeParam(const char **argumentElements,
     result=cmeFindInArgPairList(argumentElements,starName,value);
     cmeFree(starName);
     return(result);
+}
+
+static int cmeWebServiceGetBooleanParam(const char **argumentElements, const char *name,
+                                        int defaultValue)
+{
+    const char *value=NULL;
+
+    if ((cmeWebServiceGetSecureDBAttributeParam(argumentElements,name,&value))||
+        (!value))
+    {
+        return(defaultValue);
+    }
+    if (cmeWebServiceIsFalseValue(value))
+    {
+        return(0);
+    }
+    if (cmeWebServiceIsTrueValue(value))
+    {
+        return(1);
+    }
+    return(defaultValue);
 }
 
 static int cmeWebServiceBuildSecureDBAttributes(const char **argumentElements,
@@ -579,9 +607,7 @@ static int cmeWebServiceBuildSecureDBAttributes(const char **argumentElements,
     if (!cmeWebServiceIsFalseValue(shuffleValue))
     {
         attributes[numAttributes]="shuffle";
-        if ((!strcmp(shuffleValue,"1"))||(!strcasecmp(shuffleValue,"true"))||
-            (!strcasecmp(shuffleValue,"yes"))||(!strcasecmp(shuffleValue,"on"))||
-            (!shuffleValue[0]))
+        if (cmeWebServiceIsTrueValue(shuffleValue))
         {
             attributeData[numAttributes]=cmeDefaultEncAlg;
         }
@@ -594,9 +620,7 @@ static int cmeWebServiceBuildSecureDBAttributes(const char **argumentElements,
     if (!cmeWebServiceIsFalseValue(protectValue))
     {
         attributes[numAttributes]="protect";
-        if ((!strcmp(protectValue,"1"))||(!strcasecmp(protectValue,"true"))||
-            (!strcasecmp(protectValue,"yes"))||(!strcasecmp(protectValue,"on"))||
-            (!protectValue[0]))
+        if (cmeWebServiceIsTrueValue(protectValue))
         {
             attributeData[numAttributes]=cmeDefaultEncAlg;
         }
@@ -6345,6 +6369,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
     int processedRows=0;
     int numCols=0;
     int numSecureDBAttributes=0;
+    int replaceDB=0;
     sqlite3 *pDB=NULL;
     char *orgKey=NULL;                  //requester orgKey.
     char *userId=NULL;                  //requester userId.
@@ -6440,6 +6465,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
        columnNamesToMatch[cont]=NULL;
     }
     numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
+    replaceDB=cmeWebServiceGetBooleanParam(argumentElements,"replaceDB",0);
     cmeStrConstrAppend(&dbFilePath,"%s%s",cmeDefaultFilePath,cmeDefaultResourcesDBName);
     if(!strcmp(method,"POST")) //Method = POST is ok, process:
     {
@@ -6521,7 +6547,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                 }
                 else //OK
                 {
-                    if (numResultRegisters>0) //resource is already in DB -> Error
+                    if ((numResultRegisters>0)&&((!replaceDB)||(strcmp("file.csv",urlElements[5])))) //resource is already in DB -> Error
                     {
                         cmeStrConstrAppend(responseText,"<b>403 ERROR Forbidden request.</b><br>"
                                            "Document resource already exists! "
@@ -6553,12 +6579,12 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         return(3);
                     }
                     if(!strcmp("file.csv",urlElements[5])) //Process 'file.csv' type
-                    {   // TODO (OHR#1#): if CSV -> Ensure that attribute, attributeData and replaceDB are taken from user parameters via API (right now these are only predefined test values!)
+                    {
                         resourceInfoText = (char *) MHD_lookup_connection_value(connection,MHD_GET_ARGUMENT_KIND,"*resourceInfo");
                         if(newOrgKey) //Create resource using newOrgKey
                         {
                             result=cmeCSVFileToSecureDB(postImportFile,1,&numCols,&processedRows,userId,orgId,newOrgKey,  //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
-                                                        attributes, attributesData,numSecureDBAttributes,0,
+                                                        attributes, attributesData,numSecureDBAttributes,replaceDB,
                                                         resourceInfoText,
                                                         urlElements[5], //document type
                                                         urlElements[7], //documentId
@@ -6568,7 +6594,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         else //Create resource using orgKey
                         {
                             result=cmeCSVFileToSecureDB(postImportFile,1,&numCols,&processedRows,userId,orgId,orgKey,  //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
-                                                        attributes, attributesData,numSecureDBAttributes,0,
+                                                        attributes, attributesData,numSecureDBAttributes,replaceDB,
                                                         resourceInfoText,
                                                         urlElements[5], //document type
                                                         urlElements[7], //documentId


### PR DESCRIPTION
## Summary
- centralize delete count response formatting
- move CSV secure attributes shuffle and protect into request parameters
- read CSV replaceDB from request parameters
- add raw-compatible document types: file.txt, file.json, file.xml, file.html, file.pdf, file.png, file.jpg, file.gif, file.zip, file.bin

## Verification
- direct compile of webservice_interface.c
- ./configure
- make