### PR TITLE
[codex] Harden parser limits and add live coverage matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2209,7 +2209,12 @@ column, upload a `script.perl` document, and execute that parser script
 through both HTTP and HTTPS.  HTTPS uses a per-run client certificate chain
 signed by the committed test CA fixture.  `CDSE_DEBUG_TEST_TIMEOUT` controls
 the overall executable timeout and defaults to 120s.  Use `--skip-web` only
-when the local environment cannot bind test ports.
+when the local environment cannot bind test ports.  Live API runs also write
+coverage artifacts under the log directory: `live-api-coverage.csv` for
+machine-readable comparisons and `live-api-coverage.txt` for the fixed-width
+summary table.  Each row records protocol, feature name, inferred HTTP method,
+expected and actual status, curl result, marker status, elapsed time, and
+body/meta log paths.
 
 The committed test database under `TEST/testDB_opt_cdse` uses
 `0CDBB9AF76AF43BDB72E095989E612CC` as the `EngineAdmin` / `EngineOrg`

--- a/README.md
+++ b/README.md
@@ -1730,6 +1730,14 @@ This is a raw file
     succeeds. Perl scripts use the embedded Perl interpreter. Python
     scripts are executed with `python3` and receive two command-line
     arguments: an input CSV file path and an output CSV file path.
