### PR TITLE
[codex] Complete security and DB hardening TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,13 @@ replaceDB
     If omitted or set to 0, false, no, off or none, duplicate document
     resources are rejected.
 
+vacuumDB
+    Optional for file.csv uploads and content row/column writes.  If
+    set to 1, true, yes or on, each temporary memory database is
+    vacuumed before it is saved as a durable secure database file.
+    Secure imports with protection attributes still vacuum by default
+    to remove slack space that may contain unprotected data.
+
 #### 3.5 Optional Column index parameters for content rows (`file.csv`)
 
 

--- a/README.md
+++ b/README.md
@@ -2020,9 +2020,14 @@ the whole keyspace to take into account the provided salt).  Using this kind
 of keys improves performance considerably.
 
 The default symmetric encryption algorithm used by CaumeDSE is `AES-256-GCM`.
-You may override this at runtime by setting the environment variable
-`CDSE_DEFAULT_ENC_ALG` to any cipher name recognized by OpenSSL, such as
-`aes-256-cbc` for AES in CBC mode.
+You may override this at runtime with a configuration file, or by setting the
+environment variable `CDSE_DEFAULT_ENC_ALG` to any cipher name recognized by
+OpenSSL, such as `aes-256-cbc` for AES in CBC mode.  By default CaumeDSE reads
+`caumedse.conf` from the configured data directory, and `CDSE_CONFIG_FILE` may
+point to an alternate configuration file.  The supported configuration keys for
+this setting are `defaultEncAlg`, `default_enc_alg`, and
+`CDSE_DEFAULT_ENC_ALG`; the environment variable takes precedence over the
+configuration file.
 
 All other keys are assumed to be human generated passwords or passphrases
 which require key expansion with a slow function, in order to limit

--- a/README.md
+++ b/README.md
@@ -1978,6 +1978,12 @@ mode (which is slower), use the following parameter when running
     --enable-DEBUG
 Before running CaumeDSE in DEBUG mode, copy the contents of TEST/testfiles to /opt/cdse/testfiles and TEST/testDB_opt_cdse to /opt/cdse (or the directory specified by PATH_DATADIR) to provide data for the internal tests.
 
+Temporary-file deletion uses one zero-fill overwrite pass by default.  To
+compile with additional overwrite passes, define
+`CDSE_SECURE_OVERWRITE_PASSES` in `CFLAGS`, for example:
+
+    CFLAGS="-DCDSE_SECURE_OVERWRITE_PASSES=3" ./configure
+
 In release mode the software enters and infinite loop to answer connections;
 right now you need to kill the process to stop it).
 

--- a/TODO.md
+++ b/TODO.md
@@ -205,8 +205,9 @@
   - Source: `db.c:201`.
   - Done: memory database saves can now request a pre-save `VACUUM`; CSV upload and content row/column writes expose this through the `vacuumDB` request parameter while preserving mandatory vacuuming for protected imports.
 
-- [ ] #42 Implement signing and protected signing for protected DB values.
+- [x] #42 Implement signing and protected signing for protected DB values.
   - Source: `db.c:1253`, `db.c:1259`, `db.c:2225`, `db.c:2231`.
+  - Done: `sign` and `signProtected` now compute and verify keyed signatures for plaintext and protected data values, respectively, using the existing HMAC-backed integrity primitive. The CSV integrity component test now exercises both signing attributes together with `MAC` and `MACProtected`.
 
 - [x] #43 Replace direct DB protect/unprotect call sites with wrapper functions.
   - Source: `db.c:2355`, `db.c:2383`.

--- a/TODO.md
+++ b/TODO.md
@@ -197,8 +197,9 @@
   - Source: `webservice_interface.c:6546`.
   - Done: added raw-compatible handlers for `file.txt`, `file.json`, `file.xml`, `file.html`, `file.pdf`, `file.png`, `file.jpg`, `file.gif`, `file.zip` and `file.bin`, while keeping `file.csv` and `script.perl` special.
 
-- [ ] #40 Add an optional multi-round secure overwrite scheme.
+- [x] #40 Add an optional multi-round secure overwrite scheme.
   - Source: `webservice_interface.c:7307`, `filehandling.h:83`.
+  - Done: `cmeFileOverwriteAndDelete()` now supports compile-time multi-pass overwrites via `CDSE_SECURE_OVERWRITE_PASSES`, and POST temporary file cleanup uses that shared helper.
 
 - [ ] #41 Vacuum memory DBs before durable saves when requested.
   - Source: `db.c:201`.

--- a/TODO.md
+++ b/TODO.md
@@ -229,8 +229,9 @@
   - Source: `common.h:132`.
   - Done: added central IDD table-name and URL-parameter-name helpers, and replaced hard-coded internal DB column/table names in admin bootstrap, ColumnFile DB creation, and LogsDB transaction handling with IDD constants.
 
-- [ ] #48 Research secure memory clearing and memory locking for sensitive data.
+- [x] #48 Research secure memory clearing and memory locking for sensitive data.
   - Source: `engine_interface.c:310`, `engine_interface.c:1583`.
+  - Done: added `OPENSSL_cleanse()`-based secure memory clearing helpers plus best-effort `mlock()`/`munlock()` wrappers, then replaced optimizer-sensitive manual `memset()` wipes for decrypted document IDs.
 
 - [ ] #49 Verify salt requirements and fail on invalid salts.
   - Source: `engine_interface.c:1053`.

--- a/TODO.md
+++ b/TODO.md
@@ -201,8 +201,9 @@
   - Source: `webservice_interface.c:7307`, `filehandling.h:83`.
   - Done: `cmeFileOverwriteAndDelete()` now supports compile-time multi-pass overwrites via `CDSE_SECURE_OVERWRITE_PASSES`, and POST temporary file cleanup uses that shared helper.
 
-- [ ] #41 Vacuum memory DBs before durable saves when requested.
+- [x] #41 Vacuum memory DBs before durable saves when requested.
   - Source: `db.c:201`.
+  - Done: memory database saves can now request a pre-save `VACUUM`; CSV upload and content row/column writes expose this through the `vacuumDB` request parameter while preserving mandatory vacuuming for protected imports.
 
 - [ ] #42 Implement signing and protected signing for protected DB values.
   - Source: `db.c:1253`, `db.c:1259`, `db.c:2225`, `db.c:2231`.

--- a/TODO.md
+++ b/TODO.md
@@ -233,8 +233,9 @@
   - Source: `engine_interface.c:310`, `engine_interface.c:1583`.
   - Done: added `OPENSSL_cleanse()`-based secure memory clearing helpers plus best-effort `mlock()`/`munlock()` wrappers, then replaced optimizer-sensitive manual `memset()` wipes for decrypted document IDs.
 
-- [ ] #49 Verify salt requirements and fail on invalid salts.
+- [x] #49 Verify salt requirements and fail on invalid salts.
   - Source: `engine_interface.c:1053`.
+  - Done: `cmePostProtectDBRegister()` now rejects caller-supplied protected DB salts unless they are exactly `evpSaltBufferSize * 2` hex characters; omitted salts still use the existing generated-salt path.
 
 - [ ] #50 Evaluate whether another random source is needed for systems without `/dev/random` or `/dev/urandom`.
   - Source: `crypto.c:436`.

--- a/TODO.md
+++ b/TODO.md
@@ -208,8 +208,9 @@
 - [ ] #42 Implement signing and protected signing for protected DB values.
   - Source: `db.c:1253`, `db.c:1259`, `db.c:2225`, `db.c:2231`.
 
-- [ ] #43 Replace direct DB protect/unprotect call sites with wrapper functions.
+- [x] #43 Replace direct DB protect/unprotect call sites with wrapper functions.
   - Source: `db.c:2355`, `db.c:2383`.
+  - Done: verified plain DB text protect/unprotect paths use `cmeProtectDBValue()` and `cmeUnprotectDBValue()` wrappers; removed the stale wrapper TODO markers. Salted protect/unprotect wrapper cleanup remains tracked separately in `#44`.
 
 - [ ] #44 Replace direct salt/protect and unprotect/unsalt call sites with wrapper functions.
   - Source: `db.c:2420`, `db.c:2461`.

--- a/TODO.md
+++ b/TODO.md
@@ -213,8 +213,9 @@
   - Source: `db.c:2355`, `db.c:2383`.
   - Done: verified plain DB text protect/unprotect paths use `cmeProtectDBValue()` and `cmeUnprotectDBValue()` wrappers; removed the stale wrapper TODO markers. Salted protect/unprotect wrapper cleanup remains tracked separately in `#44`.
 
-- [ ] #44 Replace direct salt/protect and unprotect/unsalt call sites with wrapper functions.
+- [x] #44 Replace direct salt/protect and unprotect/unsalt call sites with wrapper functions.
   - Source: `db.c:2420`, `db.c:2461`.
+  - Done: `cmeProtectDBSaltedValue()` and `cmeUnprotectDBSaltedValue()` now delegate encryption/decryption to `cmeProtectDBValue()` and `cmeUnprotectDBValue()` after adding or before removing the value salt.
 
 - [ ] #45 Replace direct `malloc` calls with an audited allocation wrapper.
   - Source: `common.h:50`.

--- a/TODO.md
+++ b/TODO.md
@@ -221,8 +221,9 @@
   - Source: `common.h:50`.
   - Done: project allocation calls are now routed through `cmeMalloc()` and `cmeRealloc()` wrappers that log failed non-zero-size allocations with source file and line information.
 
-- [ ] #46 Read globals from a configuration file.
+- [x] #46 Read globals from a configuration file.
   - Source: `common.h:51`.
+  - Done: startup now loads runtime globals from `caumedse.conf` (or `CDSE_CONFIG_FILE`) and applies the existing `CDSE_DEFAULT_ENC_ALG` environment override after validating cipher names.
 
 - [ ] #47 Standardize IDD usage and avoid direct use of numeric IDs and column names.
   - Source: `common.h:132`.

--- a/TODO.md
+++ b/TODO.md
@@ -217,8 +217,9 @@
   - Source: `db.c:2420`, `db.c:2461`.
   - Done: `cmeProtectDBSaltedValue()` and `cmeUnprotectDBSaltedValue()` now delegate encryption/decryption to `cmeProtectDBValue()` and `cmeUnprotectDBValue()` after adding or before removing the value salt.
 
-- [ ] #45 Replace direct `malloc` calls with an audited allocation wrapper.
+- [x] #45 Replace direct `malloc` calls with an audited allocation wrapper.
   - Source: `common.h:50`.
+  - Done: project allocation calls are now routed through `cmeMalloc()` and `cmeRealloc()` wrappers that log failed non-zero-size allocations with source file and line information.
 
 - [ ] #46 Read globals from a configuration file.
   - Source: `common.h:51`.

--- a/TODO.md
+++ b/TODO.md
@@ -225,8 +225,9 @@
   - Source: `common.h:51`.
   - Done: startup now loads runtime globals from `caumedse.conf` (or `CDSE_CONFIG_FILE`) and applies the existing `CDSE_DEFAULT_ENC_ALG` environment override after validating cipher names.
 
-- [ ] #47 Standardize IDD usage and avoid direct use of numeric IDs and column names.
+- [x] #47 Standardize IDD usage and avoid direct use of numeric IDs and column names.
   - Source: `common.h:132`.
+  - Done: added central IDD table-name and URL-parameter-name helpers, and replaced hard-coded internal DB column/table names in admin bootstrap, ColumnFile DB creation, and LogsDB transaction handling with IDD constants.
 
 - [ ] #48 Research secure memory clearing and memory locking for sensitive data.
   - Source: `engine_interface.c:310`, `engine_interface.c:1583`.

--- a/common.h
+++ b/common.h
@@ -73,6 +73,10 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #define cmeMaxCSVPartsPerColumn 10000   //Max {estimated} number of parts that a CSV table can hold {required by cmeSecureDBtoMemDB}.
 #define cmeMaxRAWDataInPart 4000        //Max number of bytes in a secure file slice {part}, estimated from smallest SQLITE secureDB column files. {RECOMMENDED: 5120}
 #define cmeDefaultContentReaderCallbackPageSize (1024*64)   //Default Page size for ContentReaderCallback functions.
+#ifndef CDSE_SECURE_OVERWRITE_PASSES
+#define CDSE_SECURE_OVERWRITE_PASSES 1  //Compile-time overwrite passes for temporary file deletion. Set >1 to enable multi-round overwrites.
+#endif
+#define cmeSecureOverwriteBufferSize 4096
 
 #ifdef PATH_DATADIR
 #define cmeDefaultFilePath PATH_DATADIR "/"                     //Default virtual root path for storing engine files {DBs}.

