### PR TITLE
[codex] Use storage path for secure DB deletion

### DIFF
--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -561,7 +561,8 @@ check_component sqlite_thread_safety 'Testing thread safety|Thread safety test|t
 
 check_component csv_securedb_roundtrip 'CSV file to secure DB|AcmeIncPayroll.csv|Retrieved data from secure table|Omar|Pablo' "$FULL_LOG" \
     '--- Retrieved data from secure table (CSV file to secure DB):' \
-    '[10][10][Pablo][Martinez][14000.5]'
+    '[10][10][Pablo][Martinez][14000.5]' \
+    'TESTS: testCSV(), PASS: secure DB replacement removed old column files from non-default storage path.'
 
 check_component memtable_securedb_roundtrip 'Memory Table to secure DB|AcmeIncPayroll Tests.csv|Retrieved data from secure table' "$FULL_LOG" \
     '--- Retrieved data from secure table (Memory Table to secure DB):' \

--- a/TODO.md
+++ b/TODO.md
@@ -289,13 +289,14 @@
     - Batch 3: drop only the generated-artifact stash, leave unrelated older stashes untouched, and verify the worktree remains clean.
   - Done: inspected `codex-generated-verification-artifacts`, confirmed it contained only generated build/dependency outputs (`.Po`, `.o`, generated binaries, `Makefile`, `config.*`), dropped that stash, and left unrelated older stashes untouched.
 
-- [ ] #55 Use document storage paths when deleting secure DB column files.
+- [x] #55 Use document storage paths when deleting secure DB column files.
   - Source: `engine_interface.c:566`.
   - Goal: make `cmeDeleteSecureDB()` delete column files from the storage path associated with the secure document instead of assuming `cmeDefaultFilePath`.
   - Plan:
     - Batch 1: trace `cmeDeleteSecureDB()` callers and ResourcesDB document metadata to identify the authoritative storage path available during deletion.
     - Batch 2: update deletion path construction to use the provided or document-defined storage path, preserving existing local filesystem behavior and secure cleanup semantics.
     - Batch 3: add DEBUG/component coverage that creates a secure document under a non-default storage path, deletes it, and verifies ResourcesDB rows and column files are both removed.
+  - Done: `cmeDeleteSecureDB()` now builds secure column file delete paths from the supplied storage path with the previous default path as a fallback, and DEBUG component coverage verifies replacement removes old column files created under a non-default storage directory.
 
 - [x] #56 Add Python parser script support.
   - Source: `webservice_interface.c:8771`, `webservice_interface.c:9002`.

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -563,7 +563,7 @@ int cmeDeleteSecureDB (sqlite3 *pResourcesDB,const char *documentId, const char 
                 return(4);
             }
             //Delete Column Files:
-            cmeStrConstrAppend(&currentFName,"%s%s",cmeDefaultFilePath,colSQLDBfNames[cont]); // NOTE (OHR#2#): Use provided storagePath (or better yet, get it from the document defined storage) instead of using cmeDefaultFilePath
+            cmeStrConstrAppend(&currentFName,"%s%s",storagePath?storagePath:cmeDefaultFilePath,colSQLDBfNames[cont]);
             result=remove(currentFName);
             cmeFree(currentFName);
             if (result)

--- a/function_tests.c
+++ b/function_tests.c
@@ -561,9 +561,15 @@ void testCSV ()
     int numCols=0;
     int numRows=0;
     int processedRows=0;
+    int deleteNumResultRegisterCols=0;
+    int deleteNumResultRegisters=0;
+    int oldColumnFilesRemoved=1;
     char *fName=NULL;
     char *fName2=NULL;
     char *resourcesDBPath=NULL;
+    char *deleteStoragePath=NULL;
+    char **deleteResultRegisterCols=NULL;
+    char **deleteColumnFilePaths=NULL;
     char **elements=NULL;
     char **pQueryResult=NULL;
     char **pQueryResult2=NULL;
@@ -577,6 +583,8 @@ void testCSV ()
     fName=cmeTestPath("testfiles/CSVtest.csv");
     fName2=cmeTestPath("testfiles/CSVtest2.csv");
     resourcesDBPath=cmeTestPath(cmeDefaultResourcesDBName);
+    cmeStrConstrAppend(&deleteStoragePath,"%sdelete-storage/",cmeDefaultFilePath);
+    mkdir(deleteStoragePath,0700);
 
     result=cmeCSVFileRowsToMemTable (fName, &elements, &numCols, &processedRows, 0, 6, 10);
     for (cont2=0; cont2<=processedRows; cont2++)
@@ -622,6 +630,7 @@ void testCSV ()
         cmeFree(fName);
         cmeFree(fName2);
         cmeFree(resourcesDBPath);
+        cmeFree(deleteStoragePath);
         return;
     }
     cmeSecureDBToMemDB (&resultDB, pResourcesDB,"AcmeIncPayroll.csv","password1",cmeDefaultFilePath);
@@ -644,6 +653,7 @@ void testCSV ()
         cmeFree(fName);
         cmeFree(fName2);
         cmeFree(resourcesDBPath);
