### PR TITLE
[codex] Add live auth negatives and API examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+CaumeDSE is a C/autotools project. Core source and headers live at the
+repository root, including `main.c`, `crypto.c`, `db.c`, `filehandling.c`,
+`engine_admin.c`, `engine_interface.c`, and `webservice_interface.c`. DEBUG and
+component coverage lives in `debug_tests.c` and `function_tests.c`. Test assets,
+certificates, fixtures, and verifier scripts are under `TEST/`; examples for
+external clients are under `samples/`. User-facing documentation is in
+`README.md`, `TUTORIAL.md`, `API_EXAMPLES.md`, and `TODO.md`.
+
+## Build, Test, and Development Commands
+
+- `./configure --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP`
+  configures a DEBUG build with committed test databases and HTTP TLS-auth
+  bypass for local verification.
+- `make` builds `CaumeDSE` and `CaumeDSE-debug-tests`.
+- `make check` runs the autotools check target.
+- `TEST/run_debug_components.sh` performs the full build/install/component/live
+  verifier flow under `/tmp/cdse-verify`.
+- `TEST/run_debug_components.sh --skip-build --skip-web` reruns component checks
+  against an existing build without binding web ports.
+- `TEST/run_debug_components.sh --live-only --web-protocol=http|https` reruns a
+  focused live API flow and writes `live-api-coverage.csv`.
+
+## Coding Style & Naming Conventions
+
+Follow the existing C style: four-space indentation, braces on their own lines
+for functions and larger blocks, `cme`-prefixed functions, and explicit cleanup
+paths. Prefer existing helpers such as `cmeMalloc`, `cmeFree`,
+`cmeStrConstrAppend`, storage wrappers, and SQL helper functions. Keep comments
+short and useful; avoid broad refactors in focused fixes.
+
+## Testing Guidelines
+
+Add or update DEBUG component checks for C behavior and live verifier checks for
+HTTP(S) API behavior. Keep test fixtures in `TEST/testfiles/`. Validate shell
+changes with `bash -n TEST/run_debug_components.sh`. For live API work, run at
+least the focused HTTP and HTTPS verifier modes when practical.
+
+## Commit & Pull Request Guidelines
+
+Use concise, imperative commit messages matching recent history, for example
+`Add live negative auth checks` or `Harden parser script limits`. Keep generated
+build artifacts (`*.o`, `.deps/`, `config.log`, binaries) out of commits unless
+explicitly required. Pull requests should summarize behavior changes, security
+impact, touched routes/files, and exact validation commands with pass/fail
+counts.
+
+## Security & Configuration Tips
+
+Do not commit real organization keys, private certificates, or production data.
+Use the committed `TEST/testCertAuth/` fixtures only for DEBUG verification.
+Production deployments should use HTTPS, restricted data directories, protected
+key handling outside CaumeDSE, and no DEBUG authentication bypasses.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -1,0 +1,257 @@
+# CaumeDSE API Examples
+
+This file contains compact `curl` examples aligned with the live verifier flow
+in `TEST/run_debug_components.sh`. The examples are meant for development and
+integration testing. They show the request shape for common resources without
+expanding the main README API reference.
+
+## Setup
+
+Use HTTP only in DEBUG/test environments. For HTTPS, set `TLS_ARGS` to the CA,
+client certificate chain, and client key used by your test or deployment.
+
+```sh
+BASE_URL="http://localhost:18080"
+ORG="ExampleOrg"
+ORG_KEY="example-org-key"
+USER="User123"
+STORAGE="ExampleStorage"
+STORAGE_PATH="/tmp/caumedse-example-storage"
+CSV_DOC="payroll.csv"
+SCRIPT_PERL="sum_salary.pl"
+SCRIPT_PYTHON="sum_salary.py"
+AUTH="userId=$USER&orgId=$ORG&orgKey=$ORG_KEY"
+TLS_ARGS=""
+
+# HTTPS example:
+# BASE_URL="https://localhost:18443"
+# TLS_ARGS="--cacert /tmp/cdse-verify/cdse/ca.pem --cert client_chain.pem --key client.key"
+```
+
+The examples use committed verifier fixtures:
+
+- `TEST/testfiles/live-api-small.csv`
+- `TEST/testfiles/test.pl`
+- `TEST/testfiles/test.py`
+
+## Negative Authentication Checks
+
+Missing credentials return `401`.
+
+```sh
+curl -i $TLS_ARGS "$BASE_URL/organizations/$ORG"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG?userId=$USER&orgId=$ORG"
+```
+
+On HTTPS, requests without a client certificate or with a certificate whose
+user common name does not match `userId` also return `401`.
+
+```sh
+curl -i --cacert /tmp/cdse-verify/cdse/ca.pem \
+  "$BASE_URL/organizations/$ORG?$AUTH"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG?userId=${USER}_mismatch&orgId=$ORG&orgKey=$ORG_KEY"
+```
+
+## Organizations, Storage, and Users
+
+Create an organization, storage resource, and user.
+
+```sh
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG?$AUTH&newOrgKey=$ORG_KEY&*resourceInfo=example%20organization&*certificate=undefined&*publicKey=undefined"
+
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE?$AUTH&newOrgKey=$ORG_KEY&*resourceInfo=example%20storage&*location=localhost&*type=local&*accessPath=$STORAGE_PATH&*accessUser=undefined&*accessPassword=undefined"
+
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG/users/$USER?$AUTH&newOrgKey=$ORG_KEY&*resourceInfo=example%20user&*certificate=undefined&*publicKey=undefined&*basicAuthPwdHash=undefined&*oauthConsumerKey=undefined&*oauthConsumerSecret=undefined"
+```
+
+## Document Types
+
+List document types, check `file.csv`, and verify an unsupported document type.
+
+```sh
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -I $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/unsupported.type?$AUTH&newOrgKey=$ORG_KEY"
+```
+
+## Role and Filter Resources
+
+Create and read role, whitelist, and blacklist resources. These examples mirror
+the live verifier setup. Fine-grained deny behavior is covered in DEBUG
+component tests.
+
+```sh
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG/users/$USER/roleTables/users?$AUTH&newOrgKey=$ORG_KEY&*_get=1&*_post=0&*_put=1&*_delete=0&*_head=1&*_options=1"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/users/$USER/roleTables/users?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG/users/$USER/filterWhitelist/$USER?$AUTH&newOrgKey=$ORG_KEY&*_get=1&*_post=0&*_put=0&*_delete=0&*_head=1&*_options=1"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/users/$USER/filterWhitelist/$USER?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG/users/$USER/filterBlacklist/$USER?$AUTH&newOrgKey=$ORG_KEY&*_get=0&*_post=1&*_put=0&*_delete=0&*_head=0&*_options=0"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/users/$USER/filterBlacklist/$USER?$AUTH&newOrgKey=$ORG_KEY"
+```
+
+## Secure CSV Documents
+
+Upload a CSV document, list documents, and retrieve content.
+
+```sh
+curl -i $TLS_ARGS \
+  -F "file=@TEST/testfiles/live-api-small.csv" \
+  -F "userId=$USER" \
+  -F "orgId=$ORG" \
+  -F "orgKey=$ORG_KEY" \
+  -F "newOrgKey=$ORG_KEY" \
+  -F "*resourceInfo=example CSV" \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -I $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/content?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+```
+
+## Rows and Columns
+
+Read a row, read a column, and create/delete a representative column in a
+separate temporary document.
+
+```sh
+curl -i $TLS_ARGS -X OPTIONS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentRows?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentRows/1?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+
+curl -i $TLS_ARGS -X OPTIONS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentColumns?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentColumns/name?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+
+COLUMN_DOC="columns.csv"
+
+curl -i $TLS_ARGS -X POST \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$COLUMN_DOC/contentColumns/Col1?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X DELETE \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$COLUMN_DOC/contentColumns/Col1?$AUTH&newOrgKey=$ORG_KEY"
+```
+
+## Secure DB Browsing
+
+Browse registered secure CSV databases, tables, rows, and columns.
+
+```sh
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables/data/tableRows/1?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables/data/tableColumns/name?$AUTH&newOrgKey=$ORG_KEY"
+
+# Invalid row selectors return 403.
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables/data/tableRows/0?$AUTH&newOrgKey=$ORG_KEY"
+```
+
+## Parser Scripts
+
+Upload Perl and Python parser scripts and run them against the secure CSV
+document.
+
+```sh
+curl -i $TLS_ARGS \
+  -F "file=@TEST/testfiles/test.pl" \
+  -F "userId=$USER" \
+  -F "orgId=$ORG" \
+  -F "orgKey=$ORG_KEY" \
+  -F "newOrgKey=$ORG_KEY" \
+  -F "*resourceInfo=example Perl script" \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/script.perl/documents/$SCRIPT_PERL"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/parserScripts/$SCRIPT_PERL?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+
+curl -I $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/parserScripts/missing.pl?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+
+curl -i $TLS_ARGS \
+  -F "file=@TEST/testfiles/test.py" \
+  -F "userId=$USER" \
+  -F "orgId=$ORG" \
+  -F "orgKey=$ORG_KEY" \
+  -F "newOrgKey=$ORG_KEY" \
+  -F "*resourceInfo=example Python script" \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/script.python/documents/$SCRIPT_PYTHON"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/parserScripts/$SCRIPT_PYTHON?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+```
+
+Parser resource-limit failures are covered by the live verifier using
+`TEST/testfiles/test_timeout.py` and `TEST/testfiles/test_oversize.py`.
+
+## Cleanup
+
+Delete the disposable resources created by these examples.
+
+```sh
+curl -i $TLS_ARGS -X DELETE \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X DELETE \
+  "$BASE_URL/organizations/$ORG/users/$USER/roleTables/users?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X DELETE \
+  "$BASE_URL/organizations/$ORG/users/$USER/filterWhitelist/$USER?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X DELETE \
+  "$BASE_URL/organizations/$ORG/users/$USER/filterBlacklist/$USER?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS -X DELETE \
+  "$BASE_URL/organizations/$ORG/users/$USER?$AUTH&newOrgKey=$ORG_KEY"
+```
+
+## Verification
+
+The examples are derived from the live verifier. To exercise the same flow and
+produce a coverage matrix, run:
+
+```sh
+TEST/run_debug_components.sh --live-only --web-protocol=http
+TEST/run_debug_components.sh --live-only --web-protocol=https
+```
+
+The verifier writes `live-api-coverage.csv` and `live-api-coverage.txt` under
+its log directory.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,16 @@ This is the canonical GitHub-compatible Markdown README. The legacy `README` fil
 For an applied explanation of the cryptographic and data-security concepts used
 by CaumeDSE, see [TUTORIAL.md](TUTORIAL.md).
 
