### PR TITLE
[codex] Add verifier redaction and AI-safe API guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ external clients are under `samples/`. User-facing documentation is in
   against an existing build without binding web ports.
 - `TEST/run_debug_components.sh --live-only --web-protocol=http|https` reruns a
   focused live API flow and writes `live-api-coverage.csv`.
+- `TEST/run_debug_components.sh --ci-smoke` runs the CI-friendly build,
+  component-marker, startup, and single-protocol live profile.
 
 ## Coding Style & Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ external clients are under `samples/`. User-facing documentation is in
   focused live API flow and writes `live-api-coverage.csv`.
 - `TEST/run_debug_components.sh --ci-smoke` runs the CI-friendly build,
   component-marker, startup, and single-protocol live profile.
+- Prefix verifier runs with `CDSE_VERIFY_REDACT=1` before sharing logs; it masks
+  org keys, `newOrgKey`, selected credential-style request parameters, and
+  generated certificate/key paths in retained artifacts.
 
 ## Coding Style & Naming Conventions
 

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -1,0 +1,129 @@
+# AI-Safe CaumeDSE API Usage
+
+This guide describes safe patterns for LLM agents and automation that call
+CaumeDSE APIs. It complements `API_EXAMPLES.md` by focusing on credential
+handling, least privilege, parser-script review, logging, and cleanup.
+
+## Security Model for Agents
+
+Treat an AI agent as an untrusted client. It can plan requests and inspect
+non-secret responses, but it should not receive raw organization keys,
+certificate private keys, access passwords, OAuth secrets, or sensitive CSV
+rows unless a human has explicitly approved that disclosure.
+
+Recommended boundaries:
+
+- Store `orgKey`, `newOrgKey`, TLS key paths, and OAuth/client secrets in the
+  calling process environment or a dedicated secret manager.
+- Give the agent opaque variable names such as `$ORG_KEY` instead of secret
+  values.
+- Run live verifier checks with `CDSE_VERIFY_REDACT=1` before sharing artifacts.
+- Use disposable organizations, users, storage paths, and documents for agent
+  trials.
+- Prefer HTTPS and client certificates outside DEBUG-only local testing.
+
+## Safe Workflow
+
+Use the same shape as the live verifier:
+
+1. Create a temporary organization, storage resource, and least-privilege user.
+2. Add only the role/filter resources needed for the task.
+3. Upload test CSV or script fixtures from known local paths.
+4. Query narrow resources such as a specific row, column, table, or parser
+   output.
+5. Delete temporary documents, role/filter rows, users, and storage artifacts.
+6. Review `summary.txt` and `live-api-coverage.csv` with redaction enabled.
+
+Example shell setup:
+
+```sh
+export BASE_URL="https://localhost:18443"
+export ORG="AgentTrialOrg"
+export USER="AgentTrialUser"
+export STORAGE="AgentTrialStorage"
+export ORG_KEY="$(openssl rand -hex 32)"
+export AUTH="userId=$USER&orgId=$ORG&orgKey=$ORG_KEY"
+export TLS_ARGS="--cacert /tmp/cdse-verify/cdse/ca.pem --cert client_chain.pem --key client.key"
+```
+
+The agent may generate request templates that reference `$AUTH`, `$ORG_KEY`,
+and `$TLS_ARGS`. Do not paste expanded command lines containing real secrets
+into prompts, issue trackers, shared logs, or chat transcripts.
+
+## Request Patterns
+
+Prefer explicit, narrow API calls:
+
+```sh
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentColumns/name?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+```
+
+Avoid broad or open-ended data dumps unless the agent has a clear need and the
+data has been reviewed for sensitivity. For parser scripts, upload only scripts
+from reviewed local files:
+
+```sh
+curl -i $TLS_ARGS \
+  -F "file=@TEST/testfiles/test.py" \
+  -F "userId=$USER" \
+  -F "orgId=$ORG" \
+  -F "orgKey=$ORG_KEY" \
+  -F "newOrgKey=$ORG_KEY" \
+  -F "*resourceInfo=reviewed Python parser" \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/script.python/documents/$SCRIPT_PYTHON"
+```
+
+## Parser-Script Guardrails
+
+Generated parser scripts are code. Review them before upload and reject scripts
+that:
+
+- Read files outside the provided CSV input.
+- Open network connections.
+- Print secrets, environment variables, or raw credentials.
+- Generate unbounded output or long-running loops.
+- Depend on hidden state outside the uploaded document and script.
+
+The DEBUG verifier covers normal parser execution plus timeout and oversized
+output cases. Keep those checks in the workflow when changing parser behavior.
+
+## Logging and Artifact Handling
+
+Use redacted verification for CI and AI-assisted debugging:
+
+```sh
+CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke
+CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --live-only --web-protocol=https
+```
+
+Redaction masks `orgKey`, `newOrgKey`, selected credential-style request
+parameters, and generated certificate/key paths in retained verifier artifacts.
+It preserves status codes, markers, elapsed times, and artifact names so
+failures remain diagnosable.
+
+## Anti-Patterns
+
+Do not:
+
+- Ask an LLM to remember or transform real organization keys.
+- Paste expanded `curl` URLs containing `orgKey` or `newOrgKey`.
+- Let an agent invent parser scripts and upload them without human review.
+- Use a manager or admin user when a narrow test user is sufficient.
+- Keep temporary AI-created organizations, users, documents, or parser scripts
+  after the task is complete.
+- Share raw DEBUG logs or live request artifacts without redaction.
+
+## Validation
+
+Validate AI-facing examples against the live verifier routes:
+
+```sh
+bash -n TEST/run_debug_components.sh
+CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --help
+CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke
+```
+
+For quick documentation-only edits, compare route names against
+`API_EXAMPLES.md` and `TEST/run_debug_components.sh` before running the full
+live flow.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -255,4 +255,8 @@ TEST/run_debug_components.sh --live-only --web-protocol=https
 ```
 
 The verifier writes `live-api-coverage.csv` and `live-api-coverage.txt` under
-its log directory.
+its log directory.  Use `CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh ...`
+when saving verifier artifacts in CI or AI-assisted debugging sessions; this
+masks organization keys, `newOrgKey` values, selected credential-style request
+parameters, and generated certificate/key paths in summaries and live request
+artifacts.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -249,6 +249,7 @@ The examples are derived from the live verifier. To exercise the same flow and
 produce a coverage matrix, run:
 
 ```sh