--- a/common.h
+++ b/common.h
@@ -133,7 +133,15 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
                                                        //Note that there is NO default orgKey for EngineOrg... it will be generated randomly the first time the engine is run and won't be stored in clear {so take note!}.
 
 #define cmeInternalDBDefinitionsVersion "1.0.21_1 Jul 2012" //Version of internal DB definitions for engine
-// TODO (OHR#4#): Standardize the use of IDD in the project (i.e. avoid direct use of numbers and col. names).
+#define cmeIDDMatchName(columnName) "_" columnName           //URL match parameter name for a protected DB column.
+#define cmeIDDRequiredSaveName(columnName) "*" columnName    //URL save parameter name for a required protected DB column.
+#define cmeIDDColumnFileDataTableName "data"                 //Table name for ColumnFile data tables.
+#define cmeIDDColumnFileMetaTableName "meta"                 //Table name for ColumnFile meta tables.
+#define cmeIDDResourcesDBDocumentsTableName "documents"      //Table name for ResourceDB documents.
+#define cmeIDDResourcesDBUsersTableName "users"              //Table name for ResourceDB users.
+#define cmeIDDResourcesDBStorageTableName "storage"          //Table name for ResourceDB storage.
+#define cmeIDDResourcesDBOrganizationsTableName "organizations" //Table name for ResourceDB organizations.
+#define cmeIDDLogsDBTransactionsTableName "transactions"     //Table name for LogsDB transactions.
 #define cmeIDDanydb_id 0                        //Column index {0 based} for WSID column for most internal sqlite register id
 #define cmeIDDanydb_id_name "id"                //Column name for WSID column for most internal sqlite register id
 #define cmeIDDanydb_userId 1                    //Column index {0 based} for WSID column for most internal sqlite user id of creator

--- a/common.h
+++ b/common.h
@@ -459,6 +459,12 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #if HAVE_SYS_SOCKET_H
 #include <sys/socket.h>     //for microhttpd
 #endif
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/mman.h>       //for mlock(), munlock()
+#define CME_HAVE_MLOCK 1
+#else
+#define CME_HAVE_MLOCK 0
+#endif
 #if HAVE_FCNTL_H
 #include <fcntl.h>          //for microhttpd
 #endif
@@ -474,6 +480,7 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #if HAVE_OPENSSL_ERR_H
 #include <openssl/err.h>      //Error functions
 #endif
+#include <openssl/crypto.h>   //OPENSSL_cleanse()
 #if HAVE_OPENSSL_RAND_H
 #include <openssl/rand.h>     //Pseudo Random generator functions
 #endif
@@ -516,6 +523,52 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #include <XSUB.h>   //for embedded perl interpreter (32 bit machines)
 #endif
 EXTERN_C void xs_init (pTHX); //for embedded perl interpreter (using dynamically generated: 'xs_init.c')
+
+static inline void cmeSecureMemClear(void *ptr, size_t size)
+{
+    if (ptr && size)
+    {
+        OPENSSL_cleanse(ptr,size);
+    }
+}
+
+static inline void cmeSecureStrClear(char *ptr)
+{
+    if (ptr)
+    {
+        cmeSecureMemClear(ptr,strlen(ptr));
+    }
+}
+
+#define cmeSecureFreeStr(a) {if(a){ cmeSecureStrClear(a); free(a); a=NULL;}}
+
+static inline int cmeSecureMemLock(void *ptr, size_t size)
+{
+#if CME_HAVE_MLOCK
+    if (ptr && size)
+    {
+        return(mlock(ptr,size));
+    }
+#else
+    (void)ptr;
+    (void)size;
+#endif
+    return(0);
+}
+
+static inline int cmeSecureMemUnlock(void *ptr, size_t size)
+{
+#if CME_HAVE_MLOCK
+    if (ptr && size)
+    {
+        cmeSecureMemClear(ptr,size);
+        return(munlock(ptr,size));
+    }
+#else
+    cmeSecureMemClear(ptr,size);
+#endif
+    return(0);
+}
 
 static inline void *cmeMalloc(size_t size, const char *file, int line)
 {

--- a/common.h
+++ b/common.h
@@ -47,7 +47,6 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #include "config.h"
 #endif
 
-//TODO (OHR#8#): Replace calls to malloc with audited, simple, wrapper function.
 //TODO (OHR#9#): Define function to read Globals in main.c from config file
 #define prngSeedBytes 16
 #define evpMaxHashStrLen 2*64+1         //Max length for character representation of hex bytestr hash {RECOMMENDED: 2*64+1}. At 2 chars per byte, SHA-512 requires 64 bytes, + 1 ending null char.
@@ -508,6 +507,37 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #include <XSUB.h>   //for embedded perl interpreter (32 bit machines)
 #endif
 EXTERN_C void xs_init (pTHX); //for embedded perl interpreter (using dynamically generated: 'xs_init.c')
+
+static inline void *cmeMalloc(size_t size, const char *file, int line)
+{
+    void *ptr=malloc(size);
+
+    if ((size)&&(!ptr))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeMalloc(), malloc(%lu) failed at %s:%d.\n",
+                (unsigned long)size,file,line);
+#endif
+    }
+    return(ptr);
+}
+
+static inline void *cmeRealloc(void *ptr, size_t size, const char *file, int line)
+{
+    void *newPtr=realloc(ptr,size);
+
+    if ((size)&&(!newPtr))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeRealloc(), realloc(%p,%lu) failed at %s:%d.\n",
+                ptr,(unsigned long)size,file,line);
+#endif
+    }
+    return(newPtr);
+}
+
+#define malloc(size) cmeMalloc((size),__FILE__,__LINE__)
+#define realloc(ptr,size) cmeRealloc((ptr),(size),__FILE__,__LINE__)
 
 // --- CaumeDSE includes
 #include "crypto.h"

--- a/common.h
+++ b/common.h
@@ -47,7 +47,6 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #include "config.h"
 #endif
 
-//TODO (OHR#9#): Define function to read Globals in main.c from config file
 #define prngSeedBytes 16
 #define evpMaxHashStrLen 2*64+1         //Max length for character representation of hex bytestr hash {RECOMMENDED: 2*64+1}. At 2 chars per byte, SHA-512 requires 64 bytes, + 1 ending null char.
 #define evpMaxHashBytesLen 64           //Max length for byte representation of hash {RECOMMENDED: 64}. SHA-512 requires 64 bytes.
@@ -104,7 +103,9 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #define cmeDefaultLookupSalt "4361756d654453454c6f6f6b75703121"        //Fixed 16-byte hex salt for deterministic protected lookup HMAC derivation.
 #define cmeDefaultSqlBufferLen 8192         //Default size of Buffer for SQL queries. {8192}
 extern char cmeDefaultEncAlg[];             //Default algorithm for symmetric encryption in engine admin. databases.
-void cmeInitDefaultEncAlg();                //Initialize default algorithm from environment
+void cmeLoadConfiguration();                //Initialize runtime globals from configuration file and environment.
+void cmeInitDefaultEncAlg();                //Initialize default algorithm from environment.
+#define cmeDefaultConfigFile cmeDefaultFilePath "caumedse.conf" //Default runtime configuration file.
 #define cmeDefaultHshAlg "sha256"           //Default algorithm for bytestring hashing {digest}.
 #define cmeDefaultMACAlg "sha256"             //Default algorithm for bytestring HMAC MACs .
 #define cmeDefaultInsertSqlRows 512         //Default # of rows to be inserted into a sqlite3 db at a time {within a Begin - Commit block}.

--- a/config.c
+++ b/config.c
@@ -1,6 +1,4 @@
 #include "common.h"
-#include <string.h>
-#include <stdlib.h>
 
 char cmeDefaultEncAlg[64] = "aes-256-gcm";
 

--- a/config.c
+++ b/config.c
@@ -2,23 +2,122 @@
 
 char cmeDefaultEncAlg[64] = "aes-256-gcm";
 
+static char *cmeTrimConfigValue(char *value)
+{
+    char *end = NULL;
+    while (*value && isspace((unsigned char)*value))
+    {
+        value++;
+    }
+    if (!*value)
+    {
+        return value;
+    }
+    end = value + strlen(value) - 1;
+    while (end > value && isspace((unsigned char)*end))
+    {
+        *end = '\0';
+        end--;
+    }
+    return value;
+}
+
+static char *cmeUnquoteConfigValue(char *value)
+{
+    size_t valueLen = strlen(value);
+    if (valueLen >= 2 &&
+        ((value[0] == '"' && value[valueLen-1] == '"') ||
+         (value[0] == '\'' && value[valueLen-1] == '\'')))
+    {
+        value[valueLen-1] = '\0';
+        value++;
+    }
+    return value;
+}
+
+static int cmeSetDefaultEncAlg(const char *value, const char *source)
+{
+    const EVP_CIPHER *cipher = NULL;
+    if (!value || !*value)
+    {
+        return 1;
+    }
+    if (cmeGetCipher(&cipher, value) == 0)
+    {
+        strncpy(cmeDefaultEncAlg, value, sizeof(cmeDefaultEncAlg)-1);
+        cmeDefaultEncAlg[sizeof(cmeDefaultEncAlg)-1] = '\0';
+#ifdef DEBUG
+        fprintf(stdout,"CaumeDSE Debug: using default encryption algorithm %s from %s.\n", cmeDefaultEncAlg, source);
+#endif
+        return 0;
+    }
+#ifdef ERROR_LOG
+    fprintf(stderr,"CaumeDSE Error: cmeSetDefaultEncAlg(), unsupported algorithm %s from %s; using default %s.\n", value, source, cmeDefaultEncAlg);
+#endif
+    return 1;
+}
+
+static void cmeLoadConfigFile(const char *configPath)
+{
+    FILE *configFile = NULL;
+    char line[512];
+    configFile = fopen(configPath, "r");
+    if (!configFile)
+    {
+#ifdef DEBUG
+        fprintf(stdout,"CaumeDSE Debug: configuration file %s not loaded.\n", configPath);
+#endif
+        return;
+    }
+    while (fgets(line, sizeof(line), configFile))
+    {
+        char *comment = strchr(line, '#');
+        char *separator = NULL;
+        char *key = NULL;
+        char *value = NULL;
+        if (comment)
+        {
+            *comment = '\0';
+        }
+        separator = strchr(line, '=');
+        if (!separator)
+        {
+            continue;
+        }
+        *separator = '\0';
+        key = cmeTrimConfigValue(line);
+        value = cmeTrimConfigValue(separator + 1);
+        value = cmeUnquoteConfigValue(value);
+        if (!*key || !*value)
+        {
+            continue;
+        }
+        if (strcmp(key, "defaultEncAlg") == 0 ||
+            strcmp(key, "default_enc_alg") == 0 ||
+            strcmp(key, "CDSE_DEFAULT_ENC_ALG") == 0)
+        {
+            cmeSetDefaultEncAlg(value, configPath);
+        }
+    }
+    fclose(configFile);
+}
+
+void cmeLoadConfiguration()
+{
+    const char *configPath = getenv("CDSE_CONFIG_FILE");
+    if (!configPath || !*configPath)
+    {
+        configPath = cmeDefaultConfigFile;
+    }
+    cmeLoadConfigFile(configPath);
+    cmeInitDefaultEncAlg();
+}
+
 void cmeInitDefaultEncAlg()
 {
     const char *envAlg = getenv("CDSE_DEFAULT_ENC_ALG");
-    const EVP_CIPHER *cipher = NULL;
     if (envAlg && *envAlg)
     {
-        if (cmeGetCipher(&cipher, envAlg) == 0)
-        {
-            strncpy(cmeDefaultEncAlg, envAlg, sizeof(cmeDefaultEncAlg)-1);
-            cmeDefaultEncAlg[sizeof(cmeDefaultEncAlg)-1] = '\0';
-#ifdef DEBUG
-            fprintf(stdout,"CaumeDSE Debug: using default encryption algorithm %s from environment.\n", cmeDefaultEncAlg);
-#endif
-            return;
-        }
-#ifdef ERROR_LOG
-        fprintf(stderr,"CaumeDSE Error: cmeInitDefaultEncAlg(), unsupported algorithm %s; using default %s.\n", envAlg, cmeDefaultEncAlg);
-#endif
+        cmeSetDefaultEncAlg(envAlg, "environment CDSE_DEFAULT_ENC_ALG");
     }
 }