+For tested `curl` examples based on the live verifier fixtures, see
+[API_EXAMPLES.md](API_EXAMPLES.md).
+
 
 ## Contents
 
 - [Purpose and Philosophy](#purpose-and-philosophy)
 - [Status](#status)
 - [Cryptography and Data Security Tutorial](TUTORIAL.md)
+- [API Examples](API_EXAMPLES.md)
 - [License](#license)
 - [Architecture and Functionality](#architecture-and-functionality)
 - [REST Resource API Reference](#rest-resource-api-reference)

--- a/README.md
+++ b/README.md
@@ -2206,10 +2206,13 @@ debug executable.  In full mode it also starts a held-open DEBUG web service
 for each protocol and uses `curl` to authenticate, create a temporary
 organization and storage resource, upload a CSV document, query a row and
 column, upload a `script.perl` document, and execute that parser script
-through both HTTP and HTTPS.  HTTPS uses a per-run client certificate chain
-signed by the committed test CA fixture.  `CDSE_DEBUG_TEST_TIMEOUT` controls
-the overall executable timeout and defaults to 120s.  Use `--skip-web` only
-when the local environment cannot bind test ports.  Live API runs also write
+through both HTTP and HTTPS.  The live flow also asserts negative
+authentication cases for missing credentials on both protocols and missing or
+mismatched client certificates on HTTPS.  HTTPS uses a per-run client
+certificate chain signed by the committed test CA fixture.
+`CDSE_DEBUG_TEST_TIMEOUT` controls the overall executable timeout and defaults
+to 120s.  Use `--skip-web` only when the local environment cannot bind test
+ports.  Live API runs also write
 coverage artifacts under the log directory: `live-api-coverage.csv` for
 machine-readable comparisons and `live-api-coverage.txt` for the fixed-width
 summary table.  Each row records protocol, feature name, inferred HTTP method,

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -509,6 +509,13 @@ run_live_web_flow() {
         return 1
     fi
 
+    live_api_check "$protocol" auth_missing_all 401 "$base_url/organizations/$org_name" "" "${curl_tls_args[@]}"
+    live_api_check "$protocol" auth_missing_org_key 401 "$base_url/organizations/$org_name?userId=$user_id&orgId=$org_name" "" "${curl_tls_args[@]}"
+    if [ "$protocol" = "https" ]; then
+        live_api_check "$protocol" auth_missing_client_cert 401 "$base_url/organizations/$org_name?$auth" "" --cacert "$PREFIX/cdse/ca.pem"
+        live_api_check "$protocol" auth_client_cert_user_mismatch 401 "$base_url/organizations/$org_name?userId=${user_id}_mismatch&orgId=$org_name&orgKey=$org_key" "" "${curl_tls_args[@]}"
+    fi
+
     live_api_check "$protocol" create_org 201 "$base_url/organizations/$org_name?$auth&*resourceInfo=live%20$protocol%20organization&*certificate=undefined&*publicKey=undefined&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" create_storage 201 "$base_url/organizations/$org_name/storage/$storage_name?$auth&newOrgKey=$org_key&*resourceInfo=live%20$protocol%20storage&*location=localhost&*type=local&*accessPath=$storage_path&*accessUser=undefined&*accessPassword=undefined" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" create_user 201 "$base_url/organizations/$org_name/users/$role_user?$auth&newOrgKey=$org_key&*resourceInfo=live%20$protocol%20user&*certificate=undefined&*publicKey=undefined&*basicAuthPwdHash=undefined&*oauthConsumerKey=undefined&*oauthConsumerSecret=undefined" "" "${curl_tls_args[@]}" -X POST

--- a/TODO.md
+++ b/TODO.md
@@ -366,13 +366,14 @@
     - Batch 4: document the limits and the remaining embedded-Perl boundary, then validate syntax, component markers, and focused live parser flows.
   - Done: added compile-time parser limits for Python child-process timeout, Python output-file size, and shared parser result-table cells; Python parser temp files are still securely overwritten/deleted on timeout and oversized-output paths. Added live verifier fixtures for timeout and oversized output, extended HTTP/HTTPS live parser checks, documented the limits in README and TUTORIAL, and validated `bash -n TEST/run_debug_components.sh`, `make`, `TEST/run_debug_components.sh --skip-build --skip-web`, `TEST/run_debug_components.sh --web-protocol=http`, and `TEST/run_debug_components.sh --live-only --web-protocol=https`. Embedded Perl now shares the result-table cap; process-level Perl runtime isolation remains a future hardening step because it requires moving Perl execution out of the embedded interpreter path.
 
-- [ ] #63 Add live negative authorization scenarios.
+- [x] #63 Add live negative authorization scenarios.
   - Source: `TEST/run_debug_components.sh`, roleTables/filterWhitelist/filterBlacklist routes, TLS client certificate setup.
   - Goal: increase confidence that authorization failures are enforced over live HTTP(S), not only representative component tests.
   - Plan:
     - Batch 1: define negative cases for denied role/filter combinations, wrong user, missing org key, invalid client certificate, and forbidden document access.
     - Batch 2: add isolated live requests that assert the expected 401/403/404 responses without weakening cleanup.
     - Batch 3: validate both HTTP and HTTPS focused modes and document any protocol-specific authentication differences.
+  - Done: added isolated live negative authentication checks before disposable resource setup: missing all credentials and missing `orgKey` over HTTP/HTTPS, plus missing client certificate and user/certificate CN mismatch over HTTPS. These rows are captured in the live API coverage matrix. Documented the negative live coverage in README and TUTORIAL, and validated `bash -n TEST/run_debug_components.sh`, `TEST/run_debug_components.sh --live-only --web-protocol=http` (`44 passed, 0 failed, 10 skipped`), and `TEST/run_debug_components.sh --live-only --web-protocol=https` (`46 passed, 0 failed, 10 skipped`). Role/filter deny behavior remains covered by DEBUG component tests because the disposable live setup intentionally starts with `CDSE_DEBUG_TEST_SKIP_AUTHZ=1` to bootstrap per-run organizations and storage.
 
 - [ ] #64 Create API reference examples from live verifier fixtures.
   - Source: `README.md`, `TEST/run_debug_components.sh`, live API fixture data.

--- a/TODO.md
+++ b/TODO.md
@@ -375,13 +375,14 @@
     - Batch 3: validate both HTTP and HTTPS focused modes and document any protocol-specific authentication differences.
   - Done: added isolated live negative authentication checks before disposable resource setup: missing all credentials and missing `orgKey` over HTTP/HTTPS, plus missing client certificate and user/certificate CN mismatch over HTTPS. These rows are captured in the live API coverage matrix. Documented the negative live coverage in README and TUTORIAL, and validated `bash -n TEST/run_debug_components.sh`, `TEST/run_debug_components.sh --live-only --web-protocol=http` (`44 passed, 0 failed, 10 skipped`), and `TEST/run_debug_components.sh --live-only --web-protocol=https` (`46 passed, 0 failed, 10 skipped`). Role/filter deny behavior remains covered by DEBUG component tests because the disposable live setup intentionally starts with `CDSE_DEBUG_TEST_SKIP_AUTHZ=1` to bootstrap per-run organizations and storage.
 
-- [ ] #64 Create API reference examples from live verifier fixtures.
+- [x] #64 Create API reference examples from live verifier fixtures.
   - Source: `README.md`, `TEST/run_debug_components.sh`, live API fixture data.
   - Goal: provide tested, minimal API examples without further expanding the main README.
   - Plan:
     - Batch 1: extract the current live verifier flow into a concise examples outline for organization, storage, user, document, parser, and DB browsing operations.
     - Batch 2: add `API_EXAMPLES.md` with curl examples aligned to the live verifier fixtures and documented authentication parameters.
     - Batch 3: cross-link the examples from README and validate example routes against live verifier behavior.
+  - Done: added `API_EXAMPLES.md` with curl examples derived from the live verifier flow, covering authentication negatives, organization/storage/user setup, documentTypes, role/filter resources, secure CSV upload/content, rows/columns, secure DB browsing, parser scripts, cleanup, and verifier commands. Linked it from README and validated the examples against the current live verifier route names and committed fixtures.
 
 - [ ] #65 Add CI-friendly verifier profile.
   - Source: `TEST/run_debug_components.sh`, build/test workflow.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -445,10 +445,12 @@ TEST/run_debug_components.sh --live-only --web-protocol=https
 The verifier checks cryptographic primitives, protected database behavior,
 role/filter resources, document routes, secure CSV round trips, MAC-protected
 values, web startup, live API flows, parser execution, DB browsing, and
-negative routes. Live API runs write `live-api-coverage.csv` and
-`live-api-coverage.txt` under the verifier log directory so route coverage,
-expected/actual statuses, marker checks, elapsed time, and response log paths
-can be reviewed without reading the shell script.
+negative routes. The live API flow asserts missing-credential failures on HTTP
+and HTTPS plus missing and mismatched client certificate failures on HTTPS.
+Live API runs write `live-api-coverage.csv` and `live-api-coverage.txt` under
+the verifier log directory so route coverage, expected/actual statuses, marker
+checks, elapsed time, and response log paths can be reviewed without reading
+the shell script.
 
 ## Operational Checklist
 


### PR DESCRIPTION
## Summary

- add live negative authentication checks for missing credentials and HTTPS client certificate failures
- add `API_EXAMPLES.md` with curl examples derived from the live verifier route flow and committed fixtures
- add `AGENTS.md` contributor guidance for structure, commands, style, testing, PRs, and security notes
- link API examples from README and mark TODO #63/#64 complete

## Impact

The live verifier now covers additional authentication failure paths before disposable resource setup. Contributors and integrators get concise, tested API examples and repository-specific contribution guidance.

## Validation

- `bash -n TEST/run_debug_components.sh`
- `TEST/run_debug_components.sh --live-only --web-protocol=http` (`44 passed, 0 failed, 10 skipped`)
- `TEST/run_debug_components.sh --live-only --web-protocol=https` (`46 passed, 0 failed, 10 skipped`)
- checked `API_EXAMPLES.md` route and fixture references against `TEST/run_debug_components.sh`