+TEST/run_debug_components.sh --ci-smoke
 TEST/run_debug_components.sh --live-only --web-protocol=http
 TEST/run_debug_components.sh --live-only --web-protocol=https
 ```

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -3,7 +3,8 @@
 This file contains compact `curl` examples aligned with the live verifier flow
 in `TEST/run_debug_components.sh`. The examples are meant for development and
 integration testing. They show the request shape for common resources without
-expanding the main README API reference.
+expanding the main README API reference. For AI-agent and automation guardrails
+around these examples, see `AI_USAGE.md`.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ by CaumeDSE, see [TUTORIAL.md](TUTORIAL.md).
 For tested `curl` examples based on the live verifier fixtures, see
 [API_EXAMPLES.md](API_EXAMPLES.md).
 
+For safe AI-agent and automation patterns around the API, see
+[AI_USAGE.md](AI_USAGE.md).
+
 
 ## Contents
 
@@ -15,6 +18,7 @@ For tested `curl` examples based on the live verifier fixtures, see
 - [Status](#status)
 - [Cryptography and Data Security Tutorial](TUTORIAL.md)
 - [API Examples](API_EXAMPLES.md)
+- [AI-Safe API Usage](AI_USAGE.md)
 - [License](#license)
 - [Architecture and Functionality](#architecture-and-functionality)
 - [REST Resource API Reference](#rest-resource-api-reference)

--- a/README.md
+++ b/README.md
@@ -2203,6 +2203,10 @@ flows:
 
     TEST/run_debug_components.sh
 
+For CI smoke coverage, use:
+
+    TEST/run_debug_components.sh --ci-smoke
+
 The full mode uses `CDSE_DEBUG_TEST_HTTP_PORT` and
 `CDSE_DEBUG_TEST_HTTPS_PORT` when set, or ports 18080 and 18443 by default.
 The script rejects invalid, duplicate, or busy ports before launching the
@@ -2222,6 +2226,10 @@ machine-readable comparisons and `live-api-coverage.txt` for the fixed-width
 summary table.  Each row records protocol, feature name, inferred HTTP method,
 expected and actual status, curl result, marker status, elapsed time, and
 body/meta log paths.
+
+The `--ci-smoke` profile runs configure, build, install, component markers,
+HTTP/HTTPS startup checks, and one live API protocol. It defaults to HTTP live
+coverage; use `--ci-smoke --web-protocol=https` to select HTTPS instead.
 
 The committed test database under `TEST/testDB_opt_cdse` uses
 `0CDBB9AF76AF43BDB72E095989E612CC` as the `EngineAdmin` / `EngineOrg`

--- a/README.md
+++ b/README.md
@@ -2227,6 +2227,13 @@ summary table.  Each row records protocol, feature name, inferred HTTP method,
 expected and actual status, curl result, marker status, elapsed time, and
 body/meta log paths.
 
+Set `CDSE_VERIFY_REDACT=1` for CI logs or AI-assisted debugging sessions.  In
+that mode the verifier masks `orgKey`, `newOrgKey`, selected credential-style
+request parameters, and generated certificate/key file paths in `summary.txt`,
+live request body/meta artifacts, the full DEBUG run log, component extract
+logs, and live service logs.  Redaction is disabled by default so local
+debugging keeps full request details unless explicitly requested.
+
 The `--ci-smoke` profile runs configure, build, install, component markers,
 HTTP/HTTPS startup checks, and one live API protocol. It defaults to HTTP live
 coverage; use `--ci-smoke --web-protocol=https` to select HTTPS instead.

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -15,6 +15,7 @@ WEB_PROTOCOL="both"
 WEB_PROTOCOL_SET=0
 CI_SMOKE=0
 LIVE_FLOW_ID="liveflow$$"
+REDACT_OUTPUT="${CDSE_VERIFY_REDACT:-0}"
 
 PASSED=0
 FAILED=0
@@ -41,6 +42,7 @@ usage() {
     printf '  CDSE_DEBUG_TEST_HTTP_PORT  HTTP test port, default 18080\n'
     printf '  CDSE_DEBUG_TEST_HTTPS_PORT HTTPS test port, default 18443\n'
     printf '  CDSE_DEBUG_TEST_TIMEOUT    executable timeout, default 120s\n'
+    printf '  CDSE_VERIFY_REDACT         redact live verifier secrets from summaries and artifacts when set to 1/true/on\n'
 }
 
 while [ "$#" -gt 0 ]; do
@@ -113,8 +115,60 @@ printf 'protocol,feature,method,expected_status,actual_status,curl_rc,marker,sta
 printf '%-7s %-32s %-7s %-8s %-8s %-7s %-6s %-8s %-7s %s\n' \
     "proto" "feature" "method" "expect" "actual" "curl" "marker" "status" "elapsed" "logs" > "$LIVE_COVERAGE_TXT"
 
+elapsed_seconds() {
+    local start="$1"
+    local now
+
+    now="$(date +%s)"
+    printf '%ss' "$((now - start))"
+}
+
+csv_escape() {
+    local value="$1"
+    value="${value//\"/\"\"}"
+    printf '"%s"' "$value"
+}
+
+redaction_enabled() {
+    case "$REDACT_OUTPUT" in
+        1|true|TRUE|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+redact_stream() {
+    if ! redaction_enabled; then
+        cat
+        return 0
+    fi
+
+    sed -E \
+        -e 's/([?&])(\*?)(orgKey|newOrgKey|accessPath|accessUser|accessPassword|basicAuthPwdHash|oauthConsumerSecret|certificate|publicKey)=([^&"[:space:]]*)/\1\2\3=<redacted>/g' \
+        -e 's/(^|[[:space:]])(\*?)(orgKey|newOrgKey|accessPath|accessUser|accessPassword|basicAuthPwdHash|oauthConsumerSecret|certificate|publicKey)=([^"[:space:]]*)/\1\2\3=<redacted>/g' \
+        -e 's/(")(\*?)(orgKey|newOrgKey|accessPath|accessUser|accessPassword|basicAuthPwdHash|oauthConsumerSecret|certificate|publicKey)=([^"]*)(")/\1\2\3=<redacted>\5/g' \
+        -e 's#([^"[:space:]]*/[^"[:space:]]+\.(key|pem|srl|req|cnf))#<redacted-cert-path>#g'
+}
+
+redact_file_in_place() {
+    local file="$1"
+    local tmp
+
+    if ! redaction_enabled || [ ! -f "$file" ]; then
+        return 0
+    fi
+    tmp="${file}.redacted.$$"
+    if redact_stream < "$file" > "$tmp"; then
+        mv "$tmp" "$file"
+    else
+        rm -f "$tmp"
+        return 1
+    fi
+}
+
 note() {
-    printf '%s\n' "$*" | tee -a "$SUMMARY_FILE"
+    printf '%s\n' "$*" | redact_stream | tee -a "$SUMMARY_FILE"
 }
 
 record_pass() {
@@ -130,20 +184,6 @@ record_fail() {
 record_skip() {
     SKIPPED=$((SKIPPED + 1))
     note "SKIP $1 - $2"
-}
-
-elapsed_seconds() {
-    local start="$1"
-    local now
-
-    now="$(date +%s)"
-    printf '%ss' "$((now - start))"
-}
-
-csv_escape() {
-    local value="$1"
-    value="${value//\"/\"\"}"
-    printf '"%s"' "$value"
 }
 
 infer_live_method() {
@@ -288,6 +328,7 @@ extract_component_log() {
     local pattern="$2"
     local source="$3"
     grep -nE -- "$pattern" "$source" > "$out" 2>/dev/null || true
+    redact_file_in_place "$out"
 }
 
 check_component() {
@@ -354,6 +395,8 @@ live_curl() {
     LIVE_LAST_STATUS="$status"
     LIVE_LAST_CURL_RC="$rc"
     printf 'name=%s\nurl=%s\nstatus=%s\ncurl_rc=%s\n' "$name" "$url" "$status" "$rc" >> "$meta"
+    redact_file_in_place "$body"
+    redact_file_in_place "$meta"
     if [ "$rc" -ne 0 ]; then
         return 1
     fi
@@ -526,6 +569,7 @@ run_live_web_flow() {
 
     if ! wait_for_log_marker "$service_log" "CaumeDSE Debug: cmeWebServiceSetup(), $protocol_label server started on port $port." 20; then
         stop_live_service "$service_pid"
+        redact_file_in_place "$service_log"
         record_fail "live_${protocol}_api_flow" "service did not start log=$service_log"
         return 1
     fi
@@ -610,6 +654,7 @@ run_live_web_flow() {
     live_api_check "$protocol" delete_user 200 "$base_url/organizations/$org_name/users/$role_user?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
 
     stop_live_service "$service_pid"
+    redact_file_in_place "$service_log"
 
     if [ "$LIVE_FLOW_FAILED" -eq 0 ]; then
         record_pass "live_${protocol}_api_flow"
@@ -623,7 +668,7 @@ note "CaumeDSE DEBUG component verification"
 note "root=$ROOT_DIR"
 note "prefix=$PREFIX"
 note "logs=$LOG_ROOT"
-note "http_port=$HTTP_PORT https_port=$HTTPS_PORT timeout=$RUN_TIMEOUT web_protocol=$WEB_PROTOCOL live_only=$LIVE_ONLY ci_smoke=$CI_SMOKE"
+note "http_port=$HTTP_PORT https_port=$HTTPS_PORT timeout=$RUN_TIMEOUT web_protocol=$WEB_PROTOCOL live_only=$LIVE_ONLY ci_smoke=$CI_SMOKE redact=$REDACT_OUTPUT"
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
     run_step configure ./configure --prefix="$PREFIX" --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP || exit 1
@@ -853,6 +898,7 @@ else
     record_skip live_https_api_flow "requested --skip-web"
 fi
 
+redact_file_in_place "$FULL_LOG"
 append_live_coverage_summary
 note "RESULT passed=$PASSED failed=$FAILED skipped=$SKIPPED"
 note "summary=$SUMMARY_FILE"

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -12,6 +12,8 @@ SKIP_BUILD=0
 SKIP_WEB=0
 LIVE_ONLY=0
 WEB_PROTOCOL="both"
+WEB_PROTOCOL_SET=0
+CI_SMOKE=0
 LIVE_FLOW_ID="liveflow$$"
 
 PASSED=0
@@ -24,12 +26,13 @@ LIVE_LAST_STATUS=""
 LIVE_LAST_CURL_RC=""
 
 usage() {
-    printf 'Usage: %s [--skip-build] [--skip-web] [--live-only] [--web-protocol=http|https|both]\n' "$0"
+    printf 'Usage: %s [--skip-build] [--skip-web] [--live-only] [--ci-smoke] [--web-protocol=http|https|both]\n' "$0"
     printf '\n'
     printf 'Options:\n'
     printf '  --skip-build              reuse the current install prefix\n'
     printf '  --skip-web                skip DEBUG web startup and live API checks\n'
     printf '  --live-only               run only live API checks; implies --skip-build\n'
+    printf '  --ci-smoke                run build, component markers, and one live protocol; default http\n'
     printf '  --web-protocol=VALUE      live protocol to run: http, https, or both; default both\n'
     printf '\n'
     printf 'Environment:\n'
@@ -52,8 +55,12 @@ while [ "$#" -gt 0 ]; do
             LIVE_ONLY=1
             SKIP_BUILD=1
             ;;
+        --ci-smoke)
+            CI_SMOKE=1
+            ;;
         --web-protocol=*)
             WEB_PROTOCOL="${1#*=}"
+            WEB_PROTOCOL_SET=1
             ;;
         -h|--help)
             usage
@@ -68,6 +75,10 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
+if [ "$CI_SMOKE" -eq 1 ] && [ "$WEB_PROTOCOL_SET" -eq 0 ]; then
+    WEB_PROTOCOL="http"
+fi
+
 case "$WEB_PROTOCOL" in
     http|https|both)
         ;;
@@ -80,6 +91,16 @@ esac
 
 if [ "$LIVE_ONLY" -eq 1 ] && [ "$SKIP_WEB" -eq 1 ]; then
     printf '%s\n' '--live-only cannot be combined with --skip-web' >&2
+    exit 2
+fi
+
+if [ "$CI_SMOKE" -eq 1 ] && [ "$LIVE_ONLY" -eq 1 ]; then
+    printf '%s\n' '--ci-smoke cannot be combined with --live-only' >&2
+    exit 2
+fi
+
+if [ "$CI_SMOKE" -eq 1 ] && [ "$SKIP_WEB" -eq 1 ]; then
+    printf '%s\n' '--ci-smoke cannot be combined with --skip-web' >&2
     exit 2
 fi
 
@@ -602,7 +623,7 @@ note "CaumeDSE DEBUG component verification"
 note "root=$ROOT_DIR"
 note "prefix=$PREFIX"
 note "logs=$LOG_ROOT"
-note "http_port=$HTTP_PORT https_port=$HTTPS_PORT timeout=$RUN_TIMEOUT web_protocol=$WEB_PROTOCOL live_only=$LIVE_ONLY"
+note "http_port=$HTTP_PORT https_port=$HTTPS_PORT timeout=$RUN_TIMEOUT web_protocol=$WEB_PROTOCOL live_only=$LIVE_ONLY ci_smoke=$CI_SMOKE"
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
     run_step configure ./configure --prefix="$PREFIX" --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP || exit 1

--- a/TODO.md
+++ b/TODO.md
@@ -384,10 +384,67 @@
     - Batch 3: cross-link the examples from README and validate example routes against live verifier behavior.
   - Done: added `API_EXAMPLES.md` with curl examples derived from the live verifier flow, covering authentication negatives, organization/storage/user setup, documentTypes, role/filter resources, secure CSV upload/content, rows/columns, secure DB browsing, parser scripts, cleanup, and verifier commands. Linked it from README and validated the examples against the current live verifier route names and committed fixtures.
 
-- [ ] #65 Add CI-friendly verifier profile.
+- [x] #65 Add CI-friendly verifier profile.
   - Source: `TEST/run_debug_components.sh`, build/test workflow.
   - Goal: keep full local verification available while providing a practical PR/CI smoke profile.
   - Plan:
     - Batch 1: define the minimum CI smoke set: syntax/build, component markers, and one selected live protocol.
     - Batch 2: add a verifier switch such as `--ci-smoke` that selects the bounded profile without changing the default full run.
     - Batch 3: document expected runtime, prerequisites, exit behavior, and failure artifacts.
+  - Done: added `--ci-smoke` to `TEST/run_debug_components.sh`. The profile keeps the normal configure/build/check/install path, component marker extraction, and DEBUG web startup checks, then runs one live API protocol instead of both. It defaults to HTTP live coverage and accepts `--ci-smoke --web-protocol=https` to select HTTPS. Documented the command in README, TUTORIAL, API_EXAMPLES, and AGENTS, and validated `bash -n TEST/run_debug_components.sh` plus `TEST/run_debug_components.sh --ci-smoke` (`73 passed, 0 failed, 1 skipped`).
+
+- [ ] #66 Add AI-safe API usage examples.
+  - Source: `AI_USAGE.md`, `API_EXAMPLES.md`, live verifier fixtures.
+  - Goal: document safe patterns for LLM agents and automation that call CaumeDSE without leaking keys or over-broad access.
+  - Plan:
+    - Batch 1: outline safe agent workflows for scoped org keys, least-privilege users, parser-script restrictions, audit logs, and cleanup.
+    - Batch 2: add `AI_USAGE.md` with concrete examples and explicit anti-patterns for prompts, logs, and generated scripts.
+    - Batch 3: cross-link from README/API examples and validate examples against current verifier routes.
+
+- [ ] #67 Add machine-readable OpenAPI spec.
+  - Source: `README.md`, `API_EXAMPLES.md`, `TEST/run_debug_components.sh`.
+  - Goal: make CaumeDSE easier for AI agents, SDK generators, docs tooling, and API validators to consume.
+  - Plan:
+    - Batch 1: inventory documented REST resources, methods, parameters, status codes, and response formats.
+    - Batch 2: add `openapi.yaml` for the stable documented routes, starting with live-verifier-covered resources.
+    - Batch 3: add a lightweight validation check that compares key examples or route names against the spec.
+
+- [ ] #68 Add JSON output mode for key API resources.
+  - Source: `webservice_interface.c`, response formatting helpers, README/API examples.
+  - Goal: provide structured responses that are easier for AI agents and modern clients to parse than HTML or CSV.
+  - Plan:
+    - Batch 1: identify shared response-formatting helpers and the safest initial resources to support.
+    - Batch 2: add `outputType=json` for documentTypes, documents, content rows/columns, dbNames/dbTables, parserScripts, and role/filter reads.
+    - Batch 3: extend DEBUG/live verifier coverage and document JSON examples.
+
+- [ ] #69 Add AI agent integration sample.
+  - Source: `samples/ai-agent/`, `API_EXAMPLES.md`, verifier fixtures.
+  - Goal: show a guarded end-to-end Python agent workflow using CaumeDSE APIs.
+  - Plan:
+    - Batch 1: define a minimal scripted workflow for create org/storage, upload CSV, query rows/columns, run parser, and cleanup.
+    - Batch 2: add a sample Python client with guardrails to avoid putting org keys or sensitive data in prompts/logs.
+    - Batch 3: document setup, expected outputs, and validation against DEBUG/live verifier fixtures.
+
+- [ ] #70 Add redaction mode for logs and verifier artifacts.
+  - Source: DEBUG logging, `TEST/run_debug_components.sh`, live coverage artifacts.
+  - Goal: reduce accidental disclosure of org keys, `newOrgKey`, certificate paths, and sensitive query values during AI-assisted debugging and CI runs.
+  - Plan:
+    - Batch 1: identify log and metadata paths that currently include secrets or sensitive request values.
+    - Batch 2: add a config/env-controlled redaction mode for live verifier artifacts and selected DEBUG diagnostics.
+    - Batch 3: validate that pass/fail diagnostics remain useful while secrets are masked.
+
+- [ ] #71 Add MCP server prototype.
+  - Source: new `samples/mcp-server/` or `samples/ai-agent/`, REST API examples.
+  - Goal: expose safe CaumeDSE operations through Model Context Protocol tools for AI assistants.
+  - Plan:
+    - Batch 1: define a minimal tool surface such as list document types, upload CSV, query column, run parser, and cleanup workspace.
+    - Batch 2: implement a prototype MCP wrapper that calls the REST API with scoped credentials.
+    - Batch 3: document security boundaries and avoid exposing raw org keys or unrestricted parser execution.
+
+- [ ] #72 Add prompt-injection resistant parser-script guidance.
+  - Source: `TUTORIAL.md`, parser script docs, `TEST/testfiles/`.
+  - Goal: help users treat CSV contents and generated parser scripts as untrusted inputs in LLM-connected systems.
+  - Plan:
+    - Batch 1: document prompt-injection and data-exfiltration risks specific to parser scripts and CSV content.
+    - Batch 2: add safe parser-script patterns and review checklists for generated Perl/Python scripts.
+    - Batch 3: link the guidance from parser documentation and AI usage examples.

--- a/TODO.md
+++ b/TODO.md
@@ -425,13 +425,20 @@
     - Batch 2: add a sample Python client with guardrails to avoid putting org keys or sensitive data in prompts/logs.
     - Batch 3: document setup, expected outputs, and validation against DEBUG/live verifier fixtures.
 
-- [ ] #70 Add redaction mode for logs and verifier artifacts.
+- [x] #70 Add redaction mode for logs and verifier artifacts.
   - Source: DEBUG logging, `TEST/run_debug_components.sh`, live coverage artifacts.
   - Goal: reduce accidental disclosure of org keys, `newOrgKey`, certificate paths, and sensitive query values during AI-assisted debugging and CI runs.
   - Plan:
     - Batch 1: identify log and metadata paths that currently include secrets or sensitive request values.
     - Batch 2: add a config/env-controlled redaction mode for live verifier artifacts and selected DEBUG diagnostics.
     - Batch 3: validate that pass/fail diagnostics remain useful while secrets are masked.
+  - Done: added opt-in `CDSE_VERIFY_REDACT=1` support to the DEBUG verifier.
+    Redacted runs mask `orgKey`, `newOrgKey`, selected credential-style request
+    parameters, and generated certificate/key paths in `summary.txt`, live
+    request body/meta artifacts, the full DEBUG run log, component extract logs,
+    and live service logs while preserving statuses, markers, elapsed times, and
+    artifact names. Documented the mode in README, TUTORIAL, API_EXAMPLES, and
+    AGENTS.
 
 - [ ] #71 Add MCP server prototype.
   - Source: new `samples/mcp-server/` or `samples/ai-agent/`, REST API examples.

--- a/TODO.md
+++ b/TODO.md
@@ -393,13 +393,17 @@
     - Batch 3: document expected runtime, prerequisites, exit behavior, and failure artifacts.
   - Done: added `--ci-smoke` to `TEST/run_debug_components.sh`. The profile keeps the normal configure/build/check/install path, component marker extraction, and DEBUG web startup checks, then runs one live API protocol instead of both. It defaults to HTTP live coverage and accepts `--ci-smoke --web-protocol=https` to select HTTPS. Documented the command in README, TUTORIAL, API_EXAMPLES, and AGENTS, and validated `bash -n TEST/run_debug_components.sh` plus `TEST/run_debug_components.sh --ci-smoke` (`73 passed, 0 failed, 1 skipped`).
 
-- [ ] #66 Add AI-safe API usage examples.
+- [x] #66 Add AI-safe API usage examples.
   - Source: `AI_USAGE.md`, `API_EXAMPLES.md`, live verifier fixtures.
   - Goal: document safe patterns for LLM agents and automation that call CaumeDSE without leaking keys or over-broad access.
   - Plan:
     - Batch 1: outline safe agent workflows for scoped org keys, least-privilege users, parser-script restrictions, audit logs, and cleanup.
     - Batch 2: add `AI_USAGE.md` with concrete examples and explicit anti-patterns for prompts, logs, and generated scripts.
     - Batch 3: cross-link from README/API examples and validate examples against current verifier routes.
+  - Done: added `AI_USAGE.md` with AI-agent boundaries, least-privilege
+    workflow guidance, secret-safe shell setup, narrow request examples,
+    parser-script review guardrails, redacted verifier usage, anti-patterns, and
+    validation commands. Linked it from README and API_EXAMPLES.
 
 - [ ] #67 Add machine-readable OpenAPI spec.
   - Source: `README.md`, `API_EXAMPLES.md`, `TEST/run_debug_components.sh`.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -435,6 +435,9 @@ TEST/run_debug_components.sh
 # Component-only rerun using an existing install.
 TEST/run_debug_components.sh --skip-build --skip-web
 
+# CI smoke profile: build, component markers, web startup, and HTTP live flow.
+TEST/run_debug_components.sh --ci-smoke
+
 # Focused live HTTP rerun.
 TEST/run_debug_components.sh --live-only --web-protocol=http
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -455,6 +455,13 @@ the verifier log directory so route coverage, expected/actual statuses, marker
 checks, elapsed time, and response log paths can be reviewed without reading
 the shell script.
 
+For CI logs or AI-assisted debugging, run the verifier with
+`CDSE_VERIFY_REDACT=1`.  This masks `orgKey`, `newOrgKey`, selected
+credential-style request parameters, and generated certificate/key paths in the
+run summary, live request artifacts, the full DEBUG run log, component extract
+logs, and live service logs while preserving status codes, markers, elapsed
+times, and artifact names.
+
 ## Operational Checklist
 
 Use this checklist before handling real sensitive data:


### PR DESCRIPTION
## Summary
- add opt-in verifier artifact redaction with CDSE_VERIFY_REDACT=1
- document redacted CI and AI-assisted debugging workflows
- add AI_USAGE.md with safe agent/API patterns, parser guardrails, and anti-patterns
- mark TODO #66 and #70 complete

## Validation
- bash -n TEST/run_debug_components.sh
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --help
- git diff --check