+    Python parser child processes are bounded by
+    `CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS`, and their output CSV files are
+    rejected above `CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES` before loading.
+    Parser result tables are rejected above
+    `CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS`. These limits are compile-time
+    macros with conservative defaults. Embedded Perl parser callbacks share
+    the result-table limit; hard runtime isolation for Perl requires moving
+    Perl execution out of the embedded interpreter path.
 
     Example 1)     Get parsed contents of payroll.csv file (of type
             file.csv) using script myscript.pl (of type

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -18,6 +18,10 @@ PASSED=0
 FAILED=0
 SKIPPED=0
 SUMMARY_FILE=""
+LIVE_COVERAGE_CSV=""
+LIVE_COVERAGE_TXT=""
+LIVE_LAST_STATUS=""
+LIVE_LAST_CURL_RC=""
 
 usage() {
     printf 'Usage: %s [--skip-build] [--skip-web] [--live-only] [--web-protocol=http|https|both]\n' "$0"
@@ -81,7 +85,12 @@ fi
 
 mkdir -p "$LOG_ROOT"
 SUMMARY_FILE="$LOG_ROOT/summary.txt"
+LIVE_COVERAGE_CSV="$LOG_ROOT/live-api-coverage.csv"
+LIVE_COVERAGE_TXT="$LOG_ROOT/live-api-coverage.txt"
 : > "$SUMMARY_FILE"
+printf 'protocol,feature,method,expected_status,actual_status,curl_rc,marker,status,elapsed,body,meta\n' > "$LIVE_COVERAGE_CSV"
+printf '%-7s %-32s %-7s %-8s %-8s %-7s %-6s %-8s %-7s %s\n' \
+    "proto" "feature" "method" "expect" "actual" "curl" "marker" "status" "elapsed" "logs" > "$LIVE_COVERAGE_TXT"
 
 note() {
     printf '%s\n' "$*" | tee -a "$SUMMARY_FILE"
@@ -108,6 +117,93 @@ elapsed_seconds() {
 
     now="$(date +%s)"
     printf '%ss' "$((now - start))"
+}
+
+csv_escape() {
+    local value="$1"
+    value="${value//\"/\"\"}"
+    printf '"%s"' "$value"
+}
+
+infer_live_method() {
+    local method="GET"
+    local arg
+    local prev_x=0
+
+    for arg in "$@"; do
+        if [ "$prev_x" -eq 1 ]; then
+            method="$arg"
+            prev_x=0
+            continue
+        fi
+        case "$arg" in
+            -X)
+                prev_x=1
+                ;;
+            -X*)
+                method="${arg#-X}"
+                ;;
+            --request)
+                prev_x=1
+                ;;
+            --request=*)
+                method="${arg#--request=}"
+                ;;
+            -I|--head)
+                method="HEAD"
+                ;;
+            -F|--form|-F*|--form=*)
+                if [ "$method" = "GET" ]; then
+                    method="POST"
+                fi
+                ;;
+        esac
+    done
+    printf '%s' "$method"
+}
+
+record_live_coverage() {
+    local protocol="$1"
+    local feature="$2"
+    local method="$3"
+    local expected="$4"
+    local actual="$5"
+    local curl_rc="$6"
+    local marker_status="$7"
+    local status="$8"
+    local elapsed="$9"
+    local body="${10}"
+    local meta="${11}"
+
+    {
+        csv_escape "$protocol"; printf ','
+        csv_escape "$feature"; printf ','
+        csv_escape "$method"; printf ','
+        csv_escape "$expected"; printf ','
+        csv_escape "$actual"; printf ','
+        csv_escape "$curl_rc"; printf ','
+        csv_escape "$marker_status"; printf ','
+        csv_escape "$status"; printf ','
+        csv_escape "$elapsed"; printf ','
+        csv_escape "$body"; printf ','
+        csv_escape "$meta"; printf '\n'
+    } >> "$LIVE_COVERAGE_CSV"
+
+    printf '%-7s %-32s %-7s %-8s %-8s %-7s %-6s %-8s %-7s body=%s meta=%s\n' \
+        "$protocol" "$feature" "$method" "$expected" "$actual" "$curl_rc" \
+        "$marker_status" "$status" "$elapsed" "$body" "$meta" >> "$LIVE_COVERAGE_TXT"
+}
+
+append_live_coverage_summary() {
+    if [ ! -s "$LIVE_COVERAGE_TXT" ] || [ "$(wc -l < "$LIVE_COVERAGE_TXT")" -le 1 ]; then
+        return 0
+    fi
+    note "LIVE API COVERAGE MATRIX"
+    while IFS= read -r line; do
+        note "$line"
+    done < "$LIVE_COVERAGE_TXT"
+    note "live_api_coverage_csv=$LIVE_COVERAGE_CSV"
+    note "live_api_coverage_txt=$LIVE_COVERAGE_TXT"
 }
 
 run_step() {
@@ -234,6 +330,8 @@ live_curl() {
 
     status="$(curl --silent --show-error --max-time 20 --output "$body" --write-out '%{http_code}' "$@" "$url" 2>"$meta")"
     rc=$?
+    LIVE_LAST_STATUS="$status"
+    LIVE_LAST_CURL_RC="$rc"
     printf 'name=%s\nurl=%s\nstatus=%s\ncurl_rc=%s\n' "$name" "$url" "$status" "$rc" >> "$meta"
     if [ "$rc" -ne 0 ]; then
         return 1
@@ -261,21 +359,34 @@ live_api_check() {
     shift 5
     local body="$LOG_ROOT/live_${protocol}_${feature}.body"
     local meta="$LOG_ROOT/live_${protocol}_${feature}.meta"
+    local method
     local start
+    local elapsed
 
+    method="$(infer_live_method "$@")"
     start="$(date +%s)"
 
     if ! live_curl "$protocol" "$feature" "$expected" "$url" "$@"; then
         LIVE_FLOW_FAILED=1
-        record_fail "live_${protocol}_${feature}" "expected HTTP $expected elapsed=$(elapsed_seconds "$start") body=$body meta=$meta"
+        elapsed="$(elapsed_seconds "$start")"
+        record_live_coverage "$protocol" "$feature" "$method" "$expected" "$LIVE_LAST_STATUS" "$LIVE_LAST_CURL_RC" "not_checked" "FAIL" "$elapsed" "$body" "$meta"
+        record_fail "live_${protocol}_${feature}" "expected HTTP $expected elapsed=$elapsed body=$body meta=$meta"
         return 1
     fi
     if [ -n "$marker" ] && ! check_live_body_marker "$protocol" "$feature" "$marker"; then
         LIVE_FLOW_FAILED=1
-        record_fail "live_${protocol}_${feature}" "missing marker '$marker' elapsed=$(elapsed_seconds "$start") body=$body meta=$meta"
+        elapsed="$(elapsed_seconds "$start")"
+        record_live_coverage "$protocol" "$feature" "$method" "$expected" "$LIVE_LAST_STATUS" "$LIVE_LAST_CURL_RC" "missing" "FAIL" "$elapsed" "$body" "$meta"
+        record_fail "live_${protocol}_${feature}" "missing marker '$marker' elapsed=$elapsed body=$body meta=$meta"
         return 1
     fi
-    record_pass "live_${protocol}_${feature} ($(elapsed_seconds "$start"))"
+    elapsed="$(elapsed_seconds "$start")"
+    if [ -n "$marker" ]; then
+        record_live_coverage "$protocol" "$feature" "$method" "$expected" "$LIVE_LAST_STATUS" "$LIVE_LAST_CURL_RC" "found" "PASS" "$elapsed" "$body" "$meta"
+    else
+        record_live_coverage "$protocol" "$feature" "$method" "$expected" "$LIVE_LAST_STATUS" "$LIVE_LAST_CURL_RC" "none" "PASS" "$elapsed" "$body" "$meta"
+    fi
+    record_pass "live_${protocol}_${feature} ($elapsed)"
     return 0
 }
 
@@ -714,6 +825,7 @@ else
     record_skip live_https_api_flow "requested --skip-web"
 fi
 
+append_live_coverage_summary
 note "RESULT passed=$PASSED failed=$FAILED skipped=$SKIPPED"
 note "summary=$SUMMARY_FILE"
 note "full_log=$FULL_LOG"

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -358,6 +358,8 @@ run_live_web_flow() {
     local column_doc_name="${LIVE_FLOW_ID}_${protocol}_columns.csv"
     local script_name="${LIVE_FLOW_ID}_${protocol}.pl"
     local python_script_name="${LIVE_FLOW_ID}_${protocol}.py"
+    local python_timeout_script_name="${LIVE_FLOW_ID}_${protocol}_timeout.py"
+    local python_oversize_script_name="${LIVE_FLOW_ID}_${protocol}_oversize.py"
     local user_id="User123"
     local role_user="${LIVE_FLOW_ID}_${protocol}_user"
     local auth="userId=$user_id&orgId=$org_name&orgKey=$org_key"
@@ -446,6 +448,22 @@ run_live_web_flow() {
         -F "newOrgKey=$org_key" \
         -F "*resourceInfo=live $protocol Python script"
     live_api_check "$protocol" python_parser_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_script_name?$auth&newOrgKey=$org_key&outputType=csv" "82400" "${curl_tls_args[@]}"
+    live_api_check "$protocol" upload_python_timeout_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_timeout_script_name" "" "${curl_tls_args[@]}" \
+        -F "file=@$ROOT_DIR/TEST/testfiles/test_timeout.py" \
+        -F "userId=$user_id" \
+        -F "orgId=$org_name" \
+        -F "orgKey=$org_key" \
+        -F "newOrgKey=$org_key" \
+        -F "*resourceInfo=live $protocol timeout Python script"
+    live_api_check "$protocol" python_parser_timeout 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_timeout_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
+    live_api_check "$protocol" upload_python_oversize_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_oversize_script_name" "" "${curl_tls_args[@]}" \
+        -F "file=@$ROOT_DIR/TEST/testfiles/test_oversize.py" \
+        -F "userId=$user_id" \
+        -F "orgId=$org_name" \
+        -F "orgKey=$org_key" \
+        -F "newOrgKey=$org_key" \
+        -F "*resourceInfo=live $protocol oversize Python script"
+    live_api_check "$protocol" python_parser_oversize 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_oversize_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" document_delete 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
     live_api_check "$protocol" role_table_delete 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
     live_api_check "$protocol" filter_whitelist_delete 200 "$base_url/organizations/$org_name/users/$role_user/filterWhitelist/$role_user?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE

--- a/TEST/testfiles/test_oversize.py
+++ b/TEST/testfiles/test_oversize.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        return 2
+
+    output_path = sys.argv[2]
+    with open(output_path, "w", newline="") as dst:
+        dst.write("payload\n")
+        dst.write("x" * (1024 * 1024 + 1))
+        dst.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TEST/testfiles/test_timeout.py
+++ b/TEST/testfiles/test_timeout.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import sys
+import time
+
+
+def main():
+    if len(sys.argv) != 3:
+        return 2
+    time.sleep(15)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TODO.md
+++ b/TODO.md
@@ -346,3 +346,45 @@
     - Batch 3: write `TUTORIAL.md` with practical examples, diagrams or tables where useful, and explicit notes about what CaumeDSE protects, what it does not protect, and how to operate it safely.
     - Batch 4: cross-link the tutorial from `README.md`, validate examples against current fixtures/API routes, and run documentation/spell checks or targeted verifier commands as appropriate.
   - Done: added `TUTORIAL.md` covering threat models, key handling, salts, PBKDF2, AES-GCM encryption, HMAC/MACProtected integrity, secure CSV/raw-file storage, protected lookup indexes, TLS client certificates, role/filter authorization, parser execution, secure deletion, audit logs, verifier usage, and operational boundaries. Linked the tutorial from `README.md` and validated the documentation references plus `TEST/run_debug_components.sh --skip-build --skip-web`.
+
+- [ ] #61 Add live verifier API coverage matrix output.
+  - Source: `TEST/run_debug_components.sh`, live HTTP(S) API checks, README API resource tree.
+  - Goal: make live API coverage visible as a clear matrix instead of requiring maintainers to infer coverage from shell code.
+  - Plan:
+    - Batch 1: inventory current `live_api_check` calls and define matrix columns for protocol, feature, method, expected status, marker, elapsed time, and log paths.
+    - Batch 2: have the verifier emit a stable coverage table or CSV artifact while preserving the current PASS/FAIL summary.
+    - Batch 3: document how to compare coverage after route changes and validate HTTP-only, HTTPS-only, and both-protocol runs.
+
+- [x] #62 Harden parser script execution limits.
+  - Source: `webservice_interface.c`, `TEST/run_debug_components.sh`, `TEST/testfiles/test.py`, `TEST/testfiles/test.pl`.
+  - Goal: bound parser-script execution and output so scripts that process decrypted CSV data cannot hang a worker indefinitely or create unbounded response data.
+  - Plan:
+    - Batch 1: add explicit parser execution limits for child-process parser runtimes, starting with Python timeout and output-file byte caps.
+    - Batch 2: add shared parser result-size validation for both Perl and Python results, with clear DEBUG/error diagnostics and secure temporary-file cleanup on timeout/error paths.
+    - Batch 3: add focused DEBUG/live verifier fixtures for normal parser execution, timeout, oversized output, and temporary-file cleanup behavior.
+    - Batch 4: document the limits and the remaining embedded-Perl boundary, then validate syntax, component markers, and focused live parser flows.
+  - Done: added compile-time parser limits for Python child-process timeout, Python output-file size, and shared parser result-table cells; Python parser temp files are still securely overwritten/deleted on timeout and oversized-output paths. Added live verifier fixtures for timeout and oversized output, extended HTTP/HTTPS live parser checks, documented the limits in README and TUTORIAL, and validated `bash -n TEST/run_debug_components.sh`, `make`, `TEST/run_debug_components.sh --skip-build --skip-web`, `TEST/run_debug_components.sh --web-protocol=http`, and `TEST/run_debug_components.sh --live-only --web-protocol=https`. Embedded Perl now shares the result-table cap; process-level Perl runtime isolation remains a future hardening step because it requires moving Perl execution out of the embedded interpreter path.
+
+- [ ] #63 Add live negative authorization scenarios.
+  - Source: `TEST/run_debug_components.sh`, roleTables/filterWhitelist/filterBlacklist routes, TLS client certificate setup.
+  - Goal: increase confidence that authorization failures are enforced over live HTTP(S), not only representative component tests.
+  - Plan:
+    - Batch 1: define negative cases for denied role/filter combinations, wrong user, missing org key, invalid client certificate, and forbidden document access.
+    - Batch 2: add isolated live requests that assert the expected 401/403/404 responses without weakening cleanup.
+    - Batch 3: validate both HTTP and HTTPS focused modes and document any protocol-specific authentication differences.
+
+- [ ] #64 Create API reference examples from live verifier fixtures.
+  - Source: `README.md`, `TEST/run_debug_components.sh`, live API fixture data.
+  - Goal: provide tested, minimal API examples without further expanding the main README.
+  - Plan:
+    - Batch 1: extract the current live verifier flow into a concise examples outline for organization, storage, user, document, parser, and DB browsing operations.
+    - Batch 2: add `API_EXAMPLES.md` with curl examples aligned to the live verifier fixtures and documented authentication parameters.
+    - Batch 3: cross-link the examples from README and validate example routes against live verifier behavior.
+
+- [ ] #65 Add CI-friendly verifier profile.
+  - Source: `TEST/run_debug_components.sh`, build/test workflow.
+  - Goal: keep full local verification available while providing a practical PR/CI smoke profile.
+  - Plan:
+    - Batch 1: define the minimum CI smoke set: syntax/build, component markers, and one selected live protocol.
+    - Batch 2: add a verifier switch such as `--ci-smoke` that selects the bounded profile without changing the default full run.
+    - Batch 3: document expected runtime, prerequisites, exit behavior, and failure artifacts.

--- a/TODO.md
+++ b/TODO.md
@@ -347,13 +347,14 @@
     - Batch 4: cross-link the tutorial from `README.md`, validate examples against current fixtures/API routes, and run documentation/spell checks or targeted verifier commands as appropriate.
   - Done: added `TUTORIAL.md` covering threat models, key handling, salts, PBKDF2, AES-GCM encryption, HMAC/MACProtected integrity, secure CSV/raw-file storage, protected lookup indexes, TLS client certificates, role/filter authorization, parser execution, secure deletion, audit logs, verifier usage, and operational boundaries. Linked the tutorial from `README.md` and validated the documentation references plus `TEST/run_debug_components.sh --skip-build --skip-web`.
 
-- [ ] #61 Add live verifier API coverage matrix output.
+- [x] #61 Add live verifier API coverage matrix output.
   - Source: `TEST/run_debug_components.sh`, live HTTP(S) API checks, README API resource tree.
   - Goal: make live API coverage visible as a clear matrix instead of requiring maintainers to infer coverage from shell code.
   - Plan:
     - Batch 1: inventory current `live_api_check` calls and define matrix columns for protocol, feature, method, expected status, marker, elapsed time, and log paths.
     - Batch 2: have the verifier emit a stable coverage table or CSV artifact while preserving the current PASS/FAIL summary.
     - Batch 3: document how to compare coverage after route changes and validate HTTP-only, HTTPS-only, and both-protocol runs.
+  - Done: `TEST/run_debug_components.sh` now writes `live-api-coverage.csv` and `live-api-coverage.txt` under the verifier log directory and appends the fixed-width matrix plus artifact paths to `summary.txt`. Each live request row records protocol, feature, inferred HTTP method, expected and actual status, curl result, marker status, pass/fail state, elapsed time, and body/meta log paths. Documented the artifacts in README and TUTORIAL, and validated `bash -n TEST/run_debug_components.sh`, `TEST/run_debug_components.sh --live-only --web-protocol=http`, and `TEST/run_debug_components.sh --live-only --web-protocol=https`; each focused live run produced 41 live request rows and passed with `42 passed, 0 failed, 10 skipped`.
 
 - [x] #62 Harden parser script execution limits.
   - Source: `webservice_interface.c`, `TEST/run_debug_components.sh`, `TEST/testfiles/test.py`, `TEST/testfiles/test.pl`.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -366,11 +366,16 @@ Security considerations:
 - Parser output is decrypted application data.
 - Temporary files must be protected by filesystem permissions and cleanup.
 - Scripts should be reviewed for data exfiltration and resource exhaustion.
+- Python parser scripts run in a child process with a compile-time timeout and
+  output-file size cap. Perl parser callbacks use the embedded interpreter and
+  share the parser result-table cap; process-level Perl isolation is a separate
+  hardening step.
 
 Verifier coverage:
 
-`TEST/run_debug_components.sh` uploads Perl and Python parser scripts and runs
-both over live HTTP and HTTPS flows.
+`TEST/run_debug_components.sh` uploads Perl and Python parser scripts, runs both
+over live HTTP and HTTPS flows, and verifies Python timeout and oversized-output
+failure paths.
 
 ## Secure Deletion and Temporary Files
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -445,7 +445,10 @@ TEST/run_debug_components.sh --live-only --web-protocol=https
 The verifier checks cryptographic primitives, protected database behavior,
 role/filter resources, document routes, secure CSV round trips, MAC-protected
 values, web startup, live API flows, parser execution, DB browsing, and
-negative routes.
+negative routes. Live API runs write `live-api-coverage.csv` and
+`live-api-coverage.txt` under the verifier log directory so route coverage,
+expected/actual statuses, marker checks, elapsed time, and response log paths
+can be reviewed without reading the shell script.
 
 ## Operational Checklist
 

--- a/common.h
+++ b/common.h
@@ -71,6 +71,15 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #define cmeMaxCSVPartsPerColumn 10000   //Max {estimated} number of parts that a CSV table can hold {required by cmeSecureDBtoMemDB}.
 #define cmeMaxRAWDataInPart 4000        //Max number of bytes in a secure file slice {part}, estimated from smallest SQLITE secureDB column files. {RECOMMENDED: 5120}
 #define cmeMaxSQLDBFileNameCollisionRetries 64 //Max attempts to regenerate a random ColumnFile name after detecting a collision.
+#ifndef CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS
+#define CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS 10 //Max seconds to wait for child-process parser scripts.
+#endif
+#ifndef CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES
+#define CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES (1024*1024) //Max parser output CSV size before loading it.
+#endif
+#ifndef CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS
+#define CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS 1000000 //Max cells allowed in parser result tables.
+#endif
 #define cmeDefaultContentReaderCallbackPageSize (1024*64)   //Default Page size for ContentReaderCallback functions.
 #ifndef CDSE_SECURE_OVERWRITE_PASSES
 #define CDSE_SECURE_OVERWRITE_PASSES 1  //Compile-time overwrite passes for temporary file deletion. Set >1 to enable multi-round overwrites.

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -44,6 +44,8 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 ***/
 #include "common.h"
 #include <errno.h>
+#include <signal.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 
 static void cmeWebServiceSetThreadStatus(struct cmeWebServiceConnectionInfoStruct *con_info, int threadStatus)
@@ -727,10 +729,64 @@ static int cmeWebServiceLoadCSVToResultMemTable(const char *filePath)
     return(0);
 }
 
+static int cmeWebServiceValidateParserResultSize(const char *context)
+{
+    long long cells;
+
+    if ((cmeResultMemTableCols<0)||(cmeResultMemTableRows<0))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: %s(), invalid parser result dimensions cols=%d rows=%d.\n",
+                context?context:"cmeWebServiceValidateParserResultSize",
+                cmeResultMemTableCols,cmeResultMemTableRows);
+#endif
+        return(1);
+    }
+    cells=(long long)cmeResultMemTableCols*(long long)(cmeResultMemTableRows+1);
+    if (cells>CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: %s(), parser result has %lld cells; limit is %d.\n",
+                context?context:"cmeWebServiceValidateParserResultSize",
+                cells,CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS);
+#endif
+        return(2);
+    }
+    return(0);
+}
+
+static int cmeWebServiceValidateParserOutputFileSize(const char *filePath)
+{
+    struct stat st;
+
+    if (!filePath)
+    {
+        return(1);
+    }
+    if (stat(filePath,&st))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeWebServiceValidateParserOutputFileSize(), stat() failed for '%s': %s.\n",
+                filePath,strerror(errno));
+#endif
+        return(2);
+    }
+    if (st.st_size>CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeWebServiceValidateParserOutputFileSize(), parser output '%s' is %lld bytes; limit is %d.\n",
+                filePath,(long long)st.st_size,CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES);
+#endif
+        return(3);
+    }
+    return(0);
+}
+
 static int cmeWebServiceRunPythonParserScript(const char *scriptPath)
 {
     int result=0;
     int status=0;
+    int waited=0;
     char *inputPath=NULL;
     char *outputPath=NULL;
     pid_t pid;
@@ -762,15 +818,48 @@ static int cmeWebServiceRunPythonParserScript(const char *scriptPath)
         }
         else
         {
-            do
+            while (1)
             {
-                result=waitpid(pid,&status,0);
-            } while ((result<0)&&(errno==EINTR));
-            if ((result<0)||(!WIFEXITED(status))||(WEXITSTATUS(status)!=0))
+                result=waitpid(pid,&status,WNOHANG);
+                if (result==pid)
+                {
+                    break;
+                }
+                if ((result<0)&&(errno==EINTR))
+                {
+                    continue;
+                }
+                if (result<0)
+                {
+                    break;
+                }
+                if (waited>=CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS)
+                {
+                    kill(pid,SIGTERM);
+                    sleep(1);
+                    if (waitpid(pid,&status,WNOHANG)==0)
+                    {
+                        kill(pid,SIGKILL);
+                    }
+                    while ((waitpid(pid,&status,0)<0)&&(errno==EINTR))
+                    {
+                    }
+#ifdef ERROR_LOG
+                    fprintf(stderr,"CaumeDSE Error: cmeWebServiceRunPythonParserScript(), parser timed out after %d seconds.\n",
+                            CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS);
+#endif
+                    result=6;
+                    break;
+                }
+                sleep(1);
+                waited++;
+            }
+            if ((result!=6)&&
+                ((result<0)||(!WIFEXITED(status))||(WEXITSTATUS(status)!=0)))
             {
                 result=5;
             }
