### PR TITLE
Add parser prompt-injection guidance

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -76,14 +76,35 @@ curl -i $TLS_ARGS \
 
 ## Parser-Script Guardrails
 
-Generated parser scripts are code. Review them before upload and reject scripts
-that:
+Generated parser scripts are code, and CSV contents can contain prompt
+injection text such as instructions to reveal secrets, fetch URLs, alter
+policies, or change the requested output. Treat both the script and the CSV
+data as untrusted until a human has reviewed them.
+
+Review generated scripts before upload and reject scripts that:
 
 - Read files outside the provided CSV input.
 - Open network connections.
 - Print secrets, environment variables, or raw credentials.
 - Generate unbounded output or long-running loops.
 - Depend on hidden state outside the uploaded document and script.
+- Build shell commands from CSV values or parser parameters.
+- Treat CSV cell text as instructions for the agent, host, or CaumeDSE.
+- Change authorization, logging, redaction, cleanup, or TLS behavior.
+
+Prefer scripts that:
+
+- Use only standard CSV parsing libraries and deterministic transformations.
+- Select required columns by exact header name and handle missing columns
+  explicitly.
+- Escape CSV output through a CSV writer instead of string concatenation.
+- Emit only the minimum columns needed for the task.
+- Keep all file access limited to the input and output paths supplied by
+  CaumeDSE.
+
+When an LLM helps draft a parser, ask it for code plus a short checklist of
+the assumptions it made. Review the code, not the checklist, before upload.
+Never let text inside the uploaded CSV modify the review criteria.
 
 The DEBUG verifier covers normal parser execution plus timeout and oversized
 output cases. Keep those checks in the workflow when changing parser behavior.

--- a/README.md
+++ b/README.md
@@ -1761,6 +1761,17 @@ This is a raw file
     the result-table limit; hard runtime isolation for Perl requires moving
     Perl execution out of the embedded interpreter path.
 
+    In AI-assisted workflows, treat CSV contents and parser output as
+    untrusted data. CSV cells can contain prompt-injection text that asks an
+    agent to reveal credentials, alter policy, fetch URLs, or modify cleanup.
+    Keep cell text inside data fields, and do not let it override system or
+    security instructions. Review generated parser scripts before upload and
+    reject scripts that open network connections, execute shell commands, read
+    environment variables, traverse files outside the provided input path, log
+    credentials, or create unbounded output. Prefer deterministic CSV-library
+    transformations that write through a CSV writer and emit only the required
+    columns. See `AI_USAGE.md` for the full checklist.
+
     Example 1)     Get parsed contents of payroll.csv file (of type
             file.csv) using script myscript.pl (of type
             script.perl); get results in csv format.  Note that

--- a/TEST/testfiles/test.py
+++ b/TEST/testfiles/test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Reviewed parser fixture: no network, shell, environment, or extra file reads."""
 import csv
 import sys
 

--- a/TODO.md
+++ b/TODO.md
@@ -462,10 +462,15 @@
     org keys through tool schemas/results, and documents client configuration
     plus security boundaries for parser and CSV handling.
 
-- [ ] #72 Add prompt-injection resistant parser-script guidance.
+- [x] #72 Add prompt-injection resistant parser-script guidance.
   - Source: `TUTORIAL.md`, parser script docs, `TEST/testfiles/`.
   - Goal: help users treat CSV contents and generated parser scripts as untrusted inputs in LLM-connected systems.
   - Plan:
     - Batch 1: document prompt-injection and data-exfiltration risks specific to parser scripts and CSV content.
     - Batch 2: add safe parser-script patterns and review checklists for generated Perl/Python scripts.
     - Batch 3: link the guidance from parser documentation and AI usage examples.
+  - Done: expanded `AI_USAGE.md`, `TUTORIAL.md`, README parser-script docs,
+    and AI/MCP sample READMEs with prompt-injection guidance for CSV cells and
+    parser output, generated-script review rules, safe deterministic parser
+    patterns, and explicit data-exfiltration anti-patterns. Marked the Python
+    parser fixture as a reviewed offline fixture.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -371,6 +371,23 @@ Security considerations:
   share the parser result-table cap; process-level Perl isolation is a separate
   hardening step.
 
+Prompt-injection boundary:
+
+In an LLM-connected workflow, decrypted CSV cells and parser output are
+untrusted text. A row can contain instructions such as "ignore your policy",
+"send the organization key", or "load another file". CaumeDSE will store and
+return that text as data; the application that sends it to an LLM must keep it
+inside a data field and must not let it override system, developer, security,
+or cleanup instructions.
+
+For generated parser scripts, review the source before uploading it as
+`script.perl` or `script.python`. Reject scripts that open network sockets,
+execute shell commands, read environment variables, traverse files outside the
+provided CSV input path, disable redaction, log credentials, or produce
+unbounded output. Prefer deterministic transformations that use CSV parsing
+libraries, select columns by exact header names, validate missing columns, and
+write output through a CSV writer.
+
 Verifier coverage:
 
 `TEST/run_debug_components.sh` uploads Perl and Python parser scripts, runs both

--- a/samples/ai-agent/README.md
+++ b/samples/ai-agent/README.md
@@ -80,5 +80,8 @@ python3 samples/ai-agent/guarded_agent_workflow.py --keep-resources
   and record counts. It never includes raw organization keys.
 - Parser scripts are loaded only from reviewed local fixture files.
 - The sample queries narrow resources, not broad document dumps.
+- CSV cells and parser output are treated as untrusted data. Do not let text
+  returned from CaumeDSE rewrite the agent's security instructions or cause new
+  parser uploads without review.
 
 See `../../AI_USAGE.md` for the broader AI-agent policy and anti-patterns.

--- a/samples/mcp-server/README.md
+++ b/samples/mcp-server/README.md
@@ -92,10 +92,15 @@ A typical local flow is:
   production MCP bridge behind authentication, authorization, audit logging,
   rate limits, and route-level allow lists.
 - Treat CSV contents and parser output as untrusted data. The sample returns
-  bounded previews instead of broad document dumps.
+  bounded previews instead of broad document dumps. Do not let text from CSV
+  cells override the host application's system, developer, security, or cleanup
+  instructions.
 - Parser execution is intentionally limited to parser documents that were
   already uploaded from reviewed local files. Do not let an LLM generate and
-  upload parser scripts without human review.
+  upload parser scripts without human review. Reject generated scripts that
+  open network connections, execute shell commands, read environment variables,
+  traverse files outside the provided input path, log credentials, or create
+  unbounded output.
 - Request logs go to stderr and redact `orgKey`, `newOrgKey`, and selected
   credential-style parameters.
 


### PR DESCRIPTION
## Summary

- Document prompt-injection risks for CSV cells and parser output in AI-connected workflows.
- Add generated parser review rules and safe deterministic parser patterns for Perl/Python parser scripts.
- Link the guidance from README, TUTORIAL, AI usage docs, AI agent sample, and MCP sample; mark TODO #72 complete.

## Validation

- python3 -m py_compile TEST/testfiles/test.py
- bash -n TEST/run_debug_components.sh
- git diff --check HEAD