--- a/db.c
+++ b/db.c
@@ -1266,13 +1266,189 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
         else if (!strncmp(memProtectMetaData[cont*cmeIDDColumnFileMetaNumCols+cmeIDDColumnFileMeta_attribute],
                  cmeIDDColumnFileMeta_attribute_3, sizeof(cmeIDDColumnFileMeta_attribute_3)))
         {
-            //TODO (OHR#5#): sign; requires userId to get certificate/private key (check issues with private key)
+            //Compute a keyed signature of the plaintext value and store it in sign for each data row.
+            //memData snapshot always contains the original plaintext values taken before any protection.
+            result=sqlite3_prepare_v2(memSecureDB,"UPDATE data SET sign=? WHERE id=?;",-1,&updateDataMACStmt,NULL);
+            if (result!=SQLITE_OK)
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), sqlite3_prepare_v2() Error"
+                        " can't prepare sign update: %s !\n",sqlite3_errmsg(memSecureDB));
+#endif
+                cmeMemSecureDBProtectFree();
+                return(26);
+            }
+            for(cont2=1;cont2<=numRowsData;cont2++)
+            {
+                cmeStrConstrAppend(&currentDataId,"%d",atoi(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_id]));
+                result=cmeHMACByteString(
+                    (const unsigned char*)memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value],
+                    (unsigned char**)&currentEncB64Data,
+                    strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value]),
+                    &written,cmeDefaultMACAlg,&(currentDataSalt[cont2-1]),orgKey);
+                if (result) //Error
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeHMACByteString() Error, can't "
+                            "compute sign for 'value' in data row id %s with algorithm %s!\n",
+                            currentDataId,cmeDefaultMACAlg);
+#endif
+                    cmeMemSecureDBProtectFree();
+                    return(26);
+                }
+#ifdef DEBUG
+                fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), computed sign"
+                        " for 'value' in row id %s. Result: %s.\n",currentDataId,currentEncB64Data);
+#endif
+                if (cmeSQLRows(memSecureDB,"BEGIN;",NULL,NULL))
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeSQLRows() Error, can't "
+                            "begin sign update transaction for data row id %s!\n",currentDataId);
+#endif
+                    cmeMemSecureDBProtectFree();
+                    return(27);
+                }
+                result=sqlite3_bind_text(updateDataMACStmt,1,currentEncB64Data,-1,SQLITE_TRANSIENT);
+                if (result==SQLITE_OK)
+                {
+                    result=sqlite3_bind_int(updateDataMACStmt,2,atoi(currentDataId));
+                }
+                cmeFree(currentEncB64Data);
+                if (result==SQLITE_OK)
+                {
+                    result=sqlite3_step(updateDataMACStmt);
+                }
+                if (result!=SQLITE_DONE) //Error
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), sqlite3_step() Error, can't "
+                            "store sign for data row id %s: %s!\n",currentDataId,sqlite3_errmsg(memSecureDB));
+#endif
+                    cmeSQLRows(memSecureDB,"ROLLBACK;",NULL,NULL);
+                    cmeMemSecureDBProtectFree();
+                    return(27);
+                }
+                sqlite3_reset(updateDataMACStmt);
+                sqlite3_clear_bindings(updateDataMACStmt);
+                if (cmeSQLRows(memSecureDB,"COMMIT;",NULL,NULL))
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeSQLRows() Error, can't "
+                            "commit sign update transaction for data row id %s!\n",currentDataId);
+#endif
+                    cmeSQLRows(memSecureDB,"ROLLBACK;",NULL,NULL);
+                    cmeMemSecureDBProtectFree();
+                    return(27);
+                }
+#ifdef DEBUG
+                fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), stored sign for row id %s in table data.\n",
+                        currentDataId);
+#endif
+                cmeFree(currentDataId);
+            }
+            sqlite3_finalize(updateDataMACStmt);
+            updateDataMACStmt=NULL;
         }
         // Check if protection attribute = "signProtected".
         else if (!strncmp(memProtectMetaData[cont*cmeIDDColumnFileMetaNumCols+cmeIDDColumnFileMeta_attribute],
                      cmeIDDColumnFileMeta_attribute_4, sizeof(cmeIDDColumnFileMeta_attribute_4)))
         {
-            //TODO (OHR#5#): signProtected; requires userId to get certificate/private key (check issues with private key)
+            //Compute a keyed signature of the encrypted value and store it in signProtected for each data row.
+            //Re-reads current (already-encrypted) values from DB since memData snapshot contains plaintext.
+            result=cmeMemTable(memSecureDB,"SELECT * FROM data;",&memDataEncrypted,&numRowsEncrypted,&numColsEncrypted);
+            if (result) //Error
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeMemTable() Error, can't "
+                        "read 'data' table for signProtected computation!\n");
+#endif
+                cmeMemSecureDBProtectFree();
+                return(28);
+            }
+            result=sqlite3_prepare_v2(memSecureDB,"UPDATE data SET signProtected=? WHERE id=?;",-1,&updateDataMACProtectedStmt,NULL);
+            if (result!=SQLITE_OK)
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), sqlite3_prepare_v2() Error"
+                        " can't prepare signProtected update: %s !\n",sqlite3_errmsg(memSecureDB));
+#endif
+                cmeMemSecureDBProtectFree();
+                return(29);
+            }
+            for(cont2=1;cont2<=numRowsData;cont2++)
+            {
+                cmeStrConstrAppend(&currentDataId,"%d",atoi(memDataEncrypted[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_id]));
+                result=cmeHMACByteString(
+                    (const unsigned char*)memDataEncrypted[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value],
+                    (unsigned char**)&currentEncB64Data,
+                    strlen(memDataEncrypted[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value]),
+                    &written,cmeDefaultMACAlg,&(currentDataSalt[cont2-1]),orgKey);
+                if (result) //Error
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeHMACByteString() Error, can't "
+                            "compute signProtected for 'value' in data row id %s with algorithm %s!\n",
+                            currentDataId,cmeDefaultMACAlg);
+#endif
+                    cmeMemSecureDBProtectFree();
+                    return(29);
+                }
+#ifdef DEBUG
+                fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), computed signProtected"
+                        " for 'value' in row id %s. Result: %s.\n",currentDataId,currentEncB64Data);
+#endif
+                if (cmeSQLRows(memSecureDB,"BEGIN;",NULL,NULL))
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeSQLRows() Error, can't "
+                            "begin signProtected update transaction for data row id %s!\n",currentDataId);
+#endif
+                    cmeMemSecureDBProtectFree();
+                    return(30);
+                }
+                result=sqlite3_bind_text(updateDataMACProtectedStmt,1,currentEncB64Data,-1,SQLITE_TRANSIENT);
+                if (result==SQLITE_OK)
+                {
+                    result=sqlite3_bind_int(updateDataMACProtectedStmt,2,atoi(currentDataId));
+                }
+                cmeFree(currentEncB64Data);
+                if (result==SQLITE_OK)
+                {
+                    result=sqlite3_step(updateDataMACProtectedStmt);
+                }
+                if (result!=SQLITE_DONE) //Error
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), sqlite3_step() Error, can't "
+                            "store signProtected for data row id %s: %s!\n",currentDataId,sqlite3_errmsg(memSecureDB));
+#endif
+                    cmeSQLRows(memSecureDB,"ROLLBACK;",NULL,NULL);
+                    cmeMemSecureDBProtectFree();
+                    return(30);
+                }
+                sqlite3_reset(updateDataMACProtectedStmt);
+                sqlite3_clear_bindings(updateDataMACProtectedStmt);
+                if (cmeSQLRows(memSecureDB,"COMMIT;",NULL,NULL))
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeSQLRows() Error, can't "
+                            "commit signProtected update transaction for data row id %s!\n",currentDataId);
+#endif
+                    cmeSQLRows(memSecureDB,"ROLLBACK;",NULL,NULL);
+                    cmeMemSecureDBProtectFree();
+                    return(30);
+                }
+#ifdef DEBUG
+                fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), stored signProtected for row id %s in table data.\n",
+                        currentDataId);
+#endif
+                cmeFree(currentDataId);
+            }
+            sqlite3_finalize(updateDataMACProtectedStmt);
+            updateDataMACProtectedStmt=NULL;
+            cmeMemTableFinal(memDataEncrypted);
+            memDataEncrypted=NULL;
         }
         // Check if protection attribute = "MAC".
         else if (!strncmp(memProtectMetaData[cont*cmeIDDColumnFileMetaNumCols+cmeIDDColumnFileMeta_attribute],
@@ -2238,13 +2414,106 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
         else if (!strncmp(currentMetaAttribute,cmeIDDColumnFileMeta_attribute_3,
                           sizeof(cmeIDDColumnFileMeta_attribute_3)))
         {
-            //TODO (OHR#5#): sign; requires userId to get certificate/private key (check issues with private key)
+            //Verify keyed signature of decrypted value against stored sign column for each data row.
+            //Re-reads current (already-decrypted) values from DB; "protect" unprotect must run first
+            //(i.e., "protect" attribute must appear before "sign" in the meta table).
+            result=cmeMemTable(memSecureDB,"SELECT * FROM data;",&memDataDecrypted,&numRowsDecrypted,&numColsDecrypted);
+            if (result) //Error
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeMemTable() Error, can't "
+                        "read 'data' table for sign verification!\n");
+#endif
+                cmeMemSecureDBUnprotectFree();
+                return(26);
+            }
+            for(cont2=1;cont2<=numRowsData;cont2++)
+            {
+                cmeStrConstrAppend(&currentDataSalt,"%s",memData[cont2*cmeIDDColumnFileDataNumCols+cmeIDDanydb_salt]);
+                cmeStrConstrAppend(&currentDataId,"%d",atoi(memDataDecrypted[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_id]));
+                result=cmeHMACByteString(
+                    (const unsigned char*)memDataDecrypted[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value],
+                    (unsigned char**)&currentEncB64Data,
+                    strlen(memDataDecrypted[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value]),
+                    &written,cmeDefaultMACAlg,&currentDataSalt,orgKey);
+                if (result) //Error
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeHMACByteString() Error, can't "
+                            "compute sign for 'value' in data row id %s with algorithm %s!\n",
+                            currentDataId,cmeDefaultMACAlg);
+#endif
+                    cmeMemSecureDBUnprotectFree();
+                    return(27);
+                }
+                if (strncmp(currentEncB64Data,
+                            memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_sign],
+                            written)) //Error: sign mismatch!
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), sign mismatch for row id %s "
+                            "in data table! Data integrity check failed.\n",currentDataId);
+#endif
+                    cmeFree(currentEncB64Data);
+                    cmeMemSecureDBUnprotectFree();
+                    return(28);
+                }
+#ifdef DEBUG
+                fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBUnprotect(), verified sign"
+                        " for 'value' in row id %s.\n",currentDataId);
+#endif
+                cmeFree(currentEncB64Data);
+                cmeFree(currentDataId);
+                cmeFree(currentDataSalt);
+            }
+            cmeMemTableFinal(memDataDecrypted);
+            memDataDecrypted=NULL;
         }
         // Check if protection attribute = "signProtected".
         else if (!strncmp(currentMetaAttribute,cmeIDDColumnFileMeta_attribute_4,
                           sizeof(cmeIDDColumnFileMeta_attribute_4)))
         {
-            //TODO (OHR#5#): signProtected; requires userId to get certificate/private key (check issues with private key)
+            //Verify keyed signature of encrypted value against stored signProtected column for each data row.
+            //Uses memData snapshot which always contains the original encrypted values taken at function start.
+            for(cont2=1;cont2<=numRowsData;cont2++)
+            {
+                cmeStrConstrAppend(&currentDataSalt,"%s",memData[cont2*cmeIDDColumnFileDataNumCols+cmeIDDanydb_salt]);
+                cmeStrConstrAppend(&currentDataId,"%d",atoi(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_id]));
+                result=cmeHMACByteString(
+                    (const unsigned char*)memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value],
+                    (unsigned char**)&currentEncB64Data,
+                    strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value]),
+                    &written,cmeDefaultMACAlg,&currentDataSalt,orgKey);
+                if (result) //Error
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeHMACByteString() Error, can't "
+                            "compute signProtected for 'value' in data row id %s with algorithm %s!\n",
+                            currentDataId,cmeDefaultMACAlg);
+#endif
+                    cmeMemSecureDBUnprotectFree();
+                    return(29);
+                }
+                if (strncmp(currentEncB64Data,
+                            memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_signProtected],
+                            written)) //Error: signProtected mismatch!
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), signProtected mismatch for row id %s "
+                            "in data table! Data integrity check failed.\n",currentDataId);
+#endif
+                    cmeFree(currentEncB64Data);
+                    cmeMemSecureDBUnprotectFree();
+                    return(30);
+                }
+#ifdef DEBUG
+                fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBUnprotect(), verified signProtected"
+                        " for 'value' in row id %s.\n",currentDataId);
+#endif
+                cmeFree(currentEncB64Data);
+                cmeFree(currentDataId);
+                cmeFree(currentDataSalt);
+            }
         }
         // Check if protection attribute = "MAC".
         else if (!strncmp(currentMetaAttribute,cmeIDDColumnFileMeta_attribute_5,

--- a/db.c
+++ b/db.c
@@ -172,7 +172,7 @@ int cmeDBClose (sqlite3 *ppDB)
 }
 
 //Based on code from: http://www.sqlite.org/backup.html
-int cmeMemDBLoadOrSave(sqlite3 *pInMemory, const char *zFilename, int isSave)
+int cmeMemDBLoadOrSaveVacuum(sqlite3 *pInMemory, const char *zFilename, int isSave, int vacuumBeforeSave)
 {
     int result=0;
     sqlite3 *pFile=NULL;
@@ -197,11 +197,23 @@ int cmeMemDBLoadOrSave(sqlite3 *pInMemory, const char *zFilename, int isSave)
         // If this is a 'load' operation (isSave==0), then data is copied
         // from the database file to database pInMemory.
         // Otherwise, data is copied from pInMemory to pFile.
-        // TODO (ANY#8#): if isSave, Vacuum mem first, then save!
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeDBMemLoadOrSave(), Opened DB file %s for "
-                "R/W successfuly. isSave: %d \n",zFilename, isSave);
+                "R/W successfuly. isSave: %d vacuumBeforeSave: %d \n",zFilename, isSave, vacuumBeforeSave);
 #endif