-            else
+            else if (result!=6)
             {
                 result=0;
             }
@@ -778,7 +867,23 @@ static int cmeWebServiceRunPythonParserScript(const char *scriptPath)
     }
     if (!result)
     {
+        result=cmeWebServiceValidateParserOutputFileSize(outputPath);
+        if (result)
+        {
+            result=7;
+        }
+    }
+    if (!result)
+    {
         result=cmeWebServiceLoadCSVToResultMemTable(outputPath);
+    }
+    if (!result)
+    {
+        result=cmeWebServiceValidateParserResultSize("cmeWebServiceRunPythonParserScript");
+        if (result)
+        {
+            result=8;
+        }
     }
     if (inputPath)
     {
@@ -9046,6 +9151,14 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                                    cmeDefaultPerlIterationFunction,cdsePerl); //Select
                         pthread_mutex_unlock(&cmePerlMutex);
                         perlLocked=0;
+                        if (!result)
+                        {
+                            result=cmeWebServiceValidateParserResultSize("cmeWebServiceProcessParserScriptResource");
+                            if (result)
+                            {
+                                result=17;
+                            }
+                        }
                     }
                     else
                     {
@@ -9267,6 +9380,14 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                                           cmeDefaultPerlIterationFunction,cdsePerl); //Select
                         pthread_mutex_unlock(&cmePerlMutex);
                         perlLocked=0;