+        cmeFree(deleteStoragePath);
         return;
     }
     result=cmeMemTableToSecureDB((const char **)pQueryResult,numCols,numRows,"User123","CaumeDSE",
@@ -672,13 +682,98 @@ void testCSV ()
         cmeFree(fName);
         cmeFree(fName2);
         cmeFree(resourcesDBPath);
+        cmeFree(deleteStoragePath);
         return;
     }
     cmeMemTableFinal(pQueryResult);
     cmeMemTableFinal(pQueryResult2);
     cmeDBClose(resultDB);
     resultDB=NULL;
-    //result=cmeDeleteSecureDB(pResourcesDB,"AcmeIncPayroll Tests.csv", "password2",cmeDefaultFilePath);
+
+    printf("\n--- Testing secure DB delete with non-default storage path:\n");
+    result=cmeCSVFileToSecureDB(fName,1,&numCols,&processedRows,"User123","CaumeDSE",
+                                "password-delete",attributes, attributesData,2,1,0,
+                                "Delete storage path test.",
+                                "file.csv","DeleteStoragePath.csv","storage-delete",deleteStoragePath);
+    if (result)
+    {
+        printf("TESTS: testCSV(), FAIL: non-default storage setup import result=%d.\n",result);
+    }
+    else
+    {
+        const char *deleteMatchColumns[2]={"documentId","type"};
+        const char *deleteMatchValues[2]={"DeleteStoragePath.csv","file.csv"};
+        result=cmeGetUnprotectDBRegisters(pResourcesDB,"documents",deleteMatchColumns,deleteMatchValues,2,
+                                          &deleteResultRegisterCols,&deleteNumResultRegisterCols,
+                                          &deleteNumResultRegisters,"password-delete");
+        if ((result)||(!deleteNumResultRegisters))
+        {
+            printf("TESTS: testCSV(), FAIL: non-default storage setup query result=%d rows=%d.\n",
+                   result,deleteNumResultRegisters);
+        }
+        else
+        {
+            deleteColumnFilePaths=(char **)malloc(sizeof(char *)*deleteNumResultRegisters);
+            for (cont=0;cont<deleteNumResultRegisters;cont++)
+            {
+                deleteColumnFilePaths[cont]=NULL;
+                cmeStrConstrAppend(&(deleteColumnFilePaths[cont]),"%s%s",deleteStoragePath,
+                                   deleteResultRegisterCols[(cont+1)*deleteNumResultRegisterCols+
+                                                            cmeIDDResourcesDBDocuments_columnFile]);
+                if (access(deleteColumnFilePaths[cont],F_OK))
+                {
+                    oldColumnFilesRemoved=0;
+                }
+            }
+            result=cmeCSVFileToSecureDB(fName2,1,&numCols,&processedRows,"User123","CaumeDSE",
+                                        "password-delete",attributes, attributesData,2,1,0,
+                                        "Delete storage path replacement test.",
+                                        "file.csv","DeleteStoragePath.csv","storage-delete",deleteStoragePath);
+            if (result)
+            {
+                printf("TESTS: testCSV(), FAIL: non-default storage replacement import result=%d.\n",result);
+            }
+            else
+            {
+                for (cont=0;cont<deleteNumResultRegisters;cont++)
+                {
+                    if (!access(deleteColumnFilePaths[cont],F_OK))
+                    {
+                        oldColumnFilesRemoved=0;
+                    }
+                }
+                if (oldColumnFilesRemoved)
+                {
+                    printf("TESTS: testCSV(), PASS: secure DB replacement removed old column files from non-default storage path.\n");
+                }
+                else
+                {
+                    printf("TESTS: testCSV(), FAIL: secure DB replacement left old column files in non-default storage path.\n");
+                }
+            }
+        }
+    }
+    if (deleteResultRegisterCols)
+    {
+        for (cont=0;cont<deleteNumResultRegisterCols*(deleteNumResultRegisters+1);cont++)
+        {
+            cmeFree(deleteResultRegisterCols[cont]);
+        }
+        cmeFree(deleteResultRegisterCols);
+    }
+    if (deleteColumnFilePaths)
+    {
+        for (cont=0;cont<deleteNumResultRegisters;cont++)
+        {
+            if (!access(deleteColumnFilePaths[cont],F_OK))
+            {
+                cmeFileOverwriteAndDelete(deleteColumnFilePaths[cont]);
+            }
+            cmeFree(deleteColumnFilePaths[cont]);
+        }
+        cmeFree(deleteColumnFilePaths);
+    }
+    cmeDeleteSecureDB(pResourcesDB,"DeleteStoragePath.csv","password-delete",deleteStoragePath);
 
     // Test integrity attributes: protect data, compute plaintext and protected signatures/MACs,
     // then verify integrity on retrieval.
@@ -724,6 +819,7 @@ void testCSV ()
     cmeFree(fName);
     cmeFree(fName2);
     cmeFree(resourcesDBPath);
+    cmeFree(deleteStoragePath);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Update `cmeDeleteSecureDB()` so secure DB column file deletion uses the supplied storage path, with the existing default path fallback.
- Add DEBUG coverage that replaces a secure DB stored under a non-default directory and verifies the old column files are removed.
- Mark TODO #55 complete and extend the component verifier marker for the new coverage.

## Root Cause

`cmeDeleteSecureDB()` deleted column files by prefixing stored column filenames with `cmeDefaultFilePath`, so replacement/deletion flows for documents stored in another directory could leave old secure DB column files behind.

## Validation

- `TEST/run_debug_components.sh --skip-web`
- Result: `passed=28 failed=0 skipped=4`