+        if ((isSave)&&(vacuumBeforeSave))
+        {
+            result=sqlite3_exec(pInMemory,"VACUUM;",NULL,NULL,NULL);
+            if (result)
+            {
+#ifdef ERROR_LOG
+                fprintf(stderr,"CaumeDSE Error: cmeMemDBLoadOrSaveVacuum(), sqlite3_exec() VACUUM error for memory DB before saving to '%s': %s\n",
+                        zFilename,sqlite3_errmsg(pInMemory));
+#endif
+                cmeDBClose(pFile);
+                return(2);
+            }
+        }
         pFrom = (isSave ? pInMemory : pFile);
         pTo   = (isSave ? pFile     : pInMemory);
         // Set up the backup procedure to copy from the "main" database of
@@ -216,6 +228,11 @@ int cmeMemDBLoadOrSave(sqlite3 *pInMemory, const char *zFilename, int isSave)
     }
     cmeDBClose(pFile); // Close the database connection opened on database file zFilename
     return (result);
+}
+
+int cmeMemDBLoadOrSave(sqlite3 *pInMemory, const char *zFilename, int isSave)
+{
+    return(cmeMemDBLoadOrSaveVacuum(pInMemory,zFilename,isSave,0));
 }
 
 int cmeSQLIterate (const char *args,int numCols,char **pStrResults,char **pColNames)

--- a/db.c
+++ b/db.c
@@ -2368,7 +2368,7 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
 
 int cmeProtectDBValue (const char *value, char **protectedValue, const char *encAlg, char **salt,
                        const char *orgKey, int *protectedValueLen)
