### PR TITLE
Add AI-friendly API integrations

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -127,3 +127,10 @@ CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke
 For quick documentation-only edits, compare route names against
 `API_EXAMPLES.md` and `TEST/run_debug_components.sh` before running the full
 live flow.
+
+## Integration Sample
+
+See `samples/ai-agent/` for a guarded Python workflow that creates disposable
+resources, uploads verifier fixtures, queries row/column/parser results as
+JSON, builds an LLM-safe prompt preview without secrets, and cleans up the
+workspace.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -4,7 +4,8 @@ This file contains compact `curl` examples aligned with the live verifier flow
 in `TEST/run_debug_components.sh`. The examples are meant for development and
 integration testing. They show the request shape for common resources without
 expanding the main README API reference. For AI-agent and automation guardrails
-around these examples, see `AI_USAGE.md`.
+around these examples, see `AI_USAGE.md`. For a machine-readable reference for
+the stable documented routes, see `openapi.yaml`.
 
 ## Setup
 
@@ -253,6 +254,7 @@ produce a coverage matrix, run:
 TEST/run_debug_components.sh --ci-smoke
 TEST/run_debug_components.sh --live-only --web-protocol=http
 TEST/run_debug_components.sh --live-only --web-protocol=https
+TEST/validate_openapi_routes.sh
 ```
 
 The verifier writes `live-api-coverage.csv` and `live-api-coverage.txt` under

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -81,6 +81,9 @@ List document types, check `file.csv`, and verify an unsupported document type.
 curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes?$AUTH&newOrgKey=$ORG_KEY"
 
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes?$AUTH&newOrgKey=$ORG_KEY&outputType=json"
+
 curl -I $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv?$AUTH&newOrgKey=$ORG_KEY"
 
@@ -100,6 +103,9 @@ curl -i $TLS_ARGS -X POST \
 
 curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/users/$USER/roleTables/users?$AUTH&newOrgKey=$ORG_KEY"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/users/$USER/roleTables/users?$AUTH&newOrgKey=$ORG_KEY&outputType=json"
 
 curl -i $TLS_ARGS -X POST \
   "$BASE_URL/organizations/$ORG/users/$USER/filterWhitelist/$USER?$AUTH&newOrgKey=$ORG_KEY&*_get=1&*_post=0&*_put=0&*_delete=0&*_head=1&*_options=1"
@@ -131,6 +137,9 @@ curl -i $TLS_ARGS \
 curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents?$AUTH&newOrgKey=$ORG_KEY"
 
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents?$AUTH&newOrgKey=$ORG_KEY&outputType=json"
+
 curl -I $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC?$AUTH&newOrgKey=$ORG_KEY"
 
@@ -149,6 +158,9 @@ curl -i $TLS_ARGS -X OPTIONS \
 
 curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentRows/1?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentRows/1?$AUTH&newOrgKey=$ORG_KEY&outputType=json"
 
 curl -i $TLS_ARGS -X OPTIONS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/contentColumns?$AUTH&newOrgKey=$ORG_KEY"
@@ -180,6 +192,9 @@ curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables/data/tableRows/1?$AUTH&newOrgKey=$ORG_KEY"
 
 curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables/data/tableRows/1?$AUTH&newOrgKey=$ORG_KEY&outputType=json"
+
+curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/dbNames/$CSV_DOC/dbTables/data/tableColumns/name?$AUTH&newOrgKey=$ORG_KEY"
 
 # Invalid row selectors return 403.
@@ -204,6 +219,9 @@ curl -i $TLS_ARGS \
 
 curl -i $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/parserScripts/$SCRIPT_PERL?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"
+
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/parserScripts/$SCRIPT_PERL?$AUTH&newOrgKey=$ORG_KEY&outputType=json"
 
 curl -I $TLS_ARGS \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/file.csv/documents/$CSV_DOC/parserScripts/missing.pl?$AUTH&newOrgKey=$ORG_KEY&outputType=csv"

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -5,7 +5,8 @@ in `TEST/run_debug_components.sh`. The examples are meant for development and
 integration testing. They show the request shape for common resources without
 expanding the main README API reference. For AI-agent and automation guardrails
 around these examples, see `AI_USAGE.md`. For a machine-readable reference for
-the stable documented routes, see `openapi.yaml`.
+the stable documented routes, see `openapi.yaml`. For a guarded end-to-end
+Python automation sample, see `samples/ai-agent/`.
 
 ## Setup
 

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ caume_common_sources = common.h config.c crypto.c crypto.h db.c db.h engine_admi
 CaumeDSE_SOURCES = main.c $(caume_common_sources)
 CaumeDSE_debug_tests_SOURCES = debug_tests.c $(caume_common_sources)
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
-EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
+EXTRA_DIST = TEST samples README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
 all: config.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ caume_common_sources = common.h config.c crypto.c crypto.h db.c db.h engine_admi
 CaumeDSE_SOURCES = main.c $(caume_common_sources)
 CaumeDSE_debug_tests_SOURCES = debug_tests.c $(caume_common_sources)
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
-EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md
+EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
 all: config.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ caume_common_sources = common.h config.c crypto.c crypto.h db.c db.h engine_admi
 CaumeDSE_SOURCES = main.c $(caume_common_sources)
 CaumeDSE_debug_tests_SOURCES = debug_tests.c $(caume_common_sources)
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
-EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md
+EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
 
 xs_init.c:
 	`@PERL@ -MExtUtils::Embed -e xsinit -- -o xs_init.c`

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ caume_common_sources = common.h config.c crypto.c crypto.h db.c db.h engine_admi
 CaumeDSE_SOURCES = main.c $(caume_common_sources)
 CaumeDSE_debug_tests_SOURCES = debug_tests.c $(caume_common_sources)
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
-EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
+EXTRA_DIST = TEST samples README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
 
 xs_init.c:
 	`@PERL@ -MExtUtils::Embed -e xsinit -- -o xs_init.c`

--- a/Makefile.in
+++ b/Makefile.in
@@ -405,7 +405,7 @@ caume_common_sources = common.h config.c crypto.c crypto.h db.c db.h engine_admi
 CaumeDSE_SOURCES = main.c $(caume_common_sources)
 CaumeDSE_debug_tests_SOURCES = debug_tests.c $(caume_common_sources)
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
-EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
+EXTRA_DIST = TEST samples README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
 all: config.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -405,7 +405,7 @@ caume_common_sources = common.h config.c crypto.c crypto.h db.c db.h engine_admi
 CaumeDSE_SOURCES = main.c $(caume_common_sources)
 CaumeDSE_debug_tests_SOURCES = debug_tests.c $(caume_common_sources)
 ipathdata_DATA = favicon.ico TEST/testCertAuth/ca.pem TEST/testCertAuth/server.pem TEST/testCertAuth/server.key
-EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md
+EXTRA_DIST = TEST README-alpha CHANGELOG.md README.md TUTORIAL.md API_EXAMPLES.md AI_USAGE.md openapi.yaml
 all: config.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 

--- a/README.md
+++ b/README.md
@@ -990,10 +990,12 @@ newOrgKey
 
 outputType
     Specifies the type of output for the result. Available values are
-    csv and HTML (the later is the default).  this is particularly
-    useful for results that return data tables, such as resource
-    specification queries or requests for the contents of csv type
-    files.
+    csv, json and HTML (the latter is the default).  This is
+    particularly useful for results that return data tables, such as
+    resource specification queries, content rows/columns, parser script
+    output, secure DB browsing, and requests for the contents of csv
+    type files. JSON table responses use this shape:
+    `{"columns":[...],"rows":[{"column":"value"}]}`.
 
 #### 3.4 Document POST parameters
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ API surface, see [openapi.yaml](openapi.yaml).
 For safe AI-agent and automation patterns around the API, see
 [AI_USAGE.md](AI_USAGE.md).
 
+For a guarded Python AI-agent workflow sample, see
+[samples/ai-agent/](samples/ai-agent/).
+
 
 ## Contents
 
@@ -23,6 +26,7 @@ For safe AI-agent and automation patterns around the API, see
 - [API Examples](API_EXAMPLES.md)
 - [OpenAPI Route Reference](openapi.yaml)
 - [AI-Safe API Usage](AI_USAGE.md)
+- [AI Agent Sample](samples/ai-agent/)
 - [License](#license)
 - [Architecture and Functionality](#architecture-and-functionality)
 - [REST Resource API Reference](#rest-resource-api-reference)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ by CaumeDSE, see [TUTORIAL.md](TUTORIAL.md).
 For tested `curl` examples based on the live verifier fixtures, see
 [API_EXAMPLES.md](API_EXAMPLES.md).
 
+For a machine-readable route reference for the stable live-verifier-covered
+API surface, see [openapi.yaml](openapi.yaml).
+
 For safe AI-agent and automation patterns around the API, see
 [AI_USAGE.md](AI_USAGE.md).
 
@@ -18,6 +21,7 @@ For safe AI-agent and automation patterns around the API, see
 - [Status](#status)
 - [Cryptography and Data Security Tutorial](TUTORIAL.md)
 - [API Examples](API_EXAMPLES.md)
+- [OpenAPI Route Reference](openapi.yaml)
 - [AI-Safe API Usage](AI_USAGE.md)
 - [License](#license)
 - [Architecture and Functionality](#architecture-and-functionality)

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -843,6 +843,12 @@ check_component db_browsing_resource 'Testing dbNames secure DB browsing resourc
     'TESTS: testDBBrowsing(), PASS: tableRow resource GET responseCode=200' \
     'TESTS: testDBBrowsing(), PASS: dbNames/dbTables/tableRows/tableColumns browsing verified.'
 
+if bash "$ROOT_DIR/TEST/validate_openapi_routes.sh" > "$LOG_ROOT/openapi-validation.log" 2>&1; then
+    record_pass "openapi_route_reference"
+else
+    record_fail "openapi_route_reference" "see $LOG_ROOT/openapi-validation.log"
+fi
+
 check_component sqlite_thread_safety 'Testing thread safety|Thread safety test|test_thread_' "$FULL_LOG" \
     '--- Thread safety test: PASSED'
 

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -585,14 +585,18 @@ run_live_web_flow() {
     live_api_check "$protocol" create_storage 201 "$base_url/organizations/$org_name/storage/$storage_name?$auth&newOrgKey=$org_key&*resourceInfo=live%20$protocol%20storage&*location=localhost&*type=local&*accessPath=$storage_path&*accessUser=undefined&*accessPassword=undefined" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" create_user 201 "$base_url/organizations/$org_name/users/$role_user?$auth&newOrgKey=$org_key&*resourceInfo=live%20$protocol%20user&*certificate=undefined&*publicKey=undefined&*basicAuthPwdHash=undefined&*oauthConsumerKey=undefined&*oauthConsumerSecret=undefined" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" document_types_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes?$auth&newOrgKey=$org_key" "file.csv" "${curl_tls_args[@]}"
+    live_api_check "$protocol" document_types_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" document_type_csv_head 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -I
     live_api_check "$protocol" document_type_unsupported 404 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/unsupported.type?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" role_table_post 201 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key&*_get=1&*_post=0&*_put=1&*_delete=0&*_head=1&*_options=1" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" role_table_get 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key" "$role_user" "${curl_tls_args[@]}"
+    live_api_check "$protocol" role_table_json_get 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" filter_whitelist_post 201 "$base_url/organizations/$org_name/users/$role_user/filterWhitelist/$role_user?$auth&newOrgKey=$org_key&*_get=1&*_post=0&*_put=0&*_delete=0&*_head=1&*_options=1" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" filter_whitelist_get 200 "$base_url/organizations/$org_name/users/$role_user/filterWhitelist/$role_user?$auth&newOrgKey=$org_key" "$role_user" "${curl_tls_args[@]}"
+    live_api_check "$protocol" filter_whitelist_json_get 200 "$base_url/organizations/$org_name/users/$role_user/filterWhitelist/$role_user?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" filter_blacklist_post 201 "$base_url/organizations/$org_name/users/$role_user/filterBlacklist/$role_user?$auth&newOrgKey=$org_key&*_get=0&*_post=1&*_put=0&*_delete=0&*_head=0&*_options=0" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" filter_blacklist_get 200 "$base_url/organizations/$org_name/users/$role_user/filterBlacklist/$role_user?$auth&newOrgKey=$org_key" "$role_user" "${curl_tls_args[@]}"
+    live_api_check "$protocol" filter_blacklist_json_get 200 "$base_url/organizations/$org_name/users/$role_user/filterBlacklist/$role_user?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_csv 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/live-api-small.csv" \
         -F "userId=$user_id" \
@@ -601,18 +605,25 @@ run_live_web_flow() {
         -F "newOrgKey=$org_key" \
         -F "*resourceInfo=live $protocol CSV"
     live_api_check "$protocol" documents_list 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents?$auth&newOrgKey=$org_key" "$csv_name" "${curl_tls_args[@]}"
+    live_api_check "$protocol" documents_json_list 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" document_head 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -I
     live_api_check "$protocol" content_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/content?$auth&newOrgKey=$org_key&outputType=csv" "Jacob" "${curl_tls_args[@]}"
     live_api_check "$protocol" content_rows_options 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X OPTIONS
     live_api_check "$protocol" row_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows/1?$auth&newOrgKey=$org_key&outputType=csv" "Jacob" "${curl_tls_args[@]}"
+    live_api_check "$protocol" row_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows/1?$auth&newOrgKey=$org_key&outputType=json" '"name":"Jacob"' "${curl_tls_args[@]}"
     live_api_check "$protocol" content_columns_options 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentColumns?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X OPTIONS
     live_api_check "$protocol" column_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentColumns/name?$auth&newOrgKey=$org_key&outputType=csv" "Jacob" "${curl_tls_args[@]}"
+    live_api_check "$protocol" column_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentColumns/name?$auth&newOrgKey=$org_key&outputType=json" '"name":"Jacob"' "${curl_tls_args[@]}"
     live_api_check "$protocol" column_create_empty_doc 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$column_doc_name/contentColumns/Col1?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" column_delete_empty_doc 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$column_doc_name/contentColumns/Col1?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
     live_api_check "$protocol" db_names_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames?$auth&newOrgKey=$org_key" "$csv_name" "${curl_tls_args[@]}"
+    live_api_check "$protocol" db_names_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" db_tables_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables?$auth&newOrgKey=$org_key" "data" "${curl_tls_args[@]}"
+    live_api_check "$protocol" db_tables_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" table_row_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableRows/1?$auth&newOrgKey=$org_key" "Jacob" "${curl_tls_args[@]}"
+    live_api_check "$protocol" table_row_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableRows/1?$auth&newOrgKey=$org_key&outputType=json" '"name":"Jacob"' "${curl_tls_args[@]}"
     live_api_check "$protocol" table_column_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableColumns/name?$auth&newOrgKey=$org_key" "Jacob" "${curl_tls_args[@]}"
+    live_api_check "$protocol" table_column_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableColumns/name?$auth&newOrgKey=$org_key&outputType=json" '"name":"Jacob"' "${curl_tls_args[@]}"
     live_api_check "$protocol" db_browse_bad_row 403 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableRows/0?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.perl/documents/$script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test.pl" \
@@ -622,6 +633,7 @@ run_live_web_flow() {
         -F "newOrgKey=$org_key" \
         -F "*resourceInfo=live $protocol Perl script"
     live_api_check "$protocol" parser_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$script_name?$auth&newOrgKey=$org_key&outputType=csv" "82400" "${curl_tls_args[@]}"
+    live_api_check "$protocol" parser_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$script_name?$auth&newOrgKey=$org_key&outputType=json" '"salary":"82400"' "${curl_tls_args[@]}"
     live_api_check "$protocol" parser_missing_head 404 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/missing.pl?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}" -I
     live_api_check "$protocol" upload_python_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test.py" \
@@ -631,6 +643,7 @@ run_live_web_flow() {
         -F "newOrgKey=$org_key" \
         -F "*resourceInfo=live $protocol Python script"
     live_api_check "$protocol" python_parser_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_script_name?$auth&newOrgKey=$org_key&outputType=csv" "82400" "${curl_tls_args[@]}"
+    live_api_check "$protocol" python_parser_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_script_name?$auth&newOrgKey=$org_key&outputType=json" '"salary":"82400"' "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_python_timeout_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_timeout_script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test_timeout.py" \
         -F "userId=$user_id" \
@@ -760,6 +773,12 @@ check_component crypto_gcm_direct 'GCM ciphertext size|GCM B64|GCM decrypted tex
 
 check_component crypto_gcm_bytestring 'testCryptoSymmetricGCM_ByteString|cipher mode|PBKDF' "$FULL_LOG" \
     'TESTS: testCryptoSymmetricGCM_ByteString(), PASS: plaintext matches.'
+
+check_component json_response_formatting 'Testing JSON response formatting|testJSONResponses|JSON outputType' "$FULL_LOG" \
+    '--- Testing JSON response formatting:' \
+    'TESTS: testJSONResponses(), PASS: table response JSON outputType.' \
+    'TESTS: testJSONResponses(), PASS: count response JSON outputType.' \
+    'TESTS: testJSONResponses(), PASS: JSON response formatting verified.'
 
 check_component crypto_streaming '---ctSize|---etSize|Decrypted text|Unprotected text' "$FULL_LOG" \
     'Unprotected text: This is cleartext This is cleartext This is cleartext This is cleartext.'

--- a/TEST/validate_openapi_routes.sh
+++ b/TEST/validate_openapi_routes.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPEC="$ROOT_DIR/openapi.yaml"
+README="$ROOT_DIR/README.md"
+EXAMPLES="$ROOT_DIR/API_EXAMPLES.md"
+VERIFIER="$ROOT_DIR/TEST/run_debug_components.sh"
+
+failures=0
+
+require_file() {
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        printf 'FAIL missing file: %s\n' "$file" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+require_pattern() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    if ! grep -Fq "$pattern" "$file"; then
+        printf 'FAIL %s missing pattern in %s: %s\n' "$label" "$file" "$pattern" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+require_file "$SPEC"
+require_file "$README"
+require_file "$EXAMPLES"
+require_file "$VERIFIER"
+
+if [ "$failures" -ne 0 ]; then
+    exit 1
+fi
+
+require_pattern "$SPEC" "openapi: 3.0.3" "openapi version"
+require_pattern "$README" "openapi.yaml" "README OpenAPI link"
+require_pattern "$EXAMPLES" "openapi.yaml" "API examples OpenAPI link"
+require_pattern "$VERIFIER" "validate_openapi_routes.sh" "verifier OpenAPI validation"
+
+required_paths=(
+    "/organizations:"
+    "/organizations/{organization}:"
+    "/organizations/{organization}/users/{user}:"
+    "/organizations/{organization}/users/{user}/roleTables/{roleTable}:"
+    "/organizations/{organization}/users/{user}/filterWhitelist/{filterUser}:"
+    "/organizations/{organization}/users/{user}/filterBlacklist/{filterUser}:"
+    "/organizations/{organization}/storage/{storage}:"
+    "/organizations/{organization}/storage/{storage}/documentTypes:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/{documentType}:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/{documentType}/documents:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/{documentType}/documents/{document}:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/{documentType}/documents/{document}/content:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentRows/{contentRow}:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentColumns/{contentColumn}:"
+    "/organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/parserScripts/{parserScript}:"
+    "/organizations/{organization}/storage/{storage}/dbNames:"
+    "/organizations/{organization}/storage/{storage}/dbNames/{dbName}/dbTables:"
+    "/organizations/{organization}/storage/{storage}/dbNames/{dbName}/dbTables/{dbTable}/tableRows/{tableRow}:"
+    "/organizations/{organization}/storage/{storage}/dbNames/{dbName}/dbTables/{dbTable}/tableColumns/{tableColumn}:"
+)
+
+for path in "${required_paths[@]}"; do
+    require_pattern "$SPEC" "$path" "OpenAPI path"
+done
+
+live_markers=(
+    "create_org"
+    "create_storage"
+    "create_user"
+    "document_types_get"
+    "role_table_post"
+    "filter_whitelist_post"
+    "filter_blacklist_post"
+    "upload_csv"
+    "content_get"
+    "row_get"
+    "column_get"
+    "db_names_get"
+    "db_tables_get"
+    "table_row_get"
+    "table_column_get"
+    "parser_get"
+    "python_parser_get"
+)
+
+for marker in "${live_markers[@]}"; do
+    require_pattern "$VERIFIER" "$marker" "live verifier marker"
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf 'OpenAPI route validation failed: %d issue(s)\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'OpenAPI route validation passed: %s\n' "$SPEC"

--- a/TODO.md
+++ b/TODO.md
@@ -423,13 +423,14 @@
     - Batch 3: extend DEBUG/live verifier coverage and document JSON examples.
   - Done: added JSON table/count response formatting with escaping and `application/json` headers, added JSON handling for the special `documentTypes` collection route, documented `outputType=json`, updated OpenAPI response metadata, and extended DEBUG plus live HTTP verifier coverage for documentTypes, documents, content rows/columns, dbNames/dbTables/tableRows/tableColumns, parserScripts, and role/filter reads.
 
-- [ ] #69 Add AI agent integration sample.
+- [x] #69 Add AI agent integration sample.
   - Source: `samples/ai-agent/`, `API_EXAMPLES.md`, verifier fixtures.
   - Goal: show a guarded end-to-end Python agent workflow using CaumeDSE APIs.
   - Plan:
     - Batch 1: define a minimal scripted workflow for create org/storage, upload CSV, query rows/columns, run parser, and cleanup.
     - Batch 2: add a sample Python client with guardrails to avoid putting org keys or sensitive data in prompts/logs.
     - Batch 3: document setup, expected outputs, and validation against DEBUG/live verifier fixtures.
+  - Done: added `samples/ai-agent/guarded_agent_workflow.py` and README documentation. The sample uses environment-based secrets, redacted request logging, reviewed verifier fixtures, narrow JSON row/column/parser queries, an LLM-safe prompt preview, and best-effort cleanup of uploaded documents, storage, and user resources. Linked the sample from README, AI_USAGE, and API_EXAMPLES.
 
 - [x] #70 Add redaction mode for logs and verifier artifacts.
   - Source: DEBUG logging, `TEST/run_debug_components.sh`, live coverage artifacts.

--- a/TODO.md
+++ b/TODO.md
@@ -414,13 +414,14 @@
     - Batch 3: add a lightweight validation check that compares key examples or route names against the spec.
   - Done: added `openapi.yaml` for the stable README/API_EXAMPLES/live-verifier route surface, including organizations, users, storage, documentTypes, documents, content, contentRows/contentColumns, parserScripts, role/filter resources, and secure DB browsing. Added `TEST/validate_openapi_routes.sh`, wired it into the DEBUG verifier summary, and linked the spec from README/API_EXAMPLES.
 
-- [ ] #68 Add JSON output mode for key API resources.
+- [x] #68 Add JSON output mode for key API resources.
   - Source: `webservice_interface.c`, response formatting helpers, README/API examples.
   - Goal: provide structured responses that are easier for AI agents and modern clients to parse than HTML or CSV.
   - Plan:
     - Batch 1: identify shared response-formatting helpers and the safest initial resources to support.
     - Batch 2: add `outputType=json` for documentTypes, documents, content rows/columns, dbNames/dbTables, parserScripts, and role/filter reads.
     - Batch 3: extend DEBUG/live verifier coverage and document JSON examples.
+  - Done: added JSON table/count response formatting with escaping and `application/json` headers, added JSON handling for the special `documentTypes` collection route, documented `outputType=json`, updated OpenAPI response metadata, and extended DEBUG plus live HTTP verifier coverage for documentTypes, documents, content rows/columns, dbNames/dbTables/tableRows/tableColumns, parserScripts, and role/filter reads.
 
 - [ ] #69 Add AI agent integration sample.
   - Source: `samples/ai-agent/`, `API_EXAMPLES.md`, verifier fixtures.

--- a/TODO.md
+++ b/TODO.md
@@ -405,13 +405,14 @@
     parser-script review guardrails, redacted verifier usage, anti-patterns, and
     validation commands. Linked it from README and API_EXAMPLES.
 
-- [ ] #67 Add machine-readable OpenAPI spec.
+- [x] #67 Add machine-readable OpenAPI spec.
   - Source: `README.md`, `API_EXAMPLES.md`, `TEST/run_debug_components.sh`.
   - Goal: make CaumeDSE easier for AI agents, SDK generators, docs tooling, and API validators to consume.
   - Plan:
     - Batch 1: inventory documented REST resources, methods, parameters, status codes, and response formats.
     - Batch 2: add `openapi.yaml` for the stable documented routes, starting with live-verifier-covered resources.
     - Batch 3: add a lightweight validation check that compares key examples or route names against the spec.
+  - Done: added `openapi.yaml` for the stable README/API_EXAMPLES/live-verifier route surface, including organizations, users, storage, documentTypes, documents, content, contentRows/contentColumns, parserScripts, role/filter resources, and secure DB browsing. Added `TEST/validate_openapi_routes.sh`, wired it into the DEBUG verifier summary, and linked the spec from README/API_EXAMPLES.
 
 - [ ] #68 Add JSON output mode for key API resources.
   - Source: `webservice_interface.c`, response formatting helpers, README/API examples.

--- a/debug_tests.c
+++ b/debug_tests.c
@@ -111,6 +111,7 @@ int main(int argc, char *argv[], char *env[])
     testPerl(cdsePerl);
     testDB(cdsePerl);
     testCSV();
+    testJSONResponses();
     testWebServices();
 
     debugTestsFree();

--- a/function_tests.c
+++ b/function_tests.c
@@ -1004,6 +1004,79 @@ static char **cmeTestAllocResponseHeaders(void)
     return(responseHeaders);
 }
 
+void testJSONResponses(void)
+{
+    int errors=0;
+    int responseCode=0;
+    char *jsonTable=NULL;
+    char *jsonCount=NULL;
+    char **responseHeaders=cmeTestAllocResponseHeaders();
+    const char *table[]={
+        "name","note",
+        "Jacob","quoted \"value\"",
+        "Line","one\ntwo"
+    };
+    const char *args[]={"outputType","json",NULL};
+
+    printf("--- Testing JSON response formatting:\n");
+    if (!responseHeaders)
+    {
+        fprintf(stderr,"CaumeDSE Error: testJSONResponses(), can't allocate response headers.\n");
+        return;
+    }
+    if (cmeConstructWebServiceTableResponse(table,2,2,args,"GET","/json-test","json-test",
+                                            &responseHeaders,&jsonTable,&responseCode) ||
+        responseCode!=200 ||
+        !jsonTable ||
+        !strstr(jsonTable,"\"columns\":[\"name\",\"note\"]") ||
+        !strstr(jsonTable,"\"name\":\"Jacob\"") ||
+        !strstr(jsonTable,"quoted \\\"value\\\"") ||
+        !strstr(jsonTable,"one\\ntwo") ||
+        !responseHeaders[2] ||
+        strcmp(responseHeaders[2],"Content-Type") ||
+        !responseHeaders[3] ||
+        strcmp(responseHeaders[3],"application/json"))
+    {
+        errors++;
+        fprintf(stderr,"CaumeDSE Error: testJSONResponses(), table JSON formatting failed. responseCode=%d body=%s\n",
+                responseCode,jsonTable?jsonTable:"(null)");
+    }
+    else
+    {
+        printf("TESTS: testJSONResponses(), PASS: table response JSON outputType.\n");
+    }
+    cmeFree(jsonTable);
+    cmeTestFreeResponseHeaders(responseHeaders);
+
+    responseHeaders=cmeTestAllocResponseHeaders();
+    responseCode=0;
+    if (!responseHeaders ||
+        cmeConstructWebServiceCountResponse("Deleted registers",3,args,"DELETE","/json-test",
+                                            &responseHeaders,&jsonCount,&responseCode) ||
+        !jsonCount ||
+        strcmp(jsonCount,"{\"Deleted registers\":3}") ||
+        !responseHeaders[2] ||
+        strcmp(responseHeaders[2],"Content-Type") ||
+        !responseHeaders[3] ||
+        strcmp(responseHeaders[3],"application/json"))
+    {
+        errors++;
+        fprintf(stderr,"CaumeDSE Error: testJSONResponses(), count JSON formatting failed. body=%s\n",
+                jsonCount?jsonCount:"(null)");
+    }
+    else
+    {
+        printf("TESTS: testJSONResponses(), PASS: count response JSON outputType.\n");
+    }
+    cmeFree(jsonCount);
+    cmeTestFreeResponseHeaders(responseHeaders);
+
+    if (!errors)
+    {
+        printf("TESTS: testJSONResponses(), PASS: JSON response formatting verified.\n");
+    }
+}
+
 static int cmeTestRoleTablesRequest(const char *method, const char *url,
                                     const char **urlElements, int numUrlElements,
                                     const char **argumentElements, int expectedCode,
@@ -1485,10 +1558,17 @@ static int cmeTestDocumentTypesRequest(const char *method, const char *url,
     int result,responseCode=0;
     char *responseText=NULL;
     char *responseFilePath=NULL;
+    char **responseHeaders=cmeTestAllocResponseHeaders();
+
+    if (!responseHeaders)
+    {
+        fprintf(stderr,"CaumeDSE Error: testDocumentTypes(), can't allocate response headers for %s.\n",marker);
+        return(1);
+    }
 
     if (numUrlElements==5)
     {
-        result=cmeWebServiceProcessDocumentTypeClass(&responseText,&responseCode,
+        result=cmeWebServiceProcessDocumentTypeClass(&responseText,&responseHeaders,&responseCode,
                                                      url,urlElements,argumentElements,method);
     }
     else
@@ -1502,11 +1582,13 @@ static int cmeTestDocumentTypesRequest(const char *method, const char *url,
                 marker,result,responseCode,expectedCode);
         cmeFree(responseText);
         cmeFree(responseFilePath);
+        cmeTestFreeResponseHeaders(responseHeaders);
         return(1);
     }
     printf("TESTS: testDocumentTypes(), PASS: %s responseCode=%d\n",marker,responseCode);
     cmeFree(responseText);
     cmeFree(responseFilePath);
+    cmeTestFreeResponseHeaders(responseHeaders);
     return(0);
 }
 

--- a/function_tests.h
+++ b/function_tests.h
@@ -62,6 +62,7 @@ void testDocumentTypes ();
 void testParserScripts ();
 void testContentRows ();
 void testThreadSafety ();
+void testJSONResponses ();
 void testWebServices ();
 
 #endif // FUNCTION_TESTS_H_INCLUDED

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,1572 @@
+openapi: 3.0.3
+info:
+  title: CaumeDSE REST API
+  version: 1.0.9
+  description: |
+    Machine-readable reference for the stable CaumeDSE routes documented in
+    README.md and exercised by TEST/run_debug_components.sh. Responses are
+    currently HTML or CSV-oriented text tables unless a route returns only a
+    status code. JSON output is tracked separately in TODO #68.
+servers:
+  - url: http://localhost:18080
+    description: DEBUG HTTP verifier server
+  - url: https://localhost:18443
+    description: DEBUG HTTPS verifier server
+tags:
+  - name: Authentication
+  - name: Organizations
+  - name: Users
+  - name: Roles and filters
+  - name: Storage
+  - name: Document types
+  - name: Documents
+  - name: Document content
+  - name: Parser scripts
+  - name: Secure DB browsing
+
+paths:
+  /organizations:
+    get:
+      tags: [Organizations]
+      summary: List organization resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/outputType"
+        - $ref: "#/components/parameters/matchPublicKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    put:
+      tags: [Organizations]
+      summary: Update matching organization resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/certificateUpdate"
+        - $ref: "#/components/parameters/publicKeyUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [Organizations]
+      summary: Delete matching organization resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    head:
+      tags: [Organizations]
+      summary: Count matching organization resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Organizations]
+      summary: Return supported methods for organizations.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+    get:
+      tags: [Organizations, Authentication]
+      summary: Read one organization resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Organizations]
+      summary: Create an organization resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/certificateUpdate"
+        - $ref: "#/components/parameters/publicKeyUpdate"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    put:
+      tags: [Organizations]
+      summary: Update one organization resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/certificateUpdate"
+        - $ref: "#/components/parameters/publicKeyUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [Organizations]
+      summary: Delete one organization resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    head:
+      tags: [Organizations]
+      summary: Check whether one organization resource exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Organizations]
+      summary: Return supported methods for one organization resource.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/users:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+    get:
+      tags: [Users]
+      summary: List user resources in an organization.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    put:
+      tags: [Users]
+      summary: Update matching user resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/certificateUpdate"
+        - $ref: "#/components/parameters/publicKeyUpdate"
+        - $ref: "#/components/parameters/basicAuthPwdHashUpdate"
+        - $ref: "#/components/parameters/oauthConsumerKeyUpdate"
+        - $ref: "#/components/parameters/oauthConsumerSecretUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete:
+      tags: [Users]
+      summary: Delete matching user resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Users]
+      summary: Count matching user resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Users]
+      summary: Return supported methods for users.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/users/{user}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/user"
+    get:
+      tags: [Users]
+      summary: Read one user resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Users]
+      summary: Create one user resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/certificateUpdate"
+        - $ref: "#/components/parameters/publicKeyUpdate"
+        - $ref: "#/components/parameters/basicAuthPwdHashUpdate"
+        - $ref: "#/components/parameters/oauthConsumerKeyUpdate"
+        - $ref: "#/components/parameters/oauthConsumerSecretUpdate"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    put:
+      tags: [Users]
+      summary: Update one user resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete:
+      tags: [Users]
+      summary: Delete one user resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Users]
+      summary: Check whether one user resource exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Users]
+      summary: Return supported methods for one user resource.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/users/{user}/roleTables/{roleTable}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/user"
+      - $ref: "#/components/parameters/roleTable"
+    get: &roleFilterGet
+      tags: [Roles and filters]
+      summary: Read one role table, whitelist, or blacklist resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post: &roleFilterPost
+      tags: [Roles and filters]
+      summary: Create one role table, whitelist, or blacklist resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/methodGetUpdate"
+        - $ref: "#/components/parameters/methodPostUpdate"
+        - $ref: "#/components/parameters/methodPutUpdate"
+        - $ref: "#/components/parameters/methodDeleteUpdate"
+        - $ref: "#/components/parameters/methodHeadUpdate"
+        - $ref: "#/components/parameters/methodOptionsUpdate"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    put: &roleFilterPut
+      tags: [Roles and filters]
+      summary: Update one role table, whitelist, or blacklist resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/methodGetUpdate"
+        - $ref: "#/components/parameters/methodPostUpdate"
+        - $ref: "#/components/parameters/methodPutUpdate"
+        - $ref: "#/components/parameters/methodDeleteUpdate"
+        - $ref: "#/components/parameters/methodHeadUpdate"
+        - $ref: "#/components/parameters/methodOptionsUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete: &roleFilterDelete
+      tags: [Roles and filters]
+      summary: Delete one role table, whitelist, or blacklist resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head: &roleFilterHead
+      tags: [Roles and filters]
+      summary: Check whether one role table, whitelist, or blacklist resource exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options: &roleFilterOptions
+      tags: [Roles and filters]
+      summary: Return supported methods for one role table, whitelist, or blacklist resource.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+  /organizations/{organization}/users/{user}/filterWhitelist/{filterUser}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/user"
+      - $ref: "#/components/parameters/filterUser"
+    get: *roleFilterGet
+    post: *roleFilterPost
+    put: *roleFilterPut
+    delete: *roleFilterDelete
+    head: *roleFilterHead
+    options: *roleFilterOptions
+  /organizations/{organization}/users/{user}/filterBlacklist/{filterUser}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/user"
+      - $ref: "#/components/parameters/filterUser"
+    get: *roleFilterGet
+    post: *roleFilterPost
+    put: *roleFilterPut
+    delete: *roleFilterDelete
+    head: *roleFilterHead
+    options: *roleFilterOptions
+
+  /organizations/{organization}/storage:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+    get:
+      tags: [Storage]
+      summary: List storage resources in an organization.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/storageTypeMatch"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    put:
+      tags: [Storage]
+      summary: Update matching storage resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/locationUpdate"
+        - $ref: "#/components/parameters/storageTypeUpdate"
+        - $ref: "#/components/parameters/accessPathUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete:
+      tags: [Storage]
+      summary: Delete matching storage resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Storage]
+      summary: Count matching storage resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Storage]
+      summary: Return supported methods for storage resources.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+    get:
+      tags: [Storage]
+      summary: Read one storage resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    post:
+      tags: [Storage]
+      summary: Create one storage resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+        - $ref: "#/components/parameters/locationUpdate"
+        - $ref: "#/components/parameters/storageTypeUpdate"
+        - $ref: "#/components/parameters/accessPathUpdate"
+        - $ref: "#/components/parameters/accessUserUpdate"
+        - $ref: "#/components/parameters/accessPasswordUpdate"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    put:
+      tags: [Storage]
+      summary: Update one storage resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete:
+      tags: [Storage]
+      summary: Delete one storage resource.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Storage]
+      summary: Check whether one storage resource exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Storage]
+      summary: Return supported methods for one storage resource.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+    get:
+      tags: [Document types]
+      summary: List supported document types.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    options:
+      tags: [Document types]
+      summary: Return supported methods for documentTypes.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/{documentType}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/documentType"
+    get:
+      tags: [Document types]
+      summary: Validate one supported document type.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    head:
+      tags: [Document types]
+      summary: Check whether a document type is supported.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Document types]
+      summary: Return supported methods for one documentType.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/{documentType}/documents:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/documentType"
+    get:
+      tags: [Documents]
+      summary: List document resources for a document type.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    put:
+      tags: [Documents]
+      summary: Update matching document resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete:
+      tags: [Documents]
+      summary: Delete matching document resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Documents]
+      summary: Count matching document resources.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Documents]
+      summary: Return supported methods for documents.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/{documentType}/documents/{document}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/documentType"
+      - $ref: "#/components/parameters/document"
+    get:
+      tags: [Documents]
+      summary: Read one document resource metadata table.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Documents]
+      summary: Upload one document.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/DocumentUpload"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    put:
+      tags: [Documents]
+      summary: Update one document resource metadata table.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/resourceInfoUpdate"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    delete:
+      tags: [Documents]
+      summary: Delete one document and its secure storage parts.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Documents]
+      summary: Check whether one document resource exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Documents]
+      summary: Return supported methods for one document resource.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/{documentType}/documents/{document}/content:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/documentType"
+      - $ref: "#/components/parameters/document"
+    get:
+      tags: [Document content]
+      summary: Return reconstructed document content.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/FileContentResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    head:
+      tags: [Document content]
+      summary: Check whether reconstructed document content is available.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Document content]
+      summary: Return supported methods for content.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentRows:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/document"
+    options:
+      tags: [Document content]
+      summary: Return supported methods for CSV content rows.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentRows/{contentRow}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/document"
+      - $ref: "#/components/parameters/contentRow"
+    get:
+      tags: [Document content]
+      summary: Read one 1-based CSV content row.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/CsvResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Document content]
+      summary: Append the next CSV content row.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    put:
+      tags: [Document content]
+      summary: Update one existing CSV content row.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Document content]
+      summary: Delete one CSV content row.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Document content]
+      summary: Check whether one CSV content row exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Document content]
+      summary: Return supported methods for one CSV content row.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentColumns:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/document"
+    options:
+      tags: [Document content]
+      summary: Return supported methods for CSV content columns.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentColumns/{contentColumn}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/document"
+      - $ref: "#/components/parameters/contentColumn"
+    get:
+      tags: [Document content]
+      summary: Read one CSV content column.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/CsvResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Document content]
+      summary: Add a CSV content column, creating an empty document if needed.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    delete:
+      tags: [Document content]
+      summary: Delete a CSV content column.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/CountResponse"
+    head:
+      tags: [Document content]
+      summary: Check whether one CSV content column exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Document content]
+      summary: Return supported methods for one CSV content column.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/parserScripts:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/document"
+    options:
+      tags: [Parser scripts]
+      summary: Return supported methods for parserScripts.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/documentTypes/file.csv/documents/{document}/parserScripts/{parserScript}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/document"
+      - $ref: "#/components/parameters/parserScript"
+    get:
+      tags: [Parser scripts]
+      summary: Run a stored Perl or Python parser script against a CSV document.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/CsvResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    head:
+      tags: [Parser scripts]
+      summary: Check whether one parser script can be resolved.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Parser scripts]
+      summary: Return supported methods for one parser script resource.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/dbNames:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+    get:
+      tags: [Secure DB browsing]
+      summary: List registered secure CSV document database names.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    head:
+      tags: [Secure DB browsing]
+      summary: Count registered secure CSV document database names.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Secure DB browsing]
+      summary: Return supported methods for dbNames.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/dbNames/{dbName}/dbTables:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/dbName"
+    get:
+      tags: [Secure DB browsing]
+      summary: List exposed tables for one secure CSV document database.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+    head:
+      tags: [Secure DB browsing]
+      summary: Check whether exposed tables are available.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Secure DB browsing]
+      summary: Return supported methods for dbTables.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/dbNames/{dbName}/dbTables/{dbTable}/tableRows/{tableRow}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/dbName"
+      - $ref: "#/components/parameters/dbTable"
+      - $ref: "#/components/parameters/tableRow"
+    get:
+      tags: [Secure DB browsing]
+      summary: Read one 1-based row from an exposed secure CSV table.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    head:
+      tags: [Secure DB browsing]
+      summary: Check whether one exposed secure CSV table row exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Secure DB browsing]
+      summary: Return supported methods for tableRows.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+  /organizations/{organization}/storage/{storage}/dbNames/{dbName}/dbTables/{dbTable}/tableColumns/{tableColumn}:
+    parameters:
+      - $ref: "#/components/parameters/organization"
+      - $ref: "#/components/parameters/storage"
+      - $ref: "#/components/parameters/dbName"
+      - $ref: "#/components/parameters/dbTable"
+      - $ref: "#/components/parameters/tableColumn"
+    get:
+      tags: [Secure DB browsing]
+      summary: Read one column from an exposed secure CSV table.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+        - $ref: "#/components/parameters/newOrgKey"
+        - $ref: "#/components/parameters/outputType"
+      responses:
+        "200":
+          $ref: "#/components/responses/TableResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    head:
+      tags: [Secure DB browsing]
+      summary: Check whether one exposed secure CSV table column exists.
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - $ref: "#/components/parameters/orgId"
+        - $ref: "#/components/parameters/orgKey"
+      responses:
+        "200":
+          $ref: "#/components/responses/HeaderOnly"
+        "404":
+          $ref: "#/components/responses/HeaderOnly"
+    options:
+      tags: [Secure DB browsing]
+      summary: Return supported methods for tableColumns.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextResponse"
+
+components:
+  parameters:
+    organization:
+      name: organization
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Organization resource identifier from the URL.
+    user:
+      name: user
+      in: path
+      required: true
+      schema:
+        type: string
+      description: User resource identifier from the URL.
+    roleTable:
+      name: roleTable
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Role table resource identifier such as users or documents.
+    filterUser:
+      name: filterUser
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Whitelist or blacklist user-resource filter, interpreted as a POSIX extended regular expression.
+    storage:
+      name: storage
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Storage resource identifier from the URL.
+    documentType:
+      name: documentType
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - file.csv
+          - file.raw
+          - file.txt
+          - file.json
+          - file.xml
+          - file.html
+          - file.pdf
+          - file.png
+          - file.jpg
+          - file.gif
+          - file.zip
+          - file.bin
+          - script.perl
+          - script.python
+      description: Supported document type identifier.
+    document:
+      name: document
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Document resource identifier.
+    contentRow:
+      name: contentRow
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+      description: 1-based content row selector.
+    contentColumn:
+      name: contentColumn
+      in: path
+      required: true
+      schema:
+        type: string
+      description: CSV content column name.
+    parserScript:
+      name: parserScript
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Stored script.perl or script.python document name.
+    dbName:
+      name: dbName
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Registered file.csv document database name.
+    dbTable:
+      name: dbTable
+      in: path
+      required: true
+      schema:
+        type: string
+        enum: [data, meta]
+      description: Exposed secure CSV table name.
+    tableRow:
+      name: tableRow
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+      description: 1-based table row selector.
+    tableColumn:
+      name: tableColumn
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Exposed secure CSV table column name.
+    userId:
+      name: userId
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Authenticated CaumeDSE user identifier.
+    orgId:
+      name: orgId
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Authenticated CaumeDSE organization identifier.
+    orgKey:
+      name: orgKey
+      in: query
+      required: true
+      schema:
+        type: string
+        format: password
+      description: Organization key. Treat as a secret.
+    newOrgKey:
+      name: newOrgKey
+      in: query
+      required: false
+      schema:
+        type: string
+        format: password
+      description: Key used for creating or rewriting protected resources.
+    outputType:
+      name: outputType
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [html, csv]
+      description: Requested response format supported by current handlers.
+    matchPublicKey:
+      name: _publicKey
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Exact-match filter for publicKey.
+    storageTypeMatch:
+      name: _type
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Exact-match filter for storage type.
+    resourceInfoUpdate:
+      name: "*resourceInfo"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Resource information update value.
+    certificateUpdate:
+      name: "*certificate"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Certificate update value.
+    publicKeyUpdate:
+      name: "*publicKey"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Public key update value.
+    basicAuthPwdHashUpdate:
+      name: "*basicAuthPwdHash"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Basic-auth password hash update value.
+    oauthConsumerKeyUpdate:
+      name: "*oauthConsumerKey"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: External OAuth consumer key metadata.
+    oauthConsumerSecretUpdate:
+      name: "*oauthConsumerSecret"
+      in: query
+      required: false
+      schema:
+        type: string
+        format: password
+      description: External OAuth consumer secret metadata.
+    locationUpdate:
+      name: "*location"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Storage location update value.
+    storageTypeUpdate:
+      name: "*type"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Storage provider type. Current local storage uses local.
+    accessPathUpdate:
+      name: "*accessPath"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Storage access path.
+    accessUserUpdate:
+      name: "*accessUser"
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Storage access user metadata.
+    accessPasswordUpdate:
+      name: "*accessPassword"
+      in: query
+      required: false
+      schema:
+        type: string
+        format: password
+      description: Storage access password metadata.
+    methodGetUpdate:
+      name: "*_get"
+      in: query
+      required: false
+      schema:
+        type: integer
+        enum: [0, 1]
+      description: Allow or deny GET depending on role/filter resource type.
+    methodPostUpdate:
+      name: "*_post"
+      in: query
+      required: false
+      schema:
+        type: integer
+        enum: [0, 1]
+      description: Allow or deny POST depending on role/filter resource type.
+    methodPutUpdate:
+      name: "*_put"
+      in: query
+      required: false
+      schema:
+        type: integer
+        enum: [0, 1]
+      description: Allow or deny PUT depending on role/filter resource type.
+    methodDeleteUpdate:
+      name: "*_delete"
+      in: query
+      required: false
+      schema:
+        type: integer
+        enum: [0, 1]
+      description: Allow or deny DELETE depending on role/filter resource type.
+    methodHeadUpdate:
+      name: "*_head"
+      in: query
+      required: false
+      schema:
+        type: integer
+        enum: [0, 1]
+      description: Allow or deny HEAD depending on role/filter resource type.
+    methodOptionsUpdate:
+      name: "*_options"
+      in: query
+      required: false
+      schema:
+        type: integer
+        enum: [0, 1]
+      description: Allow or deny OPTIONS depending on role/filter resource type.
+
+  schemas:
+    TextTable:
+      type: string
+      description: HTML or CSV-style table text returned by current handlers.
+    DocumentUpload:
+      type: object
+      required: [file, userId, orgId, orgKey]
+      properties:
+        file:
+          type: string
+          format: binary
+        userId:
+          type: string
+        orgId:
+          type: string
+        orgKey:
+          type: string
+          format: password
+        newOrgKey:
+          type: string
+          format: password
+        "*resourceInfo":
+          type: string
+        shuffle:
+          type: string
+          description: Optional secure CSV import flag.
+        protect:
+          type: string
+          description: Optional secure CSV import flag.
+        replaceDB:
+          type: string
+          description: Optional secure CSV import flag.
+        vacuumDB:
+          type: string
+          description: Optional secure CSV import flag.
+
+  responses:
+    TableResponse:
+      description: Matching resources as an HTML or CSV-style table.
+      headers:
+        Engine-results:
+          schema:
+            type: integer
+          description: Number of matching result registers.
+      content:
+        text/html:
+          schema:
+            $ref: "#/components/schemas/TextTable"
+        text/csv:
+          schema:
+            type: string
+    CsvResponse:
+      description: CSV-formatted response body.
+      headers:
+        Engine-results:
+          schema:
+            type: integer
+      content:
+        text/csv:
+          schema:
+            type: string
+        text/plain:
+          schema:
+            type: string
+    FileContentResponse:
+      description: Reconstructed document content.
+      headers:
+        Engine-results:
+          schema:
+            type: integer
+      content:
+        text/csv:
+          schema:
+            type: string
+        text/plain:
+          schema:
+            type: string
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+    TextResponse:
+      description: Text response.
+      content:
+        text/plain:
+          schema:
+            type: string
+        text/html:
+          schema:
+            type: string
+    CountResponse:
+      description: Operation result count.
+      headers:
+        Engine-results:
+          schema:
+            type: integer
+      content:
+        text/plain:
+          schema:
+            type: string
+        text/html:
+          schema:
+            type: string
+        text/csv:
+          schema:
+            type: string
+    HeaderOnly:
+      description: Status and response headers only.
+      headers:
+        Engine-results:
+          schema:
+            type: integer
+    Created:
+      description: Resource created.
+      content:
+        text/plain:
+          schema:
+            type: string
+    Unauthorized:
+      description: Missing or invalid credentials, organization key, or HTTPS client certificate.
+      content:
+        text/plain:
+          schema:
+            type: string
+    Forbidden:
+      description: Authenticated caller is not authorized or selector is invalid.
+      content:
+        text/plain:
+          schema:
+            type: string
+    NotFound:
+      description: Requested resource was not found.
+      content:
+        text/plain:
+          schema:
+            type: string
+    Conflict:
+      description: Request conflicts with current resource state.
+      content:
+        text/plain:
+          schema:
+            type: string
+    ServerError:
+      description: Server-side processing failed.
+      content:
+        text/plain:
+          schema:
+            type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,8 +5,8 @@ info:
   description: |
     Machine-readable reference for the stable CaumeDSE routes documented in
     README.md and exercised by TEST/run_debug_components.sh. Responses are
-    currently HTML or CSV-oriented text tables unless a route returns only a
-    status code. JSON output is tracked separately in TODO #68.
+    currently HTML, CSV, or JSON-oriented text tables unless a route returns
+    only a status code.
 servers:
   - url: http://localhost:18080
     description: DEBUG HTTP verifier server
@@ -1278,7 +1278,7 @@ components:
       required: false
       schema:
         type: string
-        enum: [html, csv]
+        enum: [html, csv, json]
       description: Requested response format supported by current handlers.
     matchPublicKey:
       name: _publicKey
@@ -1473,6 +1473,20 @@ components:
         text/csv:
           schema:
             type: string
+        application/json:
+          schema:
+            type: object
+            properties:
+              columns:
+                type: array
+                items:
+                  type: string
+              rows:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: string
     CsvResponse:
       description: CSV-formatted response body.
       headers:
@@ -1486,6 +1500,20 @@ components:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            type: object
+            properties:
+              columns:
+                type: array
+                items:
+                  type: string
+              rows:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: string
     FileContentResponse:
       description: Reconstructed document content.
       headers:
@@ -1496,6 +1524,11 @@ components:
         text/csv:
           schema:
             type: string
+        application/json:
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
         text/plain:
           schema:
             type: string

--- a/samples/ai-agent/README.md
+++ b/samples/ai-agent/README.md
@@ -1,0 +1,84 @@
+# CaumeDSE AI Agent Integration Sample
+
+This sample shows a guarded Python workflow for automation or AI-agent
+orchestration against the CaumeDSE REST API. It uses disposable resources,
+keeps organization keys out of prompts/logs, requests JSON responses where
+available, and cleans up after itself.
+
+The script is intentionally provider-neutral. It does not call an LLM API.
+Instead, it shows the boundary where an agent can receive non-secret JSON
+summaries and choose narrow follow-up operations.
+
+## Prerequisites
+
+- Python 3.8 or later.
+- A running DEBUG/test CaumeDSE web service.
+- For HTTP testing, build with `--enable-BYPASSTLSAUTHINHTTP`.
+- For HTTPS, provide the CA and client certificate/key paths.
+
+The easiest local target is the verifier web-service mode:
+
+```sh
+TEST/run_debug_components.sh --ci-smoke
+```
+
+For manual development, run a DEBUG HTTP service and then run this sample
+against it. The defaults assume:
+
+```sh
+export CDSE_AGENT_BASE_URL="http://localhost:18080"
+```
+
+## Configuration
+
+The sample reads secrets from environment variables. Do not pass real
+organization keys on the command line.
+
+```sh
+export CDSE_AGENT_BASE_URL="http://localhost:18080"
+export CDSE_AGENT_ORG="AgentTrialOrg"
+export CDSE_AGENT_USER="AgentTrialUser"
+export CDSE_AGENT_STORAGE="AgentTrialStorage"
+export CDSE_AGENT_STORAGE_PATH="/tmp/caumedse-agent-storage"
+export CDSE_AGENT_ORG_KEY="$(openssl rand -hex 32)"
+```
+
+For HTTPS, add:
+
+```sh
+export CDSE_AGENT_BASE_URL="https://localhost:18443"
+export CDSE_AGENT_CA_CERT="/tmp/cdse-verify/cdse/ca.pem"
+export CDSE_AGENT_CLIENT_CERT="/tmp/cdse-verify/client_chain.pem"
+export CDSE_AGENT_CLIENT_KEY="/tmp/cdse-verify/client.key"
+```
+
+## Run
+
+```sh
+python3 samples/ai-agent/guarded_agent_workflow.py
+```
+
+The workflow:
+
+1. Creates a disposable organization, storage resource, and user.
+2. Uploads `TEST/testfiles/live-api-small.csv`.
+3. Queries one row and one column as JSON.
+4. Uploads `TEST/testfiles/test.py` as a reviewed parser script.
+5. Runs the parser with `outputType=json`.
+6. Deletes temporary documents and user/role/filter resources.
+
+Use `--keep-resources` only when debugging cleanup behavior:
+
+```sh
+python3 samples/ai-agent/guarded_agent_workflow.py --keep-resources
+```
+
+## Safety Notes
+
+- The script redacts `orgKey` and `newOrgKey` from logs.
+- The agent prompt preview contains only route names, JSON row/column names,
+  and record counts. It never includes raw organization keys.
+- Parser scripts are loaded only from reviewed local fixture files.
+- The sample queries narrow resources, not broad document dumps.
+
+See `../../AI_USAGE.md` for the broader AI-agent policy and anti-patterns.

--- a/samples/ai-agent/guarded_agent_workflow.py
+++ b/samples/ai-agent/guarded_agent_workflow.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Guarded CaumeDSE AI-agent workflow sample.
+
+This script demonstrates where an AI agent can safely orchestrate CaumeDSE
+requests without receiving organization keys or broad sensitive data. It uses
+only Python's standard library so it can run in constrained DEBUG/test
+environments.
+"""
+
+import argparse
+import json
+import mimetypes
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CSV = ROOT / "TEST" / "testfiles" / "live-api-small.csv"
+DEFAULT_PARSER = ROOT / "TEST" / "testfiles" / "test.py"
+
+
+class Config:
+    def __init__(self, args):
+        run_id = os.environ.get("CDSE_AGENT_RUN_ID") or str(int(time.time()))
+        self.base_url = os.environ.get("CDSE_AGENT_BASE_URL", "http://localhost:18080").rstrip("/")
+        self.org = os.environ.get("CDSE_AGENT_ORG", f"AgentTrialOrg{run_id}")
+        self.user = os.environ.get("CDSE_AGENT_USER", f"AgentTrialUser{run_id}")
+        self.storage = os.environ.get("CDSE_AGENT_STORAGE", f"AgentTrialStorage{run_id}")
+        self.storage_path = os.environ.get("CDSE_AGENT_STORAGE_PATH", f"/tmp/caumedse-agent-storage-{run_id}")
+        self.org_key = os.environ.get("CDSE_AGENT_ORG_KEY")
+        self.csv_doc = os.environ.get("CDSE_AGENT_CSV_DOC", f"agent-{run_id}.csv")
+        self.parser_doc = os.environ.get("CDSE_AGENT_PARSER_DOC", f"agent-parser-{run_id}.py")
+        self.csv_fixture = Path(args.csv_fixture)
+        self.parser_fixture = Path(args.parser_fixture)
+        self.ca_cert = os.environ.get("CDSE_AGENT_CA_CERT")
+        self.client_cert = os.environ.get("CDSE_AGENT_CLIENT_CERT")
+        self.client_key = os.environ.get("CDSE_AGENT_CLIENT_KEY")
+        self.keep_resources = args.keep_resources
+
+    def require_valid(self):
+        if not self.org_key:
+            raise SystemExit("Set CDSE_AGENT_ORG_KEY in the environment.")
+        if not self.csv_fixture.is_file():
+            raise SystemExit(f"CSV fixture not found: {self.csv_fixture}")
+        if not self.parser_fixture.is_file():
+            raise SystemExit(f"Parser fixture not found: {self.parser_fixture}")
+
+    def auth_params(self, include_new_key=False):
+        params = {
+            "userId": self.user,
+            "orgId": self.org,
+            "orgKey": self.org_key,
+        }
+        if include_new_key:
+            params["newOrgKey"] = self.org_key
+        return params
+
+
+def redact_url(url):
+    parsed = urllib.parse.urlsplit(url)
+    pairs = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    redacted = []
+    for key, value in pairs:
+        if key in {"orgKey", "newOrgKey", "*accessPassword", "*oauthConsumerSecret"}:
+            value = "<redacted>"
+        redacted.append((key, value))
+    query = urllib.parse.urlencode(redacted)
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+
+def log_request(method, url):
+    print(f"{method:<6} {redact_url(url)}")
+
+
+def ssl_context(cfg):
+    if not cfg.base_url.startswith("https://"):
+        return None
+    context = ssl.create_default_context(cafile=cfg.ca_cert) if cfg.ca_cert else ssl.create_default_context()
+    if cfg.client_cert and cfg.client_key:
+        context.load_cert_chain(cfg.client_cert, cfg.client_key)
+    return context
+
+
+def encode_query(params):
+    return urllib.parse.urlencode(params, doseq=True, safe="*[]")
+
+
+def build_url(cfg, path, params=None):
+    query = encode_query(params or {})
+    url = f"{cfg.base_url}{path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+def request(cfg, method, path, params=None, body=None, headers=None, expected=(200,)):
+    url = build_url(cfg, path, params)
+    data = body.encode("utf-8") if isinstance(body, str) else body
+    req = urllib.request.Request(url, data=data, headers=headers or {}, method=method)
+    log_request(method, url)
+    try:
+        with urllib.request.urlopen(req, context=ssl_context(cfg), timeout=30) as response:
+            payload = response.read()
+            status = response.status
+            response_headers = dict(response.headers.items())
+    except urllib.error.HTTPError as exc:
+        payload = exc.read()
+        status = exc.code
+        response_headers = dict(exc.headers.items())
+    if status not in expected:
+        text = payload.decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {path} returned {status}, expected {expected}: {text[:500]}")
+    return status, response_headers, payload
+
+
+def multipart_body(fields, file_field, file_path):
+    boundary = f"cdse-agent-{int(time.time() * 1000)}"
+    chunks = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n")
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n')
+        chunks.append(f"{value}\r\n")
+    mime_type = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+    chunks.append(f"--{boundary}\r\n")
+    chunks.append(
+        f'Content-Disposition: form-data; name="{file_field}"; filename="{file_path.name}"\r\n'
+    )
+    chunks.append(f"Content-Type: {mime_type}\r\n\r\n")
+    body = "".join(chunks).encode("utf-8") + file_path.read_bytes()
+    body += f"\r\n--{boundary}--\r\n".encode("utf-8")
+    return body, {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+
+
+def json_request(cfg, path, params):
+    params = dict(params)
+    params["outputType"] = "json"
+    _, _, payload = request(cfg, "GET", path, params=params)
+    return json.loads(payload.decode("utf-8"))
+
+
+def create_workspace(cfg):
+    auth = cfg.auth_params(include_new_key=True)
+    Path(cfg.storage_path).mkdir(parents=True, exist_ok=True)
+    request(
+        cfg,
+        "POST",
+        f"/organizations/{urllib.parse.quote(cfg.org)}",
+        params={
+            **auth,
+            "*resourceInfo": "AI agent disposable organization",
+            "*certificate": "undefined",
+            "*publicKey": "undefined",
+        },
+        expected=(201, 409),
+    )
+    request(
+        cfg,
+        "POST",
+        f"/organizations/{urllib.parse.quote(cfg.org)}/storage/{urllib.parse.quote(cfg.storage)}",
+        params={
+            **auth,
+            "*resourceInfo": "AI agent disposable storage",
+            "*location": "localhost",
+            "*type": "local",
+            "*accessPath": cfg.storage_path,
+            "*accessUser": "undefined",
+            "*accessPassword": "undefined",
+        },
+        expected=(201, 409),
+    )
+    request(
+        cfg,
+        "POST",
+        f"/organizations/{urllib.parse.quote(cfg.org)}/users/{urllib.parse.quote(cfg.user)}",
+        params={
+            **auth,
+            "*resourceInfo": "AI agent least-privilege user",
+            "*certificate": "undefined",
+            "*publicKey": "undefined",
+            "*basicAuthPwdHash": "undefined",
+            "*oauthConsumerKey": "undefined",
+            "*oauthConsumerSecret": "undefined",
+        },
+        expected=(201, 409),
+    )
+
+
+def upload_file(cfg, doc_type, doc_name, file_path, resource_info):
+    fields = {
+        **cfg.auth_params(include_new_key=True),
+        "*resourceInfo": resource_info,
+    }
+    body, headers = multipart_body(fields, "file", file_path)
+    path = (
+        f"/organizations/{urllib.parse.quote(cfg.org)}"
+        f"/storage/{urllib.parse.quote(cfg.storage)}"
+        f"/documentTypes/{urllib.parse.quote(doc_type)}"
+        f"/documents/{urllib.parse.quote(doc_name)}"
+    )
+    request(cfg, "POST", path, body=body, headers=headers, expected=(201, 409))
+
+
+def agent_prompt_preview(row_result, column_result, parser_result):
+    prompt = {
+        "task": "Choose the narrowest next CaumeDSE read operation.",
+        "available_context": {
+            "row_columns": row_result.get("columns", []),
+            "column_rows": len(column_result.get("rows", [])),
+            "parser_columns": parser_result.get("columns", []),
+            "parser_rows": len(parser_result.get("rows", [])),
+        },
+        "security_constraints": [
+            "Do not request orgKey, newOrgKey, TLS keys, or environment variables.",
+            "Prefer row, column, or parser summaries over full document content.",
+            "Do not upload generated parser scripts without human review.",
+        ],
+    }
+    print("Agent prompt preview, safe to send to an LLM:")
+    print(json.dumps(prompt, indent=2, sort_keys=True))
+
+
+def cleanup(cfg):
+    auth = cfg.auth_params(include_new_key=True)
+    quoted_org = urllib.parse.quote(cfg.org)
+    quoted_storage = urllib.parse.quote(cfg.storage)
+    quoted_user = urllib.parse.quote(cfg.user)
+    resources = [
+        ("DELETE", f"/organizations/{quoted_org}/storage/{quoted_storage}/documentTypes/file.csv/documents/{urllib.parse.quote(cfg.csv_doc)}"),
+        ("DELETE", f"/organizations/{quoted_org}/storage/{quoted_storage}/documentTypes/script.python/documents/{urllib.parse.quote(cfg.parser_doc)}"),
+        ("DELETE", f"/organizations/{quoted_org}/storage/{quoted_storage}"),
+        ("DELETE", f"/organizations/{quoted_org}/users/{quoted_user}"),
+    ]
+    for method, path in resources:
+        try:
+            request(cfg, method, path, params=auth, expected=(200, 404))
+        except RuntimeError as exc:
+            print(f"cleanup warning: {exc}", file=sys.stderr)
+
+
+def run_workflow(cfg):
+    create_workspace(cfg)
+    upload_file(cfg, "file.csv", cfg.csv_doc, cfg.csv_fixture, "reviewed AI-agent CSV fixture")
+    upload_file(cfg, "script.python", cfg.parser_doc, cfg.parser_fixture, "reviewed AI-agent parser fixture")
+
+    auth = cfg.auth_params(include_new_key=True)
+    base_doc = (
+        f"/organizations/{urllib.parse.quote(cfg.org)}"
+        f"/storage/{urllib.parse.quote(cfg.storage)}"
+        f"/documentTypes/file.csv/documents/{urllib.parse.quote(cfg.csv_doc)}"
+    )
+    row = json_request(cfg, f"{base_doc}/contentRows/1", auth)
+    column = json_request(cfg, f"{base_doc}/contentColumns/name", auth)
+    parser = json_request(cfg, f"{base_doc}/parserScripts/{urllib.parse.quote(cfg.parser_doc)}", auth)
+
+    print("Narrow JSON query summary:")
+    print(json.dumps({
+        "row_count": len(row.get("rows", [])),
+        "column_count": len(column.get("columns", [])),
+        "parser_rows": len(parser.get("rows", [])),
+    }, indent=2, sort_keys=True))
+    agent_prompt_preview(row, column, parser)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Run a guarded CaumeDSE AI-agent sample workflow.")
+    parser.add_argument("--csv-fixture", default=str(DEFAULT_CSV), help="Reviewed CSV fixture to upload.")
+    parser.add_argument("--parser-fixture", default=str(DEFAULT_PARSER), help="Reviewed Python parser fixture to upload.")
+    parser.add_argument("--keep-resources", action="store_true", help="Leave disposable resources in place for debugging.")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    cfg = Config(parse_args(argv or sys.argv[1:]))
+    cfg.require_valid()
+    try:
+        run_workflow(cfg)
+    finally:
+        if cfg.keep_resources:
+            print("Keeping disposable resources because --keep-resources was set.")
+        else:
+            cleanup(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/strhandling.c
+++ b/strhandling.c
@@ -403,6 +403,92 @@ int cmeMemTableToCSVTableStr (const char** srcMemTable,char **resultCSVTableStr,
     return(0);
 }
 
+static void cmeAppendJSONStringValue(char **dst, const char *src)
+{
+    const unsigned char *p=(const unsigned char *)src;
+
+    cmeStrConstrAppend(dst,"\"");
+    if (p)
+    {
+        while (*p)
+        {
+            switch (*p)
+            {
+                case '\"':
+                    cmeStrConstrAppend(dst,"\\\"");
+                    break;
+                case '\\':
+                    cmeStrConstrAppend(dst,"\\\\");
+                    break;
+                case '\b':
+                    cmeStrConstrAppend(dst,"\\b");
+                    break;
+                case '\f':
+                    cmeStrConstrAppend(dst,"\\f");
+                    break;
+                case '\n':
+                    cmeStrConstrAppend(dst,"\\n");
+                    break;
+                case '\r':
+                    cmeStrConstrAppend(dst,"\\r");
+                    break;
+                case '\t':
+                    cmeStrConstrAppend(dst,"\\t");
+                    break;
+                default:
+                    if (*p<0x20)
+                    {
+                        cmeStrConstrAppend(dst,"\\u%04x",*p);
+                    }
+                    else
+                    {
+                        cmeStrConstrAppend(dst,"%c",*p);
+                    }
+                    break;
+            }
+            p++;
+        }
+    }
+    cmeStrConstrAppend(dst,"\"");
+}
+
+int cmeMemTableToJSONTableStr (const char** srcMemTable,char **resultJSONTableStr,int numColumns,int numRows)
+{
+    int cont,cont2;
+
+    cmeStrConstrAppend(resultJSONTableStr,"{\"columns\":[");
+    for (cont=0;cont<numColumns;cont++)
+    {
+        cmeAppendJSONStringValue(resultJSONTableStr,srcMemTable[cont]);
+        if ((cont+1)<numColumns)
+        {
+            cmeStrConstrAppend(resultJSONTableStr,",");
+        }
+    }
+    cmeStrConstrAppend(resultJSONTableStr,"],\"rows\":[");
+    for (cont=1;cont<=numRows;cont++)
+    {
+        cmeStrConstrAppend(resultJSONTableStr,"{");
+        for(cont2=0;cont2<numColumns;cont2++)
+        {
+            cmeAppendJSONStringValue(resultJSONTableStr,srcMemTable[cont2]);
+            cmeStrConstrAppend(resultJSONTableStr,":");
+            cmeAppendJSONStringValue(resultJSONTableStr,srcMemTable[numColumns*cont+cont2]);
+            if ((cont2+1)<numColumns)
+            {
+                cmeStrConstrAppend(resultJSONTableStr,",");
+            }
+        }
+        cmeStrConstrAppend(resultJSONTableStr,"}");
+        if (cont<numRows)
+        {
+            cmeStrConstrAppend(resultJSONTableStr,",");
+        }
+    }
+    cmeStrConstrAppend(resultJSONTableStr,"]}");
+    return(0);
+}
+
 int cmeFindInArgPairList (const char** stringPairs, const char *key, const char **pValue)
 {
     int cont=0;
@@ -443,6 +529,12 @@ int cmeConstructWebServiceTableResponse (const char **resultTable, const int tab
                 result=cmeMemTableToHTMLTableStr((const char **)resultTable,resultTableStr,tableCols,tableRows);
                 cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");  //Note: fields 0 & 1 will be set with Engine-results later.
                 cmeStrConstrAppend(&((*responseHeaders)[3]),"text/html; charset=utf-8");
+            }
+            else if (!strcmp("json",pOutputType)) // user request results in JSON format.
+            {
+                result=cmeMemTableToJSONTableStr((const char **)resultTable,resultTableStr,tableCols,tableRows);
+                cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");  //Note: fields 0 & 1 will be set with Engine-results later.
+                cmeStrConstrAppend(&((*responseHeaders)[3]),"application/json");
             }
             else //Error, unknown outputType.
             {
@@ -507,6 +599,14 @@ int cmeConstructWebServiceCountResponse (const char *resultName, const int resul
             cmeStrConstrAppend(resultStr,"<p>%s: %d</p><br>",resultName,resultCount);
             cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");  //Note: fields 0 & 1 are Engine-results.
             cmeStrConstrAppend(&((*responseHeaders)[3]),"text/html; charset=utf-8");
+        }
+        else if (!strcmp("json",pOutputType))
+        {
+            cmeStrConstrAppend(resultStr,"{");
+            cmeAppendJSONStringValue(resultStr,resultName);
+            cmeStrConstrAppend(resultStr,":%d}",resultCount);
+            cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");  //Note: fields 0 & 1 are Engine-results.
+            cmeStrConstrAppend(&((*responseHeaders)[3]),"application/json");
         }
         else //Error, unknown outputType.
         {

--- a/strhandling.h
+++ b/strhandling.h
@@ -78,6 +78,8 @@ int cmeStrSqlUPDATEConstruct (char **resultQuery, const char *tableName, const c
 int cmeMemTableToHTMLTableStr (const char** srcMemTable,char **resultHTMLTableStr,int numColumns,int numRows);
 // Function to create a string with a CSV representation of a MemTable
 int cmeMemTableToCSVTableStr (const char** srcMemTable,char **resultCSVTableStr,int numColumns,int numRows);
+// Function to create a string with a JSON representation of a MemTable.
+int cmeMemTableToJSONTableStr (const char** srcMemTable,char **resultJSONTableStr,int numColumns,int numRows);
 // Function to find a key string within an (URI) Argument pair list, and return a pointer of the corresponding value within the list, if a match is found.
 int cmeFindInArgPairList (const char** stringPairs, const char *key, const char **pValue);
 // Function to construct a responseStr and add corresponding headers, according to an (optional) outputType parameter, as requested by the user (e.g. csv, html)

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -1715,7 +1715,7 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
             fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessRequest(), client requests "
                         "documentType class resource: '%s'. Method: '%s'. Url: '%s'.\n",urlElements[numUrlElements-1],method,url);
 #endif
-            result=cmeWebServiceProcessDocumentTypeClass(responseText, responseCode,
+            result=cmeWebServiceProcessDocumentTypeClass(responseText, responseHeaders, responseCode,
                                                          url, urlElements, argumentElements, method);
             if (result)
             {
@@ -6960,18 +6960,42 @@ int cmeWebServiceProcessStorageClass (char **responseText, char ***responseHeade
     }
 }
 
-int cmeWebServiceProcessDocumentTypeClass (char **responseText, int *responseCode,
+int cmeWebServiceProcessDocumentTypeClass (char **responseText, char ***responseHeaders, int *responseCode,
                                            const char *url, const char **urlElements,
                                            const char **argumentElements, const char *method)
 {
     int cont;
+    const char *pOutputType=NULL;
 
     if(!strcmp(method,"GET"))
     {
-        cmeStrConstrAppend(responseText,"<b>200 OK - Available document types:</b><br>");
-        for (cont=0;cont<cmeWebServiceNumSupportedDocumentTypes;cont++)
+        if ((argumentElements)&&(!cmeFindInArgPairList(argumentElements,"outputType",&pOutputType))&&(pOutputType)&&(!strcmp("json",pOutputType)))
         {
-            cmeStrConstrAppend(responseText,"%s<br>",cmeWebServiceSupportedDocumentTypes[cont]);
+            cmeStrConstrAppend(responseText,"{\"columns\":[\"documentType\"],\"rows\":[");
+            for (cont=0;cont<cmeWebServiceNumSupportedDocumentTypes;cont++)
+            {
+                cmeStrConstrAppend(responseText,"{\"documentType\":\"%s\"}",cmeWebServiceSupportedDocumentTypes[cont]);
+                if ((cont+1)<cmeWebServiceNumSupportedDocumentTypes)
+                {
+                    cmeStrConstrAppend(responseText,",");
+                }
+            }
+            cmeStrConstrAppend(responseText,"]}");
+            if ((responseHeaders)&&(*responseHeaders))
+            {
+                cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
+                cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",cmeWebServiceNumSupportedDocumentTypes);
+                cmeStrConstrAppend(&((*responseHeaders)[2]),"Content-Type");
+                cmeStrConstrAppend(&((*responseHeaders)[3]),"application/json");
+            }
+        }
+        else
+        {
+            cmeStrConstrAppend(responseText,"<b>200 OK - Available document types:</b><br>");
+            for (cont=0;cont<cmeWebServiceNumSupportedDocumentTypes;cont++)
+            {
+                cmeStrConstrAppend(responseText,"%s<br>",cmeWebServiceSupportedDocumentTypes[cont]);
+            }
         }
         *responseCode=200;
         return(0);

--- a/webservice_interface.h
+++ b/webservice_interface.h
@@ -123,7 +123,7 @@ int cmeWebServiceProcessStorageResource (char **responseText, char **responseFil
 int cmeWebServiceProcessStorageClass (char **responseText, char ***responseHeaders, int *responseCode,
                                       const char *url, const char **urlElements, const char **argumentElements, const char *method);
 //Function to process documentType class resource requests
-int cmeWebServiceProcessDocumentTypeClass (char **responseText, int *responseCode,
+int cmeWebServiceProcessDocumentTypeClass (char **responseText, char ***responseHeaders, int *responseCode,
                                            const char *url, const char **urlElements,
                                            const char **argumentElements, const char *method);
 //Function to process documentType resource requests


### PR DESCRIPTION
## Summary
- add an OpenAPI route reference and lightweight route validation
- add JSON output support for key table/count API responses with DEBUG/live verifier coverage
- add a guarded Python AI-agent workflow sample using verifier fixtures, redacted request logging, narrow JSON queries, and cleanup

## Validation
- TEST/validate_openapi_routes.sh
- python3 -m py_compile samples/ai-agent/guarded_agent_workflow.py
- python3 samples/ai-agent/guarded_agent_workflow.py --help
- git diff --check
- TEST/run_debug_components.sh --ci-smoke (88 passed, 0 failed, 1 skipped)
- samples/ai-agent/guarded_agent_workflow.py against local DEBUG HTTP service