+                        if (!result)
+                        {
+                            result=cmeWebServiceValidateParserResultSize("cmeWebServiceProcessParserScriptResource");
+                            if (result)
+                            {
+                                result=17;
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

- harden parser script execution by bounding Python parser runtime, output file size, and shared parser result-table size
- add live verifier fixtures for parser timeout and oversized-output failures
- add live API coverage matrix artifacts in CSV and fixed-width text form
- document the new parser limits and coverage artifacts in README/TUTORIAL, and mark TODO #61/#62 complete

## Impact

Parser scripts that process decrypted CSV data now have clearer resource limits and diagnostics. Live API verification now produces an auditable coverage matrix with protocol, feature, inferred method, expected/actual status, marker result, elapsed time, and response log paths.

## Validation

- `bash -n TEST/run_debug_components.sh`
- `make`
- `TEST/run_debug_components.sh --skip-build --skip-web` (`23 passed, 0 failed, 9 skipped`)
- `TEST/run_debug_components.sh --web-protocol=http` (`71 passed, 0 failed, 1 skipped`)
- `TEST/run_debug_components.sh --live-only --web-protocol=http` (`42 passed, 0 failed, 10 skipped`)
- `TEST/run_debug_components.sh --live-only --web-protocol=https` (`42 passed, 0 failed, 10 skipped`)