-{   //TODO (OHR#2#): Replace everywhere to protect a DB value with a call to this function.
+{
     int result;
     if (value==NULL) //Error: no value to encrypt
     {
@@ -2396,7 +2396,7 @@ int cmeProtectDBValue (const char *value, char **protectedValue, const char *enc
 
 int cmeUnprotectDBValue (const char *protectedValue, char **value, const char *encAlg, char **salt,
                          const char *orgKey, int *valueLen)
-{   //TODO (OHR#2#): Replace everywhere to unprotect a DB value with a call to this function.
+{
     int result;
 
     *value=NULL;

--- a/db.c
+++ b/db.c
@@ -2702,7 +2702,7 @@ int cmeUnprotectDBValue (const char *protectedValue, char **value, const char *e
 
 int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const char *encAlg, char **salt,
                              const char *orgKey, int *protectedValueLen)
-{   // TODO (OHR#5#): Replace everywhere to salt+protect a DB value with a call to this function. Also replace unsalted versions of this function!
+{
     int result;
     char *valueSalt=NULL;
     char *saltedValue=NULL;
@@ -2723,11 +2723,11 @@ int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const cha
     }
     cmeGetRndSaltAnySize(&valueSalt,cmeDefaultValueSaltLen);  //Get random valueSalt (16 chars, 8 byte hexstring).
     cmeStrConstrAppend(&saltedValue,"%s%s",valueSalt,value);  // Append unencrypted value to valueSalt.
-    result=cmeProtectByteString(saltedValue, protectedValue, encAlg, salt,orgKey, protectedValueLen, strlen(saltedValue));
+    result=cmeProtectDBValue(saltedValue, protectedValue, encAlg, salt, orgKey, protectedValueLen);
     if (result) //Error
     {
 #ifdef ERROR_LOG
-        fprintf(stderr,"CaumeDSE Error: cmeProtectDBSaltedValue(), cmeProtectByteString() Error, can't "
+        fprintf(stderr,"CaumeDSE Error: cmeProtectDBSaltedValue(), cmeProtectDBValue() Error, can't "
                 "protect 'salted value' %s with algorithm %s!\n",saltedValue,encAlg);
 #endif
         cmeProtectDBSaltedValueFree();
@@ -2743,7 +2743,7 @@ int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const cha
 
 int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const char *encAlg, char **salt,
                                const char *orgKey, int *valueLen)
-{   // TODO (OHR#5#): Replace everywhere to unprotect+unsalt a DB value with a call to this function. Also replace unsalted versions of this function!
+{
     int result;
     char *saltedValue=NULL;
     #define cmeUnProtectDBSaltedValueFree() \
@@ -2763,13 +2763,13 @@ int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const c
         cmeUnProtectDBSaltedValueFree();
         return(0); //No error, just a warning.
     }
-    result=cmeUnprotectByteString(protectedValue, &saltedValue, encAlg, salt, orgKey, valueLen, strlen(protectedValue));
+    result=cmeUnprotectDBValue(protectedValue, &saltedValue, encAlg, salt, orgKey, valueLen);
     if (result) //Unprotect failed. Return empty string.
     {
         *valueLen=0;
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
-        fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBSaltedValue(), cmeUnprotectByteString() Warning, can't "
+        fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBSaltedValue(), cmeUnprotectDBValue() Warning, can't "
                 "unprotect 'protectedValue' %s with algorithm %s and the key %s!\n",protectedValue,encAlg,orgKey);
 #endif
     }

--- a/db.h
+++ b/db.h
@@ -56,6 +56,7 @@ int cmeDBOpen (const char *filename, sqlite3 **ppDB);
 int cmeDBClose (sqlite3 *ppDB);
 // Wrapper function for sqlite3_backup_init(), sqlite3_backup_step() and sqlite3_backup_finish()
 int cmeMemDBLoadOrSave(sqlite3 *pInMemory, const char *zFilename, int isSave);
+int cmeMemDBLoadOrSaveVacuum(sqlite3 *pInMemory, const char *zFilename, int isSave, int vacuumBeforeSave);
 // Iteration function for cmeSQLRows that wrapps cmePerlParserScriptFunction()
 int cmeSQLIterate (const char *args,int numCols,char **pStrResults,char **pColNames);
 // Wrapper function for sqlite3_exec() and cmeSQLIterate ()

--- a/engine_admin.c
+++ b/engine_admin.c
@@ -887,8 +887,12 @@ int cmeWebServiceInitAdminSetup (const char *orgKey)
                                 "contentRows","contentColumns","dbNames","dbTables","tableRows","tableColumns",
                                 "organizations","storage","documentTypes","engineCommands","transactions","meta",
                                 "filterWhitelist","filterBlacklist"}; //Note: also    const char *tableNames[]=...
-    const char *columnNamesToMatch[2]={"userResourceId","orgResourceId"};
-    const char *columnNames[10]={"_get","_post","_put","_delete","_head","_options","userResourceId","orgResourceId","userId","orgId"};
+    const char *columnNamesToMatch[2]={cmeIDDRolesDBAnyTable_userResourceId_name,cmeIDDRolesDBAnyTable_orgResourceId_name};
+    const char *columnNames[10]={cmeIDDRolesDBAnyTable__get_name,cmeIDDRolesDBAnyTable__post_name,
+                                 cmeIDDRolesDBAnyTable__put_name,cmeIDDRolesDBAnyTable__delete_name,
+                                 cmeIDDRolesDBAnyTable__head_name,cmeIDDRolesDBAnyTable__options_name,
+                                 cmeIDDRolesDBAnyTable_userResourceId_name,cmeIDDRolesDBAnyTable_orgResourceId_name,
+                                 cmeIDDanydb_userId_name,cmeIDDanydb_orgId_name};
     char *columnValues[10]={"1","1","1","1","1","1",NULL,NULL,NULL,NULL};
     char *columnValuesFWL[10]={".*",".*",".*",".*",".*",".*",NULL,NULL,NULL,NULL};
     char *columnValuesFBL[10]={"","","","","","",NULL,NULL,NULL,NULL};
@@ -1186,9 +1190,13 @@ int cmeWebServiceInitOrgSetup (const char *orgKey)
     int numResultRegisterCols=0;
     int numResultRegisters=0;
     const int numColumns=cmeIDDResourcesDBOrganizationsNumCols-2;       //Constant: number of columns in table, ignoring id & salt
-    const char *tableName="organizations";
-    const char *columnNamesToMatch[1]={"orgResourceId"};
-    const char *columnNames[6]={"resourceInfo","certificate","publicKey","orgResourceId","userId","orgId"};
+    const char *tableName=cmeIDDResourcesDBOrganizationsTableName;
+    const char *columnNamesToMatch[1]={cmeIDDResourcesDBOrganizations_orgResourceId_name};
+    const char *columnNames[6]={cmeIDDResourcesDBOrganizations_resourceInfo_name,
+                                cmeIDDResourcesDBOrganizations_certificate_name,
+                                cmeIDDResourcesDBOrganizations_publicKey_name,
+                                cmeIDDResourcesDBOrganizations_orgResourceId_name,
+                                cmeIDDanydb_userId_name,cmeIDDanydb_orgId_name};
     char *columnValues[6]={NULL,NULL,NULL,NULL,NULL,NULL};
     char *columnValuesToMatch[1]={NULL};
     sqlite3 *pDB=NULL;
@@ -1276,9 +1284,13 @@ int cmeWebServiceInitStorageSetup (const char *orgKey)
     int numResultRegisterCols=0;
     int numResultRegisters=0;
     const int numColumns=cmeIDDResourcesDBStorageNumCols-2;       //Constant: number of columns in table, ignoring id & salt
-    const char *tableName="storage";
-    const char *columnNamesToMatch[2]={"storageId","orgResourceId"};
-    const char *columnNames[10]={"resourceInfo","location","type","storageId","accessPath","accessUser","accessPassword","orgResourceId","userId","orgId"};
+    const char *tableName=cmeIDDResourcesDBStorageTableName;
+    const char *columnNamesToMatch[2]={cmeIDDResourcesDBStorage_storageId_name,cmeIDDResourcesDBStorage_orgResourceId_name};
+    const char *columnNames[10]={cmeIDDResourcesDBStorage_resourceInfo_name,cmeIDDResourcesDBStorage_location_name,
+                                 cmeIDDResourcesDBStorage_type_name,cmeIDDResourcesDBStorage_storageId_name,
+                                 cmeIDDResourcesDBStorage_accessPath_name,cmeIDDResourcesDBStorage_accessUser_name,
+                                 cmeIDDResourcesDBStorage_accessPassword_name,cmeIDDResourcesDBStorage_orgResourceId_name,
+                                 cmeIDDanydb_userId_name,cmeIDDanydb_orgId_name};
     char *columnValues[10]={NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL};
     char *columnValuesToMatch[2]={NULL,NULL};
     sqlite3 *pDB=NULL;
@@ -1371,9 +1383,13 @@ int cmeWebServiceInitAdminIdSetup (const char *orgKey)
     int numResultRegisterCols=0;
     int numResultRegisters=0;
     const int numColumns=cmeIDDResourcesDBUsersNumCols-2;       //Constant: number of columns in table, ignoring id & salt
-    const char *tableName="users";
-    const char *columnNamesToMatch[2]={"userResourceId","orgResourceId"};
-    const char *columnNames[10]={"resourceInfo","certificate","publicKey","userResourceId","basicAuthPwdHash","oauthConsumerKey","oauthConsumerSecret","orgResourceId","userId","orgId"};
+    const char *tableName=cmeIDDResourcesDBUsersTableName;
+    const char *columnNamesToMatch[2]={cmeIDDResourcesDBUsers_userResourceId_name,cmeIDDResourcesDBUsers_orgResourceId_name};
+    const char *columnNames[10]={cmeIDDResourcesDBUsers_resourceInfo_name,cmeIDDResourcesDBUsers_certificate_name,
+                                 cmeIDDResourcesDBUsers_publicKey_name,cmeIDDResourcesDBUsers_userResourceId_name,
+                                 cmeIDDResourcesDBUsers_basicAuthPwdHash_name,cmeIDDResourcesDBUsers_oauthConsumerKey_name,
+                                 cmeIDDResourcesDBUsers_oauthConsumerSecret_name,cmeIDDResourcesDBUsers_orgResourceId_name,
+                                 cmeIDDanydb_userId_name,cmeIDDanydb_orgId_name};
     char *columnValues[10]={NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL};
     char *columnValuesToMatch[2]={NULL,NULL};
     sqlite3 *pDB=NULL;

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -289,12 +289,7 @@ int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *do
             colSQLDBfSalts[dbNumCols]=NULL;
             memFilePartsMACs[dbNumCols]=NULL;
         }
-        //TODO (OHR#2#): EVERYWHERE - Research memset() replacement to ensure delete with volatile; assess mlock ().
-        if (currentDocumentId)
-        {
-            memset(currentDocumentId,0,strlen(currentDocumentId));   //WIPING SENSITIVE DATA IN MEMORY AFTER USE!
-        }
-        cmeFree(currentDocumentId);
+        cmeSecureFreeStr(currentDocumentId);
     }
     for (cont=0;cont<dbNumCols;cont++) //Load protected columns
     {
@@ -532,7 +527,7 @@ int cmeDeleteSecureDB (sqlite3 *pResourcesDB,const char *documentId, const char 
                     colsSQLDBIds[dbNumCols]=atoi(queryResult[cont*numCols]+cmeIDDanydb_id);     //Store register ID; register will be deleted from resourcesDB index. Santized with atoi().
                     dbNumCols++;
                 }
-                memset(currentDocumentId,0,written);   //WIPING SENSITIVE DATA IN MEMORY AFTER USE!
+                cmeSecureMemClear(currentDocumentId,written);
                 cmeFree(currentDocumentId);
             }
             else //MAC is incorrect; skip decryption process.
@@ -1562,12 +1557,7 @@ int cmeExistsDocumentId (sqlite3 *pResourcesDB,const char *documentId, const cha
         {
             (*numEntries)++;
         }
-        //TODO (OHR#2#): EVERYWHERE - Research memset() replacement to ensure delete with volatile; assess mlock ().
-        if (currentDocumentId)
-        {
-            memset(currentDocumentId,0,strlen(currentDocumentId));   //WIPING SENSITIVE DATA IN MEMORY AFTER USE!
-        }
-        cmeFree(currentDocumentId);
+        cmeSecureFreeStr(currentDocumentId);
     }
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Warning: cmeExistsDocumentId(), Finished search for documentId '%s'; "

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -49,6 +49,12 @@ static const char *cmeResourcesDBDocumentLookupColumnForMatch (const char *colum
 static int cmeBuildProtectedDBSelectQuery (sqlite3 *pDB, char **query, const char *tableName, const char **columnNames,
                                            const char **columnValues, const int numColumnValues,
                                            const char *orgKey);
+static int cmeIsValidProtectedDBSalt (const char *salt);
+
+static int cmeIsValidProtectedDBSalt (const char *salt)
+{
+    return(salt && strlen(salt)==(evpSaltBufferSize*2) && cmeIsHexString(salt));
+}
 
 int cmeSecureDBToMemDB (sqlite3 **resultDB, sqlite3 *pResourcesDB,const char *documentId,
                         const char *orgKey, const char *storagePath)
@@ -1023,11 +1029,19 @@ int cmePostProtectDBRegister (sqlite3 *pDB, const char *tableName, const char **
             cmePostProtectDBRegisterFree();
             return(1);
         }
-        if (!strcmp(columnNames[cont],"salt")) //Salt provided? yes -> use it and append at the end.
+        if (!strcmp(columnNames[cont],cmeIDDanydb_salt_name)) //Salt provided? yes -> use it and append at the end.
         {
             if (columnValues[cont]) //user provided value; else use NULL
             {
-                //TODO (OHR#3#): verify salt requirements. If bad, ERROR!
+                if (!cmeIsValidProtectedDBSalt(columnValues[cont]))
+                {
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmePostProtectDBRegister(), invalid salt at columnValues[%d]; "
+                            "expected %d hex characters.\n",cont,evpSaltBufferSize*2);
+#endif
+                    cmePostProtectDBRegisterFree();
+                    return(1);
+                }
                 cmeStrConstrAppend(&salt,"%s",columnValues[cont]);
             }
         }
@@ -1036,10 +1050,10 @@ int cmePostProtectDBRegister (sqlite3 *pDB, const char *tableName, const char **
             cmeStrConstrAppend(&sqlStatement,",\"%s\"",columnNames[cont]); //add column.
         }
     }
-    cmeStrConstrAppend (&sqlStatement,",salt) VALUES (NULL"); //Second part. id=NULL goes by default.
+    cmeStrConstrAppend (&sqlStatement,"," cmeIDDanydb_salt_name ") VALUES (NULL"); //Second part. id=NULL goes by default.
     for (cont=0; cont<numColumnValues; cont++)
     {
-        if (strcmp(columnNames[cont],"salt")!=0)
+        if (strcmp(columnNames[cont],cmeIDDanydb_salt_name)!=0)
         {
             cmeStrConstrAppend(&sqlStatement,",?");
         }
@@ -1066,7 +1080,7 @@ int cmePostProtectDBRegister (sqlite3 *pDB, const char *tableName, const char **
     }
     for (cont=0; cont<numColumnValues; cont++)
     {
-        if (strcmp(columnNames[cont],"salt")!=0) //Skip salt, we will add it at the end.
+        if (strcmp(columnNames[cont],cmeIDDanydb_salt_name)!=0) //Skip salt, we will add it at the end.
         {
             if (columnValues[cont]!=NULL)
             {

--- a/filehandling.c
+++ b/filehandling.c
@@ -1470,13 +1470,73 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
     }
 }
 
+static int cmeFileOverwritePass(FILE *fp, long int fileLen, int pass)
+{
+    int result;
+    long int written=0;
+    size_t chunkLen;
+    unsigned char overwriteBuffer[cmeSecureOverwriteBufferSize];
+    unsigned char *randomBytes=NULL;
+
+    result=fseek(fp,0,SEEK_SET);
+    if (result)
+    {
+        return(1);
+    }
+    while (written<fileLen)
+    {
+        chunkLen=(size_t)(((fileLen-written)>cmeSecureOverwriteBufferSize)?
+                          cmeSecureOverwriteBufferSize:(fileLen-written));
+        if ((pass%3)==1)
+        {
+            memset(overwriteBuffer,0xFF,chunkLen);
+        }
+        else if ((pass%3)==2)
+        {
+            randomBytes=NULL;
+            result=cmePrngGetBytes(&randomBytes,(int)chunkLen);
+            if ((result)||(!randomBytes))
+            {
+                cmeFree(randomBytes);
+                return(2);
+            }
+            memcpy(overwriteBuffer,randomBytes,chunkLen);
+            cmeFree(randomBytes);
+        }
+        else
+        {
+            memset(overwriteBuffer,0,chunkLen);
+        }
+        if (fwrite(overwriteBuffer,1,chunkLen,fp)!=chunkLen)
+        {
+            return(3);
+        }
+        written+=(long int)chunkLen;
+    }
+    if (fflush(fp))
+    {
+        return(4);
+    }
+    if (fsync(fileno(fp)))
+    {
+        return(5);
+    }
+    return(0);
+}
+
 int cmeFileOverwriteAndDelete (const char *filePath)
 {
     int result;
-    long int cont,fileLen;
+    int pass;
+    int numPasses=CDSE_SECURE_OVERWRITE_PASSES;
+    long int fileLen;
     FILE *fp=NULL;
 
-    fp=fopen(filePath,"w");
+    if (numPasses<1)
+    {
+        numPasses=1;
+    }
+    fp=fopen(filePath,"r+b");
     if(!fp) //Error
     {
 #ifdef DEBUG
@@ -1494,10 +1554,26 @@ int cmeFileOverwriteAndDelete (const char *filePath)
         return(2);
     }
     fileLen=ftell(fp);
-    result=fseek(fp,0,SEEK_SET); //Go to Start of File
-    for (cont=0; cont<fileLen; cont++)
+    if (fileLen<0)
     {
-        result=fputc((int)'0',fp);
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeFileOverwriteAndDelete(), ftell() Error!\n");
+#endif
+        fclose(fp);
+        return(4);
+    }
+    for (pass=0;pass<numPasses;pass++)
+    {
+        result=cmeFileOverwritePass(fp,fileLen,pass);
+        if (result)
+        {
+#ifdef ERROR_LOG
+            fprintf(stderr,"CaumeDSE Error: cmeFileOverwriteAndDelete(), overwrite pass %d error %d for file '%s'!\n",
+                    pass,result,filePath);
+#endif
+            fclose(fp);
+            return(5);
+        }
     }
     fclose(fp);
     result=remove(filePath);
@@ -1510,8 +1586,8 @@ int cmeFileOverwriteAndDelete (const char *filePath)
         return(3);
     }
 #ifdef DEBUG
-        fprintf(stderr,"CaumeDSE Debug: cmeFileOverwriteAndDelete(), file '%s' of length %ld overwritten and deleted.\n",
-                filePath,fileLen);
+        fprintf(stderr,"CaumeDSE Debug: cmeFileOverwriteAndDelete(), file '%s' of length %ld overwritten with %d pass(es) and deleted.\n",
+                filePath,fileLen,numPasses);
 #endif
     return(0);
 }

--- a/filehandling.c
+++ b/filehandling.c
@@ -638,7 +638,7 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
         for (cont=0;cont<(*numCols);cont++)
         {
             colNames[cont]=NULL;    //Set all ptrs. to NULL as required by cmeStrConstrAppend().
-            if(!strcmp(elements[cont],"id")) //Found column named "id"!
+            if(!strcmp(elements[cont],cmeIDDanydb_id_name)) //Found column named "id"!
             {
                 cmeStrConstrAppend(&(colNames[cont]),"_id"); //"id" name is reserved for internal databases; so we change it!
             }
@@ -686,11 +686,17 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
                     cmeCSVFileToSecureDBFree();
                     return(7);
                 }
-                cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE data "
-                                    "(id INTEGER PRIMARY KEY, userId TEXT, orgId TEXT, salt TEXT,"
-                                    " value TEXT, rowOrder TEXT, MAC TEXT, sign TEXT, MACProtected TEXT,"
-                                    " signProtected TEXT, otphDkey TEXT);"
-                                    "CREATE INDEX idx_data_user_org ON data(userId,orgId,rowOrder);"
+                cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE " cmeIDDColumnFileDataTableName " "
+                                    "(" cmeIDDanydb_id_name " INTEGER PRIMARY KEY, " cmeIDDanydb_userId_name " TEXT, "
+                                    cmeIDDanydb_orgId_name " TEXT, " cmeIDDanydb_salt_name " TEXT, "
+                                    cmeIDDColumnFileData_value_name " TEXT, " cmeIDDColumnFileData_rowOrder_name " TEXT, "
+                                    cmeIDDColumnFileData_MAC_name " TEXT, " cmeIDDColumnFileData_sign_name " TEXT, "
+                                    cmeIDDColumnFileData_MACProtected_name " TEXT, "
+                                    cmeIDDColumnFileData_signProtected_name " TEXT, "
+                                    cmeIDDColumnFileData_otphDKey_name " TEXT);"
+                                    "CREATE INDEX idx_data_user_org ON " cmeIDDColumnFileDataTableName
+                                    "(" cmeIDDanydb_userId_name "," cmeIDDanydb_orgId_name ","
+                                    cmeIDDColumnFileData_rowOrder_name ");"
                                     "COMMIT;");
                 if (cmeSQLRows((ppDB[cont]),sqlQuery,NULL,NULL)) //Create a table 'data'.
                 {
@@ -702,10 +708,13 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
                     return(9);
                 }
                 cmeFree(sqlQuery);  //Free memory that was used for queries.
-                cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE meta "
-                                    "(id INTEGER PRIMARY KEY, userId TEXT, orgID TEXT, salt TEXT,"
-                                    " attribute TEXT, attributeData TEXT);"
-                                    "CREATE INDEX idx_meta_user_attr ON meta(userId,attribute);"
+                cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE " cmeIDDColumnFileMetaTableName " "
+                                    "(" cmeIDDanydb_id_name " INTEGER PRIMARY KEY, " cmeIDDanydb_userId_name " TEXT, "
+                                    cmeIDDanydb_orgId_name " TEXT, " cmeIDDanydb_salt_name " TEXT, "
+                                    cmeIDDColumnFileMeta_attribute_name " TEXT, "
+                                    cmeIDDColumnFileMeta_attributeData_name " TEXT);"
+                                    "CREATE INDEX idx_meta_user_attr ON " cmeIDDColumnFileMetaTableName
+                                    "(" cmeIDDanydb_userId_name "," cmeIDDColumnFileMeta_attribute_name ");"
                                     "COMMIT;");
                 if (cmeSQLRows((ppDB[cont]),sqlQuery,NULL,NULL)) //Create a table 'meta'.
                 {
@@ -721,7 +730,11 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
             for (cont=0;cont<numSQLDBfNames;cont++) //Insert data into meta table.
             {   //Insert 'name' attribute.
                 result=sqlite3_prepare_v2(ppDB[cont],
-                                          "INSERT INTO meta (id,userId,orgId,salt,attribute,attributeData) "
+                                          "INSERT INTO " cmeIDDColumnFileMetaTableName " "
+                                          "(" cmeIDDanydb_id_name "," cmeIDDanydb_userId_name ","
+                                          cmeIDDanydb_orgId_name "," cmeIDDanydb_salt_name ","
+                                          cmeIDDColumnFileMeta_attribute_name ","
+                                          cmeIDDColumnFileMeta_attributeData_name ") "
                                           "VALUES (NULL,?,?,?,?,?);",
                                           -1,&insertMetaStmt,NULL);
                 if (result!=SQLITE_OK)
@@ -746,7 +759,7 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
                 result=sqlite3_bind_text(insertMetaStmt,1,userId,-1,SQLITE_TRANSIENT);
                 if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,2,orgId,-1,SQLITE_TRANSIENT);
                 if (result==SQLITE_OK) result=sqlite3_bind_null(insertMetaStmt,3);
-                if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,4,"name",-1,SQLITE_TRANSIENT);
+                if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,4,cmeIDDColumnFileMeta_attribute_0,-1,SQLITE_TRANSIENT);
                 if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,5,colNames[cont%(*numCols)],-1,SQLITE_TRANSIENT);
                 if (result==SQLITE_OK) result=sqlite3_step(insertMetaStmt);
                 if (result!=SQLITE_DONE)
@@ -811,8 +824,14 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
                     rContLimit=(cycleProcessedRows>cmeMaxCSVRowsInPart)?cmeMaxCSVRowsInPart:cycleProcessedRows;
                 }
                 result=sqlite3_prepare_v2(ppDB[(*numCols)*cont+cont2],
-                                          "INSERT INTO data "
-                                          "(id,userId,orgId,salt,value,rowOrder,MAC,sign,MACProtected,signProtected,otphDkey) "
+                                          "INSERT INTO " cmeIDDColumnFileDataTableName " "
+                                          "(" cmeIDDanydb_id_name "," cmeIDDanydb_userId_name ","
+                                          cmeIDDanydb_orgId_name "," cmeIDDanydb_salt_name ","
+                                          cmeIDDColumnFileData_value_name "," cmeIDDColumnFileData_rowOrder_name ","
+                                          cmeIDDColumnFileData_MAC_name "," cmeIDDColumnFileData_sign_name ","
+                                          cmeIDDColumnFileData_MACProtected_name ","
+                                          cmeIDDColumnFileData_signProtected_name ","
+                                          cmeIDDColumnFileData_otphDKey_name ") "
                                           "VALUES (NULL,?,?,?,?,?,?,?,?,?,?);",
                                           -1,&insertDataStmt,NULL);
                 if (result!=SQLITE_OK)
@@ -1761,7 +1780,7 @@ int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int nu
         cmeStrConstrAppend(&(colNames[cont]),"%s",memTable[cont]);
     }
     // TODO (OHR#6#): Create & call function to create DB files in memory for memTable column imports.
-    if (!strcmp(colNames[0],"id")) //id column exists; we need to skip it.
+    if (!strcmp(colNames[0],cmeIDDanydb_id_name)) //id column exists; we need to skip it.
     {
         skipIdColumn=1;
     }
@@ -1810,11 +1829,17 @@ int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int nu
                 cmeMemTableToSecureDBFree();
                 return(6);
             }
-            cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE data "
-                                "(id INTEGER PRIMARY KEY, userId TEXT, orgId TEXT, salt TEXT,"
-                                " value TEXT, rowOrder TEXT, MAC TEXT, sign TEXT, MACProtected TEXT,"
-                                " signProtected TEXT, otphDkey TEXT);"
-                                "CREATE INDEX idx_data_user_org ON data(userId,orgId,rowOrder);"
+            cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE " cmeIDDColumnFileDataTableName " "
+                                "(" cmeIDDanydb_id_name " INTEGER PRIMARY KEY, " cmeIDDanydb_userId_name " TEXT, "
+                                cmeIDDanydb_orgId_name " TEXT, " cmeIDDanydb_salt_name " TEXT, "
+                                cmeIDDColumnFileData_value_name " TEXT, " cmeIDDColumnFileData_rowOrder_name " TEXT, "
+                                cmeIDDColumnFileData_MAC_name " TEXT, " cmeIDDColumnFileData_sign_name " TEXT, "
+                                cmeIDDColumnFileData_MACProtected_name " TEXT, "
+                                cmeIDDColumnFileData_signProtected_name " TEXT, "
+                                cmeIDDColumnFileData_otphDKey_name " TEXT);"
+                                "CREATE INDEX idx_data_user_org ON " cmeIDDColumnFileDataTableName
+                                "(" cmeIDDanydb_userId_name "," cmeIDDanydb_orgId_name ","
+                                cmeIDDColumnFileData_rowOrder_name ");"
                                 "COMMIT;");
             if (cmeSQLRows((ppDB[cont]),sqlQuery,NULL,NULL)) //Create a table 'data'.
             {
@@ -1826,10 +1851,13 @@ int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int nu
                 return(7);
             }
             cmeFree(sqlQuery);  //Free memory that was used for queries.
-            cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE meta "
-                                "(id INTEGER PRIMARY KEY, userId TEXT, orgID TEXT, salt TEXT,"
-                                " attribute TEXT, attributeData TEXT);"
-                                "CREATE INDEX idx_meta_user_attr ON meta(userId,attribute);"
+            cmeStrConstrAppend(&sqlQuery,"BEGIN TRANSACTION; CREATE TABLE " cmeIDDColumnFileMetaTableName " "
+                                "(" cmeIDDanydb_id_name " INTEGER PRIMARY KEY, " cmeIDDanydb_userId_name " TEXT, "
+                                cmeIDDanydb_orgId_name " TEXT, " cmeIDDanydb_salt_name " TEXT, "
+                                cmeIDDColumnFileMeta_attribute_name " TEXT, "
+                                cmeIDDColumnFileMeta_attributeData_name " TEXT);"
+                                "CREATE INDEX idx_meta_user_attr ON " cmeIDDColumnFileMetaTableName
+                                "(" cmeIDDanydb_userId_name "," cmeIDDColumnFileMeta_attribute_name ");"
                                 "COMMIT;");
             if (cmeSQLRows((ppDB[cont]),sqlQuery,NULL,NULL)) //Create a table 'meta'.
             {
@@ -1845,7 +1873,11 @@ int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int nu
         for (cont=0;cont<numSQLDBfNames;cont++) //Insert data into meta table.
         {   //Insert 'name' attribute.
             result=sqlite3_prepare_v2(ppDB[cont],
-                                      "INSERT INTO meta (id,userId,orgId,salt,attribute,attributeData) "
+                                      "INSERT INTO " cmeIDDColumnFileMetaTableName " "
+                                      "(" cmeIDDanydb_id_name "," cmeIDDanydb_userId_name ","
+                                      cmeIDDanydb_orgId_name "," cmeIDDanydb_salt_name ","
+                                      cmeIDDColumnFileMeta_attribute_name ","
+                                      cmeIDDColumnFileMeta_attributeData_name ") "
                                       "VALUES (NULL,?,?,?,?,?);",
                                       -1,&insertMetaStmt,NULL);
             if (result!=SQLITE_OK)
@@ -1870,7 +1902,7 @@ int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int nu
             result=sqlite3_bind_text(insertMetaStmt,1,userId,-1,SQLITE_TRANSIENT);
             if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,2,orgId,-1,SQLITE_TRANSIENT);
             if (result==SQLITE_OK) result=sqlite3_bind_null(insertMetaStmt,3);
-            if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,4,"name",-1,SQLITE_TRANSIENT);
+            if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,4,cmeIDDColumnFileMeta_attribute_0,-1,SQLITE_TRANSIENT);
             if (result==SQLITE_OK) result=sqlite3_bind_text(insertMetaStmt,5,colNames[(cont%(numCols-skipIdColumn))+skipIdColumn],-1,SQLITE_TRANSIENT);
             if (result==SQLITE_OK) result=sqlite3_step(insertMetaStmt);
             if (result!=SQLITE_DONE)
@@ -1935,8 +1967,14 @@ int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int nu
                 rContLimit=(numRows>cmeMaxCSVRowsInPart)?cmeMaxCSVRowsInPart:numRows;
             }
             result=sqlite3_prepare_v2(ppDB[(numCols-skipIdColumn)*cont+cont2-skipIdColumn],
-                                      "INSERT INTO data "
-                                      "(id,userId,orgId,salt,value,rowOrder,MAC,sign,MACProtected,signProtected,otphDkey) "
+                                      "INSERT INTO " cmeIDDColumnFileDataTableName " "
+                                      "(" cmeIDDanydb_id_name "," cmeIDDanydb_userId_name ","
+                                      cmeIDDanydb_orgId_name "," cmeIDDanydb_salt_name ","
+                                      cmeIDDColumnFileData_value_name "," cmeIDDColumnFileData_rowOrder_name ","
+                                      cmeIDDColumnFileData_MAC_name "," cmeIDDColumnFileData_sign_name ","
+                                      cmeIDDColumnFileData_MACProtected_name ","
+                                      cmeIDDColumnFileData_signProtected_name ","
+                                      cmeIDDColumnFileData_otphDKey_name ") "
                                       "VALUES (NULL,?,?,?,?,?,?,?,?,?,?);",
                                       -1,&insertDataStmt,NULL);
             if (result!=SQLITE_OK)

--- a/filehandling.c
+++ b/filehandling.c
@@ -479,6 +479,7 @@ int cmeWriteStrToFile (char *pSrcStr, const char *filePath, int srcStrLen)
 int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCols,int *processedRows,
                           const char *userId,const char *orgId,const char *orgKey, const char **attribute,
                           const char **attributeData, const int numAttribute,const int replaceDB,
+                          const int vacuumDB,
                           const char *resourceInfo, const char *documentType, const char *documentId,
                           const char *storageId, const char *storagePath)
 {
@@ -900,21 +901,19 @@ int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCol
         if (numAttribute)  //If security attributes are defined, override corresponding defaults.
         {
             result=cmeMemSecureDBProtect(ppDB[cont],orgKey);
-            cmeStrConstrAppend(&sqlQuery,"VACUUM;"); //Reconstruct DB without slack space w/ unprotected data!
-            if (cmeSQLRows((ppDB[cont]),sqlQuery,NULL,NULL)) //Vacuum DB col.
+            if (result)
             {
 #ifdef ERROR_LOG
-                fprintf(stderr,"CaumeDSE Error: cmeCVSFileToSecureSQL(), cmeSQLRows() Error, can't "
-                        "VACUUM DB file %d: %s!\n",cont,SQLDBfNames[cont]);
+                fprintf(stderr,"CaumeDSE Error: cmeCVSFileToSecureSQL(), cmeMemSecureDBProtect() Error, can't "
+                        "protect DB file %d: %s!\n",cont,SQLDBfNames[cont]);
 #endif
                 cmeCSVFileToSecureDBFree();
                 return(14);
             }
-            cmeFree(sqlQuery);  //Free memory that was used for queries.
         }
         cmeFree(bkpFName);
         cmeStrConstrAppend(&bkpFName,"%s%s",storagePath,SQLDBfNames[cont]);
-        result=cmeMemDBLoadOrSave(ppDB[cont],bkpFName,1);
+        result=cmeMemDBLoadOrSaveVacuum(ppDB[cont],bkpFName,1,((numAttribute)||(vacuumDB)));
         if (result)
         {
 #ifdef ERROR_LOG
@@ -1622,9 +1621,10 @@ void cmeContentReaderFreeCallback (void *cls)
         fprintf(stdout,"CaumeDSE Debug: cmeContentReaderFreeCallback(), file closed successfully; end of ContentReaderCallback.\n");
 #endif
 }
-int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int numRows,
+int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int numRows,
                            const char *userId,const char *orgId,const char *orgKey, const char **attribute,
                            const char **attributeData, const int numAttribute, const int replaceDB,
+                           const int vacuumDB,
                            const char *resourceInfo, const char *documentType, const char *documentId,
                            const char *storageId, const char *storagePath)
 {
@@ -2019,21 +2019,19 @@ void cmeContentReaderFreeCallback (void *cls)
         if (numAttribute)  //If security attributes are defined, override corresponding defaults.
         {
             result=cmeMemSecureDBProtect(ppDB[cont],orgKey);
-            cmeStrConstrAppend(&sqlQuery,"VACUUM;"); //Reconstruct DB without slack space w/ unprotected data!
-            if (cmeSQLRows((ppDB[cont]),sqlQuery,NULL,NULL)) //Vacuum DB col.
+            if (result)
             {
 #ifdef ERROR_LOG
-                fprintf(stderr,"CaumeDSE Error: cmeMemTableToSecureDB(), cmeSQLRows() Error, can't "
-                        "VACUUM DB file %d: %s!\n",cont,SQLDBfNames[cont]);
+                fprintf(stderr,"CaumeDSE Error: cmeMemTableToSecureDB(), cmeMemSecureDBProtect() Error, can't "
+                        "protect DB file %d: %s!\n",cont,SQLDBfNames[cont]);
 #endif
                 cmeMemTableToSecureDBFree();
                 return(11);
             }
-            cmeFree(sqlQuery);  //Free memory that was used for queries.
         }
         cmeFree(bkpFName);
         cmeStrConstrAppend(&bkpFName,"%s%s",storagePath,SQLDBfNames[cont]);
-        result=cmeMemDBLoadOrSave(ppDB[cont],bkpFName,1);
+        result=cmeMemDBLoadOrSaveVacuum(ppDB[cont],bkpFName,1,((numAttribute)||(vacuumDB)));
         if (result)
         {
 #ifdef ERROR_LOG

--- a/filehandling.h
+++ b/filehandling.h
@@ -61,12 +61,14 @@ int cmeWriteStrToFile (char *pSrcStr, const char *filePath, int srcStrLen);
 int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCols,int *processedRows,
                           const char *userId,const char *orgId,const char *orgKey, const char **attribute,
                           const char **attributeData, const int numAttribute,const int replaceDB,
+                          const int vacuumDB,
                           const char *resourceInfo, const char *documentType, const char *documentId,
                           const char *storageId, const char *storagePath);
 // Function that imports a memory table into several, security preprocessed, SQLite Databases (e.g. after inserting/updating a contentRow).
 int cmeMemTableToSecureDB (const char **memTable, const int numCols,const int numRows,
                            const char *userId,const char *orgId,const char *orgKey, const char **attribute,
                            const char **attributeData, const int numAttribute, const int replaceDB,
+                           const int vacuumDB,
                            const char *resourceInfo, const char *documentType, const char *documentId,
                            const char *storageId, const char *storagePath);
 // Function that slices and encrypts a raw file into several parts.

--- a/filehandling.h
+++ b/filehandling.h
@@ -79,8 +79,8 @@ int cmeRAWFileToSecureFile (const char *rawFileName, const char *userId,const ch
 int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const char *documentId,
                                const char *documentType, const char *documentPath, const char *orgId,
                                const char *storageId, const char *orgKey);
-// Function to overwrite and delete a file (meant for Temporal files in restricted/memory storage.
-// TODO (ANY#3#): Check and apply the appropriate kind of secure deletion mechanism.
+// Function to overwrite and delete a file (meant for temporal files in restricted/memory storage).
+// Define CDSE_SECURE_OVERWRITE_PASSES at compile time to use multiple overwrite passes.
 int cmeFileOverwriteAndDelete (const char *filePath);
 // Function to process callback iterations from MHD_create_response_from_callback (libmicrohttpd).
 ssize_t cmeContentReaderCallback (void *cls, uint64_t pos, char *buf, size_t max);

--- a/function_tests.c
+++ b/function_tests.c
@@ -565,8 +565,8 @@ void testCSV ()
     char **pQueryResult2=NULL;
     const char *attributes[]={"shuffle","protect"};
     const char *attributesData[]={cmeDefaultEncAlg,cmeDefaultEncAlg};
-    const char *attributesMAC[]={"protect","MAC","MACProtected"};
-    const char *attributesMACData[]={cmeDefaultEncAlg,cmeDefaultMACAlg,cmeDefaultMACAlg};
+    const char *attributesMAC[]={"protect","sign","signProtected","MAC","MACProtected"};
+    const char *attributesMACData[]={cmeDefaultEncAlg,cmeDefaultMACAlg,cmeDefaultMACAlg,cmeDefaultMACAlg,cmeDefaultMACAlg};
     sqlite3 *resultDB=NULL;
     sqlite3 *pResourcesDB=NULL;
 
@@ -676,11 +676,11 @@ void testCSV ()
     resultDB=NULL;
     //result=cmeDeleteSecureDB(pResourcesDB,"AcmeIncPayroll Tests.csv", "password2",cmeDefaultFilePath);
 
-    // Test "protect","MAC","MACProtected" column attributes: protect data, compute plaintext MAC
-    // and post-encryption MACProtected, then verify integrity on retrieval.
+    // Test integrity attributes: protect data, compute plaintext and protected signatures/MACs,
+    // then verify integrity on retrieval.
     printf("\n--- Testing MAC and MACProtected column attributes:\n");
     result=cmeCSVFileToSecureDB(fName,1,&numCols,&processedRows,"User123","CaumeDSE",
-                                "password3",attributesMAC,attributesMACData,3,1,0,
+                                "password3",attributesMAC,attributesMACData,5,1,0,
                                 "Payroll Database MAC Test.",
                                 "file.csv","AcmeIncPayrollMAC.csv","storage3",cmeDefaultFilePath);
     if (result)

--- a/function_tests.c
+++ b/function_tests.c
@@ -605,13 +605,13 @@ void testCSV ()
     }
     cmeCSVFileRowsToMemTableFinal (&elements, numCols, processedRows);
     result=cmeCSVFileToSecureDB(fName,1,&numCols,&processedRows,"User123","CaumeDSE",
-                          "password1",attributes, attributesData,2,0,"Payroll Database; Confidential.",
+                          "password1",attributes, attributesData,2,0,0,"Payroll Database; Confidential.",
                           "file.csv", "AcmeIncPayroll.csv", "storage1",cmeDefaultFilePath);
     result=cmeCSVFileToSecureDB(fName2,1,&numCols,&processedRows,"User123","CaumeDSE",
-                          "password2",attributes, attributesData,2,1,"Payroll Database 2; Tests.",
+                          "password2",attributes, attributesData,2,1,0,"Payroll Database 2; Tests.",
                           "file.csv", "AcmeIncPayroll Tests.csv","storage2",cmeDefaultFilePath);
     result=cmeCSVFileToSecureDB(fName,1,&numCols,&processedRows,"User123","CaumeDSE",
-                          "password1",attributes, attributesData,2,1,"Payroll Database; Confidential.",
+                          "password1",attributes, attributesData,2,1,0,"Payroll Database; Confidential.",
                           "file.csv", "AcmeIncPayroll.csv","storage1",cmeDefaultFilePath);
     if (cmeDBOpen(resourcesDBPath,&pResourcesDB)) //Error
     {
@@ -643,7 +643,7 @@ void testCSV ()
         return;
     }
     result=cmeMemTableToSecureDB((const char **)pQueryResult,numCols,numRows,"User123","CaumeDSE",
-                                 "password2",attributes, attributesData,2,1,"Payroll Database 2; Tests.",
+                                 "password2",attributes, attributesData,2,1,0,"Payroll Database 2; Tests.",
                                  "file.csv", "AcmeIncPayroll Tests.csv","storage2",cmeDefaultFilePath);
     cmeSecureDBToMemDB (&resultDB, pResourcesDB,"AcmeIncPayroll Tests.csv","password2",cmeDefaultFilePath);
     printf("--- Retrieved data from secure table (Memory Table to secure DB):\n");
@@ -680,7 +680,7 @@ void testCSV ()
     // and post-encryption MACProtected, then verify integrity on retrieval.
     printf("\n--- Testing MAC and MACProtected column attributes:\n");
     result=cmeCSVFileToSecureDB(fName,1,&numCols,&processedRows,"User123","CaumeDSE",
-                                "password3",attributesMAC,attributesMACData,3,1,
+                                "password3",attributesMAC,attributesMACData,3,1,0,
                                 "Payroll Database MAC Test.",
                                 "file.csv","AcmeIncPayrollMAC.csv","storage3",cmeDefaultFilePath);
     if (result)

--- a/main.c
+++ b/main.c
@@ -81,7 +81,7 @@ int setup(unsigned char **bIn,unsigned char **bOut,PerlInterpreter **myPerl)
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_ADD_ALL_CIPHERS |
                         OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
 #endif
-    cmeInitDefaultEncAlg();
+    cmeLoadConfiguration();
     return(0);
 }
 

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -6415,6 +6415,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
     int numCols=0;
     int numSecureDBAttributes=0;
     int replaceDB=0;
+    int vacuumDB=0;
     sqlite3 *pDB=NULL;
     char *orgKey=NULL;                  //requester orgKey.
     char *userId=NULL;                  //requester userId.
@@ -6511,6 +6512,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
     }
     numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
     replaceDB=cmeWebServiceGetBooleanParam(argumentElements,"replaceDB",0);
+    vacuumDB=cmeWebServiceGetBooleanParam(argumentElements,"vacuumDB",0);
     cmeStrConstrAppend(&dbFilePath,"%s%s",cmeDefaultFilePath,cmeDefaultResourcesDBName);
     if(!strcmp(method,"POST")) //Method = POST is ok, process:
     {
@@ -6630,6 +6632,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         {
                             result=cmeCSVFileToSecureDB(postImportFile,1,&numCols,&processedRows,userId,orgId,newOrgKey,  //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
                                                         attributes, attributesData,numSecureDBAttributes,replaceDB,
+                                                        vacuumDB,
                                                         resourceInfoText,
                                                         urlElements[5], //document type
                                                         urlElements[7], //documentId
@@ -6640,6 +6643,7 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                         {
                             result=cmeCSVFileToSecureDB(postImportFile,1,&numCols,&processedRows,userId,orgId,orgKey,  //This will call cmeRegisterSecureDB(); no need to call cmePostProtectDBRegister here.
                                                         attributes, attributesData,numSecureDBAttributes,replaceDB,
+                                                        vacuumDB,
                                                         resourceInfoText,
                                                         urlElements[5], //document type
                                                         urlElements[7], //documentId
@@ -9719,6 +9723,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
     int numResultRegisterCols=0;
     int numResultRegisters=0;
     int numSecureDBAttributes=0;
+    int vacuumDB=0;
     sqlite3 *pDB=NULL;
     sqlite3 *resultDB=NULL;             //Result DB for unprotected DB (before parsing)
     char *orgKey=NULL;                  //requester orgKey.
@@ -9837,6 +9842,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
         return(1);
     }
     numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
+    vacuumDB=cmeWebServiceGetBooleanParam(argumentElements,"vacuumDB",0);
     columnValues=(char **)malloc(sizeof(char *)*numColumns); //Set space to store organization resource information, columns 1 to 11 (POST/PUT).
     columnNames=(char **)malloc(sizeof(char *)*numColumns); //Set space to store organization resource information, columns 1 to 11 (POST/PUT).
     columnValuesToMatch=(char **)malloc(sizeof(char *)*numColumns); //Set space to store organization resource information, column values to match (GET/PUT).
@@ -10021,6 +10027,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
             //Create new secureDB (delete old secureDB if it exists):
             result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
                                          attributes,attributesData,numSecureDBAttributes,1,
+                                         vacuumDB,
                                          resourceInfoText,
                                          urlElements[5], //document type
                                          urlElements[7], //documentId
@@ -10201,6 +10208,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
             //Create new secureDB (delete old secureDB by using replace flag):
             result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
                                          attributes,attributesData,numSecureDBAttributes,1,
+                                         vacuumDB,
                                          resourceInfoText,
                                          urlElements[5], //document type
                                          urlElements[7], //documentId
@@ -10682,6 +10690,7 @@ int cmeWebServiceProcessContentRowResource (char **responseText, char ***respons
             //Create new secureDB (delete old secureDB by using replace flag):
             result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
                                          attributes,attributesData,numSecureDBAttributes,1,
+                                         vacuumDB,
                                          resourceInfoText,
                                          urlElements[5], //document type
                                          urlElements[7], //documentId
@@ -10803,6 +10812,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
     int numResultRegisters=0;
     int requestedColNameIDX=0;
     int numSecureDBAttributes=0;
+    int vacuumDB=0;
     sqlite3 *pDB=NULL;
     sqlite3 *resultDB=NULL;             //Result DB for unprotected DB (before parsing)
     char *orgKey=NULL;                  //requester orgKey.
@@ -10919,6 +10929,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
         return(1);
     }
     numSecureDBAttributes=cmeWebServiceBuildSecureDBAttributes(argumentElements,attributes,attributesData,2);
+    vacuumDB=cmeWebServiceGetBooleanParam(argumentElements,"vacuumDB",0);
     result=cmeSanitizeStrForSQL(urlElements[9],&sanitizedSQLStr); //Sanitize contentColumn name so that it can be used in SQL queries.
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessContentColumnResource(), Sanitized (i.e. doubled single quotes) of "
@@ -11048,6 +11059,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
                 //Create new secureDB:
                 result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
                                              attributes,attributesData,numSecureDBAttributes,1,
+                                             vacuumDB,
                                              resourceInfoText,
                                              urlElements[5], //document type
                                              urlElements[7], //documentId
@@ -11158,6 +11170,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
                 //Create new secureDB (delete old secureDB if it exists):
                 result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
                                              attributes,attributesData,numSecureDBAttributes,1,
+                                             vacuumDB,
                                              resourceInfoText,
                                              urlElements[5], //document type
                                              urlElements[7], //documentId
@@ -11915,6 +11928,7 @@ int cmeWebServiceProcessContentColumnResource (char **responseText, char ***resp
                 //Create new secureDB (delete old secureDB if it exists):
                 result=cmeMemTableToSecureDB((const char **)cmeResultMemTable,cmeResultMemTableCols,cmeResultMemTableRows,userId,orgId,orgKey,
                                              attributes,attributesData,numSecureDBAttributes,1,
+                                             vacuumDB,
                                              resourceInfoText,
                                              urlElements[5], //document type
                                              urlElements[7], //documentId

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -7414,8 +7414,6 @@ void cmeWebServiceRequestCompleted (void *cls, struct MHD_Connection *connection
 {
     #define POST            1
     int cont,result __attribute__((unused));
-    long fileSize,lcont;
-    FILE *fp=NULL;
     struct cmeWebServiceConnectionInfoStruct *con_info = *coninfo_cls;
 
 #ifdef DEBUG
@@ -7451,19 +7449,7 @@ void cmeWebServiceRequestCompleted (void *cls, struct MHD_Connection *connection
         }
         if (con_info->fileName)
         {
-            fp=fopen(con_info->fileName,"r+b"); //Reopen file for updating in binary mode.
-            if (fp)
-            {
-                fseek(fp,0,SEEK_END);
-                fileSize=ftell(fp);     //Get size of file.
-                fseek(fp,0,SEEK_SET);
-                for (lcont=0;lcont<fileSize;lcont++) //Overwrite file with 0s.
-                {   // TODO (OHR#3#): Add a conditional compiling option to replace simple overwriting with a sanitizing scheme with multiple rounds.                    fputc(0,fp);
-                }
-                fclose (fp);
-                fp=NULL;
-            }
-            result=remove(con_info->fileName); //Finally, delete the temporary file.
+            result=cmeFileOverwriteAndDelete(con_info->fileName); //Overwrite and delete the temporary file.
             cmeFree(con_info->fileName);
         }
     }

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -12046,9 +12046,20 @@ int cmeWebServiceLogRequest (const char *userId, const char *orgId, const char *
     char *salt=NULL;
     char *boundValue=NULL;
     const int numColumns=cmeIDDLogsDBTransactionsNumCols-2;       //Constant: number of columns in table, ignoring id & salt
-    const char *tableName="transactions";
-    const char *columnNames[14]={"userId","orgId","requestMethod","requestUrl","requestHeaders","startTimestamp","endTimestamp","requestDataSize",
-                                 "responseDataSize","orgResourceId","requestIPAddress","responseCode","responseHeaders","authenticated"};
+    const char *tableName=cmeIDDLogsDBTransactionsTableName;
+    const char *columnNames[14]={cmeIDDanydb_userId_name,cmeIDDanydb_orgId_name,
+                                 cmeIDDLogsDBTransactions_requestMethod_name,
+                                 cmeIDDLogsDBTransactions_requestUrl_name,
+                                 cmeIDDLogsDBTransactions_requestHeaders_name,
+                                 cmeIDDLogsDBTransactions_startTimestamp_name,
+                                 cmeIDDLogsDBTransactions_endTimestamp_name,
+                                 cmeIDDLogsDBTransactions_requestDataSize_name,
+                                 cmeIDDLogsDBTransactions_responseDataSize_name,
+                                 cmeIDDLogsDBTransactions_orgResourceId_name,
+                                 cmeIDDLogsDBTransactions_requestIPAddress_name,
+                                 cmeIDDLogsDBTransactions_responseCode_name,
+                                 cmeIDDLogsDBTransactions_responseHeaders_name,
+                                 cmeIDDLogsDBTransactions_authenticated_name};
     char *columnValues[14]={NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL};
     sqlite3 *pDB=NULL;
     char *dbFilePath=NULL;
@@ -12110,7 +12121,7 @@ int cmeWebServiceLogRequest (const char *userId, const char *orgId, const char *
         int found=0;
         for (cont=0; cont<cmeResultMemTableCols; cont++)
         {
-            if (!strcmp(cmeResultMemTable[cont],"requestMethod"))
+            if (!strcmp(cmeResultMemTable[cont],cmeIDDLogsDBTransactions_requestMethod_name))
             {
                 found=1;
                 break;
@@ -12123,12 +12134,22 @@ int cmeWebServiceLogRequest (const char *userId, const char *orgId, const char *
                                 "BEGIN TRANSACTION; DROP TABLE IF EXISTS \"%s\"; ",
                                 tableName);
             cmeStrConstrAppend(&sqlCreate,
-                                "CREATE TABLE \"%s\" (id INTEGER PRIMARY KEY, "
-                                "userId TEXT, orgId TEXT, salt TEXT, requestMethod TEXT, requestUrl TEXT, "
-                                "requestHeaders TEXT, startTimestamp TEXT, endTimestamp TEXT, requestDataSize TEXT, "
-                                "responseDataSize TEXT, orgResourceId TEXT, requestIPAddress TEXT, responseCode TEXT, "
-                                "responseHeaders TEXT, authenticated TEXT); "
-                                "CREATE INDEX \"idx_log_%s_uo\" ON \"%s\"(orgId,userId); COMMIT;",
+                                "CREATE TABLE \"%s\" (" cmeIDDanydb_id_name " INTEGER PRIMARY KEY, "
+                                cmeIDDanydb_userId_name " TEXT, " cmeIDDanydb_orgId_name " TEXT, "
+                                cmeIDDanydb_salt_name " TEXT, " cmeIDDLogsDBTransactions_requestMethod_name " TEXT, "
+                                cmeIDDLogsDBTransactions_requestUrl_name " TEXT, "
+                                cmeIDDLogsDBTransactions_requestHeaders_name " TEXT, "
+                                cmeIDDLogsDBTransactions_startTimestamp_name " TEXT, "
+                                cmeIDDLogsDBTransactions_endTimestamp_name " TEXT, "
+                                cmeIDDLogsDBTransactions_requestDataSize_name " TEXT, "
+                                cmeIDDLogsDBTransactions_responseDataSize_name " TEXT, "
+                                cmeIDDLogsDBTransactions_orgResourceId_name " TEXT, "
+                                cmeIDDLogsDBTransactions_requestIPAddress_name " TEXT, "
+                                cmeIDDLogsDBTransactions_responseCode_name " TEXT, "
+                                cmeIDDLogsDBTransactions_responseHeaders_name " TEXT, "
+                                cmeIDDLogsDBTransactions_authenticated_name " TEXT); "
+                                "CREATE INDEX \"idx_log_%s_uo\" ON \"%s\"("
+                                cmeIDDanydb_orgId_name "," cmeIDDanydb_userId_name "); COMMIT;",
                                 tableName,tableName,tableName);
             cmeSQLRows(pDB,sqlCreate,NULL,NULL);
             cmeFree(sqlCreate);
@@ -12160,10 +12181,21 @@ int cmeWebServiceLogRequest (const char *userId, const char *orgId, const char *
         }
     }
     result=sqlite3_prepare_v2(pDB,
-                              "INSERT INTO transactions "
-                              "(id,userId,orgId,requestMethod,requestUrl,requestHeaders,startTimestamp,endTimestamp,"
-                              "requestDataSize,responseDataSize,orgResourceId,requestIPAddress,responseCode,responseHeaders,"
-                              "authenticated,salt) VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
+                              "INSERT INTO " cmeIDDLogsDBTransactionsTableName " "
+                              "(" cmeIDDanydb_id_name "," cmeIDDanydb_userId_name ","
+                              cmeIDDanydb_orgId_name "," cmeIDDLogsDBTransactions_requestMethod_name ","
+                              cmeIDDLogsDBTransactions_requestUrl_name ","
+                              cmeIDDLogsDBTransactions_requestHeaders_name ","
+                              cmeIDDLogsDBTransactions_startTimestamp_name ","
+                              cmeIDDLogsDBTransactions_endTimestamp_name ","
+                              cmeIDDLogsDBTransactions_requestDataSize_name ","
+                              cmeIDDLogsDBTransactions_responseDataSize_name ","
+                              cmeIDDLogsDBTransactions_orgResourceId_name ","
+                              cmeIDDLogsDBTransactions_requestIPAddress_name ","
+                              cmeIDDLogsDBTransactions_responseCode_name ","
+                              cmeIDDLogsDBTransactions_responseHeaders_name ","
+                              cmeIDDLogsDBTransactions_authenticated_name ","
+                              cmeIDDanydb_salt_name ") VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
                               -1,&insertStmt,NULL);
     if (result!=SQLITE_OK)
     {
@@ -12185,9 +12217,9 @@ int cmeWebServiceLogRequest (const char *userId, const char *orgId, const char *
     }
     for (cont=0; cont<numColumns; cont++)
     {
-        if ((strcmp(columnNames[cont],"salt")!=0)&&(columnValues[cont]!=NULL)) //Skip salt, we will add it at the end.
+        if ((strcmp(columnNames[cont],cmeIDDanydb_salt_name)!=0)&&(columnValues[cont]!=NULL)) //Skip salt, we will add it at the end.
         {
-            if((!strcmp(columnNames[cont],"authenticated"))||(authenticationFlag==0)) //We don't encrypt the authentication flag, or any field if the authentication flag is 0.
+            if((!strcmp(columnNames[cont],cmeIDDLogsDBTransactions_authenticated_name))||(authenticationFlag==0)) //We don't encrypt the authentication flag, or any field if the authentication flag is 0.
             {
                 result=sqlite3_bind_text(insertStmt,cont+1,columnValues[cont],-1,SQLITE_TRANSIENT);
             }
@@ -12442,13 +12474,23 @@ int cmeWebServiceProcessTransactionClass (char **responseText, char ***responseH
     char **columnNamesToMatch=NULL;     //Names of columns for values to match a register (GET/PUT)
     char *dbFilePath=NULL;
     char **resultRegisterCols=NULL;
-    const char *tableName="transactions";
+    const char *tableName=cmeIDDLogsDBTransactionsTableName;
     const int numColumns=cmeIDDLogsDBTransactionsNumCols;
     const int numValidGETALLMatch=14;    //8 parameters + NONE from URL
-    const char *validGETALLMatchColumns[14]={"_userId","_orgId","_requestMethod","_requestUrl","_requestHeaders",
-                                            "_startTimestamp","_endTimestamp","_requestDataSize","_responseDataSize",
-                                            "_orgResourceId","_requestIPAddress","_responseCode","_responseHeaders",
-                                            "_authenticated"};
+    const char *validGETALLMatchColumns[14]={cmeIDDMatchName(cmeIDDanydb_userId_name),
+                                             cmeIDDMatchName(cmeIDDanydb_orgId_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_requestMethod_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_requestUrl_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_requestHeaders_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_startTimestamp_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_endTimestamp_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_requestDataSize_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_responseDataSize_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_orgResourceId_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_requestIPAddress_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_responseCode_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_responseHeaders_name),
+                                             cmeIDDMatchName(cmeIDDLogsDBTransactions_authenticated_name)};
     #define cmeWebServiceProcessTransactionClassFree() \
         do { \
             cmeFree(orgKey); \


### PR DESCRIPTION
## Summary

This PR completes a sequence of TODO items focused on DB value protection, runtime configuration, allocation diagnostics, IDD naming, and sensitive-data handling.

Key changes include:
- optional secure-memory DB vacuum before save
- protected DB value signing attributes and salted wrapper layering
- audited allocation wrappers for `malloc`/`realloc`
- runtime global loading from `caumedse.conf`/`CDSE_CONFIG_FILE`
- internal DB IDD name standardization for selected schema paths
- `OPENSSL_cleanse()`-based secure memory clearing helpers
- validation for caller-supplied protected DB salts

## Validation

Ran after the final TODO #49 implementation:
- `make`
- `make check`
- `TEST/run_debug_components.sh --skip-web`

Debug component result: `17 passed, 0 failed, 2 skipped`.

## Notes

Generated build/configuration artifacts are intentionally not included in the commits.