### PR TITLE
Harden parser temporary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1757,10 +1757,14 @@ This is a raw file
     command-line arguments: an input CSV file path and an output CSV file
     path. Parser child processes use absolute interpreter paths from
     `CDSE_PARSER_PERL_PATH` and `CDSE_PARSER_PYTHON_PATH`, run from the
-    secure temporary directory, receive a minimal `PATH`/locale
-    environment, redirect stdin/stdout/stderr to `/dev/null`, and close
-    inherited file descriptors above stderr before `execve()`. Children are
-    bounded by `CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS`; where supported, CaumeDSE also
+    parser temporary directory configured by `CDSE_PARSER_TMP_FILE_PATH`,
+    receive a minimal `PATH`/locale environment, redirect stdin/stdout/stderr
+    to `/dev/null`, and close inherited file descriptors above stderr before
+    `execve()`. Parser input/output and Perl runner files are created with
+    `mkstemp()` as `0600` regular files in a service-owned `0700` parser
+    temporary directory; existing symlink directories are refused before file
+    creation. Children are bounded by `CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS`;
+    where supported, CaumeDSE also
     applies `RLIMIT_CPU`, `RLIMIT_FSIZE`,
     `CDSE_PARSER_SCRIPT_MAX_ADDRESS_SPACE_BYTES`,
     `CDSE_PARSER_SCRIPT_MAX_OPEN_FILES`, and

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -861,6 +861,14 @@ check_component parser_scripts_resource 'Testing parserScripts resource handlers
     'TESTS: testParserScripts(), PASS: parserScripts missing script HEAD responseCode=404' \
     'TESTS: testParserScripts(), PASS: class options and missing script handling verified.'
 
+check_component parser_temp_files 'Testing parser temporary file hardening|testParserTempFiles|parser temp' "$FULL_LOG" \
+    '--- Testing parser temporary file hardening:' \
+    'TESTS: testParserTempFiles(), PASS: parser temp file created as 0600 regular file.' \
+    'TESTS: testParserTempFiles(), PASS: parser temp directory is private.' \
+    'TESTS: testParserTempFiles(), PASS: exclusive parser temp creation avoided collision.' \
+    'TESTS: testParserTempFiles(), PASS: symlink temp directory was refused.' \
+    'TESTS: testParserTempFiles(), PASS: cleanup, collision handling, and symlink refusal verified.'
+
 check_component content_rows_resource 'Testing contentRows resource handlers|testContentRows|contentRows' "$FULL_LOG" \
     '--- Testing contentRows resource handlers:' \
     'TESTS: testContentRows(), PASS: contentRows class OPTIONS responseCode=200' \

--- a/TODO.md
+++ b/TODO.md
@@ -507,13 +507,20 @@
     README/TUTORIAL documentation; existing live timeout and oversized-output
     verifier cases now exercise the common child launcher for both runtimes.
 
-- [ ] #75 Harden parser temporary file creation.
+- [x] #75 Harden parser temporary file creation.
   - Source: `webservice_interface.c`, `filehandling.c`, secure deletion helpers.
   - Goal: eliminate parser temp-file race and symlink risks by creating input/output files atomically with strict permissions in a private parser temp directory.
   - Plan:
     - Batch 1: replace random temp-path generation for parser files with exclusive creation such as `mkstemp` or `open(O_CREAT|O_EXCL)` plus restrictive modes.
     - Batch 2: ensure parser temp directories have strict ownership/permissions and are configurable separately from general storage.
     - Batch 3: add tests for cleanup, collision handling, and refusal to follow pre-existing symlinks.
+  - Done: added `CDSE_PARSER_TMP_FILE_PATH` and shared filehandling helpers
+    that create parser temp files atomically with `mkstemp()`, verify the
+    parser temp directory is a service-owned `0700` real directory, verify
+    created files are single-link regular files, and force `0600` file mode.
+    Parser input/output, Perl runner, and decrypted script temp files now use
+    the exclusive helper. Added DEBUG verifier coverage for cleanup, collision
+    handling, strict modes, and refusal to use a symlink temp directory.
 
 - [ ] #76 Add optional network and filesystem isolation for parser child processes.
   - Source: parser child launcher, deployment docs, verifier environment.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -368,8 +368,10 @@ Security considerations:
 - Temporary files must be protected by filesystem permissions and cleanup.
 - Scripts should be reviewed for data exfiltration and resource exhaustion.
 - Parser scripts run in child processes with absolute interpreter paths, a
-  minimal environment, an explicit secure-temporary working directory,
-  redirected stdio, closed inherited file descriptors, a compile-time timeout,
+  minimal environment, an explicit parser temporary working directory,
+  redirected stdio, closed inherited file descriptors, `mkstemp()`-created
+  `0600` parser input/output files under a service-owned `0700` directory,
+  refusal of symlink parser temp directories, a compile-time timeout,
   an output-file size cap,
   and OS resource limits for CPU time, file size, address space, open files,
   and process count where supported. Perl and Python parser outputs share the

--- a/common.h
+++ b/common.h
@@ -116,6 +116,9 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #define cmeDefaultCACertFile "/opt/cdse/ca.pem"             //Default file with PEM cert file for CA to validate client certificates.
 #define cmeAdminDefaultStoragePath "/opt/cdse/"             //Default storage path for first organization { = cmeDefaultFilePath}.
 #endif /*PATH_DATADIR*/
+#ifndef CDSE_PARSER_TMP_FILE_PATH
+#define CDSE_PARSER_TMP_FILE_PATH cmeDefaultSecureTmpFilePath "parser/"
+#endif
 
 #define cmeDefaultResourcesDBName "ResourcesDB"     //Default filename for ResourcesDB sqlite3 filename.
 #define cmeDefaultRolesDBName "RolesDB"             //Default filename for ResourcesDB sqlite3 filename.
@@ -482,6 +485,7 @@ void cmeInitDefaultEncAlg();                //Initialize default algorithm from 
 #if HAVE_STDINT_H
 #include <stdint.h>
 #endif
+#include <errno.h>
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/filehandling.c
+++ b/filehandling.c
@@ -88,6 +88,104 @@ FILE *cmeStorageFileOpen (const char *filePath, const char *mode)
     }
 }
 
+int cmeCreateSecureTmpFileInDir (char **tmpFilePath, FILE **tmpFile, const char *tmpDirPath, const char *prefix)
+{
+    int fd=-1;
+    struct stat dirStat;
+    struct stat fileStat;
+    char *dirPath=NULL;
+    char *templatePath=NULL;
+    FILE *fp=NULL;
+    size_t dirPathLen;
+
+    if ((!tmpFilePath)||(!tmpFile)||(!tmpDirPath)||(!tmpDirPath[0]))
+    {
+        return(1);
+    }
+    *tmpFilePath=NULL;
+    *tmpFile=NULL;
+    if ((!prefix)||(!prefix[0]))
+    {
+        prefix="parser";
+    }
+    cmeStrConstrAppend(&dirPath,"%s",tmpDirPath);
+    if (!dirPath)
+    {
+        return(2);
+    }
+    dirPathLen=strlen(dirPath);
+    while ((dirPathLen>1)&&(dirPath[dirPathLen-1]=='/'))
+    {
+        dirPath[dirPathLen-1]='\0';
+        dirPathLen--;
+    }
+    if ((mkdir(dirPath,0700))&&(errno!=EEXIST))
+    {
+        cmeFree(dirPath);
+        return(3);
+    }
+    if ((lstat(dirPath,&dirStat))||(!S_ISDIR(dirStat.st_mode)))
+    {
+        cmeFree(dirPath);
+        return(4);
+    }
+    if (dirStat.st_uid!=geteuid())
+    {
+        cmeFree(dirPath);
+        return(5);
+    }
+    if ((dirStat.st_mode&0777)!=0700)
+    {
+        if (chmod(dirPath,0700))
+        {
+            cmeFree(dirPath);
+            return(6);
+        }
+    }
+    cmeStrConstrAppend(&templatePath,"%s/%s.XXXXXX",dirPath,prefix);
+    cmeFree(dirPath);
+    if (!templatePath)
+    {
+        return(7);
+    }
+    fd=mkstemp(templatePath);
+    if (fd<0)
+    {
+        cmeFree(templatePath);
+        return(8);
+    }
+    if ((fstat(fd,&fileStat))||(!S_ISREG(fileStat.st_mode))||(fileStat.st_nlink!=1))
+    {
+        close(fd);
+        cmeStorageFileRemove(templatePath);
+        cmeFree(templatePath);
+        return(9);
+    }
+    if (fchmod(fd,0600))
+    {
+        close(fd);
+        cmeStorageFileRemove(templatePath);
+        cmeFree(templatePath);
+        return(10);
+    }
+    fp=fdopen(fd,"w+b");
+    if (!fp)
+    {
+        close(fd);
+        cmeStorageFileRemove(templatePath);
+        cmeFree(templatePath);
+        return(11);
+    }
+    *tmpFilePath=templatePath;
+    *tmpFile=fp;
+    return(0);
+}
+
+int cmeCreateParserSecureTmpFile (char **tmpFilePath, FILE **tmpFile, const char *prefix)
+{
+    return(cmeCreateSecureTmpFileInDir(tmpFilePath,tmpFile,CDSE_PARSER_TMP_FILE_PATH,prefix));
+}
+
 int cmeStorageFileClose (FILE *fp)
 {
     if (!fp)
@@ -1285,9 +1383,9 @@ int cmeRAWFileToSecureFile (const char *rawFileName, const char *userId,const ch
     return (0);
 }
 
-int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const char *documentId,
-                               const char *documentType, const char *documentPath, const char *orgId,
-                               const char *storageId, const char *orgKey)
+int cmeSecureFileToTmpRAWFileInDir (char **tmpRAWFile, sqlite3 *pResourcesDB,const char *documentId,
+                                    const char *documentType, const char *documentPath, const char *orgId,
+                                    const char *storageId, const char *orgKey, const char *tmpDirPath)
 {   //IDD v.1.0.21
     int cont,cont2,result,written,written2,MACLen;
     int numRows=0;
@@ -1643,14 +1741,10 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
     *tmpRAWFile=NULL;
     if(dbNumCols && (!partMACmismatch)) //If we found at least 1 column part and no MAC mismatch, process the file...
     {
-        cmeGetRndSalt(tmpRAWFile); //Get random HEX byte string for temporary file. Note that caller is responsible for freeing *tmpRAWFile
-        cmeStrConstrAppend(&bkpFName,"%s%s",cmeDefaultSecureTmpFilePath,*tmpRAWFile); //Set full path for temporal, unencrypted RAWFile.
-        cmeFree(*tmpRAWFile);
-        cmeStrConstrAppend(tmpRAWFile,"%s",bkpFName); //Set tmpRAWFile to the full path of the file.
-        fpTmpRAWFile=cmeStorageFileOpen(bkpFName,"wb");
-        memset(bkpFName,0,strlen(bkpFName));   //WIPING SENSITIVE DATA IN MEMORY AFTER USE!
-        cmeFree(bkpFName);  //Free bkpFName for next cycle.
-        if (!fpTmpRAWFile)  //Error
+        result=cmeCreateSecureTmpFileInDir(tmpRAWFile,&fpTmpRAWFile,
+                                           tmpDirPath?tmpDirPath:cmeDefaultSecureTmpFilePath,
+                                           "raw");
+        if (result)  //Error
         {
             cmeSecureFileToTmpRAWFileFree(); //CLEANUP.
             return(10);
@@ -1680,6 +1774,15 @@ int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const ch
         cmeSecureFileToTmpRAWFileFree(); //CLEANUP.
         return(11);
     }
+}
+
+int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const char *documentId,
+                               const char *documentType, const char *documentPath, const char *orgId,
+                               const char *storageId, const char *orgKey)
+{
+    return(cmeSecureFileToTmpRAWFileInDir(tmpRAWFile,pResourcesDB,documentId,documentType,
+                                          documentPath,orgId,storageId,orgKey,
+                                          cmeDefaultSecureTmpFilePath));
 }
 
 static int cmeFileOverwritePass(FILE *fp, long int fileLen, int pass)

--- a/filehandling.h
+++ b/filehandling.h
@@ -64,6 +64,10 @@ int cmeCSVFileRowsToMemTableFinal (char ***elements, int numCols,int processedRo
 int cmeLoadStrFromFile (char **pDstStr, const char *filePath, int *dstStrLen);
 // Function to write to a file from a char array.
 int cmeWriteStrToFile (char *pSrcStr, const char *filePath, int srcStrLen);
+// Function to create an exclusive temporary file in a strict private directory.
+int cmeCreateSecureTmpFileInDir (char **tmpFilePath, FILE **tmpFile, const char *dirPath, const char *prefix);
+// Function to create an exclusive parser temporary file with restrictive permissions.
+int cmeCreateParserSecureTmpFile (char **tmpFilePath, FILE **tmpFile, const char *prefix);
 // Function that imports a CSV file into several, security preprocessed, SQLite Databases.
 // ~ POST file.csv
 int cmeCSVFileToSecureDB (const char *CSVfName,const int hasColNames,int *numCols,int *processedRows,
@@ -89,6 +93,9 @@ int cmeRAWFileToSecureFile (const char *rawFileName, const char *userId,const ch
 int cmeSecureFileToTmpRAWFile (char **tmpRAWFile, sqlite3 *pResourcesDB,const char *documentId,
                                const char *documentType, const char *documentPath, const char *orgId,
                                const char *storageId, const char *orgKey);
+int cmeSecureFileToTmpRAWFileInDir (char **tmpRAWFile, sqlite3 *pResourcesDB,const char *documentId,
+                                    const char *documentType, const char *documentPath, const char *orgId,
+                                    const char *storageId, const char *orgKey, const char *tmpDirPath);
 // Function to overwrite and delete a file (meant for temporal files in restricted/memory storage).
 // Define CDSE_SECURE_OVERWRITE_PASSES at compile time to use multiple overwrite passes.
 int cmeFileOverwriteAndDelete (const char *filePath);

--- a/function_tests.c
+++ b/function_tests.c
@@ -47,6 +47,7 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 void testContentRows(void);
 void testContentColumns(void);
 void testDBBrowsing(void);
+void testParserTempFiles(void);
 
 static int cmeDebugTestsNonInteractiveEnabled(void)
 {
@@ -1771,6 +1772,151 @@ void testParserScripts ()
     }
 }
 
+void testParserTempFiles(void)
+{
+    int errors=0;
+    int result;
+    char *path1=NULL;
+    char *path2=NULL;
+    char *targetDir=NULL;
+    char *linkDir=NULL;
+    char *badPath=NULL;
+    FILE *fp1=NULL;
+    FILE *fp2=NULL;
+    FILE *badFile=NULL;
+    struct stat st;
+
+    printf("--- Testing parser temporary file hardening:\n");
+    result=cmeCreateParserSecureTmpFile(&path1,&fp1,"debug-parser");
+    if (result)
+    {
+        printf("TESTS: testParserTempFiles(), FAIL: first parser temp create result=%d.\n",result);
+        errors++;
+    }
+    else
+    {
+        fwrite("x",1,1,fp1);
+        cmeStorageFileClose(fp1);
+        fp1=NULL;
+        if ((lstat(path1,&st))||(!S_ISREG(st.st_mode))||((st.st_mode&0777)!=0600)||(st.st_nlink!=1))
+        {
+            printf("TESTS: testParserTempFiles(), FAIL: parser temp file mode/type/link check failed.\n");
+            errors++;
+        }
+        else
+        {
+            printf("TESTS: testParserTempFiles(), PASS: parser temp file created as 0600 regular file.\n");
+        }
+    }
+    if ((stat(CDSE_PARSER_TMP_FILE_PATH,&st))||(!S_ISDIR(st.st_mode))||((st.st_mode&0777)!=0700))
+    {
+        printf("TESTS: testParserTempFiles(), FAIL: parser temp directory mode check failed.\n");
+        errors++;
+    }
+    else
+    {
+        printf("TESTS: testParserTempFiles(), PASS: parser temp directory is private.\n");
+    }
+    result=cmeCreateParserSecureTmpFile(&path2,&fp2,"debug-parser");
+    if (result)
+    {
+        printf("TESTS: testParserTempFiles(), FAIL: second parser temp create result=%d.\n",result);
+        errors++;
+    }
+    else
+    {
+        cmeStorageFileClose(fp2);
+        fp2=NULL;
+        if ((!path1)||(!path2)||(!strcmp(path1,path2)))
+        {
+            printf("TESTS: testParserTempFiles(), FAIL: exclusive temp names collided.\n");
+            errors++;
+        }
+        else
+        {
+            printf("TESTS: testParserTempFiles(), PASS: exclusive parser temp creation avoided collision.\n");
+        }
+    }
+    cmeStrConstrAppend(&targetDir,"%sparser-symlink-target",cmeDefaultSecureTmpFilePath);
+    cmeStrConstrAppend(&linkDir,"%sparser-symlink-link",cmeDefaultSecureTmpFilePath);
+    if (targetDir&&linkDir)
+    {
+        unlink(linkDir);
+        rmdir(targetDir);
+        if ((!mkdir(targetDir,0700))&&(!symlink(targetDir,linkDir)))
+        {
+            result=cmeCreateSecureTmpFileInDir(&badPath,&badFile,linkDir,"bad-parser");
+            if (!result)
+            {
+                printf("TESTS: testParserTempFiles(), FAIL: symlink temp directory was accepted.\n");
+                errors++;
+                cmeStorageFileClose(badFile);
+                badFile=NULL;
+                cmeFileOverwriteAndDelete(badPath);
+            }
+            else
+            {
+                printf("TESTS: testParserTempFiles(), PASS: symlink temp directory was refused.\n");
+            }
+        }
+        else
+        {
+            printf("TESTS: testParserTempFiles(), FAIL: symlink refusal setup failed.\n");
+            errors++;
+        }
+    }
+    else
+    {
+        printf("TESTS: testParserTempFiles(), FAIL: symlink refusal path allocation failed.\n");
+        errors++;
+    }
+    if (fp1)
+    {
+        cmeStorageFileClose(fp1);
+    }
+    if (fp2)
+    {
+        cmeStorageFileClose(fp2);
+    }
+    if (badFile)
+    {
+        cmeStorageFileClose(badFile);
+    }
+    if (path1)
+    {
+        cmeFileOverwriteAndDelete(path1);
+    }
+    if (path2)
+    {
+        cmeFileOverwriteAndDelete(path2);
+    }
+    if (badPath)
+    {
+        cmeFileOverwriteAndDelete(badPath);
+    }
+    if (linkDir)
+    {
+        unlink(linkDir);
+    }
+    if (targetDir)
+    {
+        rmdir(targetDir);
+    }
+    cmeFree(path1);
+    cmeFree(path2);
+    cmeFree(targetDir);
+    cmeFree(linkDir);
+    cmeFree(badPath);
+    if (errors)
+    {
+        printf("TESTS: testParserTempFiles(), FAIL: %d errors.\n",errors);
+    }
+    else
+    {
+        printf("TESTS: testParserTempFiles(), PASS: cleanup, collision handling, and symlink refusal verified.\n");
+    }
+}
+
 static int cmeTestContentRowsRequest(const char *method, const char *url,
                                      const char **urlElements, int numUrlElements,
                                      const char **argumentElements, int expectedCode,
@@ -2081,6 +2227,7 @@ void testEngMgmnt ()
     testDocumentTypes();
     testStorageDocumentTree();
     testParserScripts();
+    testParserTempFiles();
 }
 
 void testWebServices ()

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -656,30 +656,13 @@ static int cmeWebServiceIsRawFileDocumentType(const char *documentType)
            (!strcmp(documentType,"file.bin")));
 }
 
-static int cmeWebServiceCreateSecureTmpPath(char **tmpPath)
-{
-    char *tmpName=NULL;
-
-    if (!tmpPath)
-    {
-        return(1);
-    }
-    *tmpPath=NULL;
-    if (cmeGetRndSalt(&tmpName))
-    {
-        return(2);
-    }
-    cmeStrConstrAppend(tmpPath,"%s%s",cmeDefaultSecureTmpFilePath,tmpName);
-    cmeFree(tmpName);
-    return((*tmpPath)?0:3);
-}
-
-static int cmeWebServiceWriteResultMemTableCSV(const char *filePath)
+static int cmeWebServiceWriteResultMemTableCSV(FILE *fp)
 {
     int result;
+    int written;
     char *csvTable=NULL;
 
-    if ((!filePath)||(!cmeResultMemTable)||(cmeResultMemTableCols<=0))
+    if ((!fp)||(!cmeResultMemTable)||(cmeResultMemTableCols<=0))
     {
         return(1);
     }
@@ -690,7 +673,8 @@ static int cmeWebServiceWriteResultMemTableCSV(const char *filePath)
         cmeFree(csvTable);
         return(2);
     }
-    result=cmeWriteStrToFile(csvTable,filePath,(int)strlen(csvTable));
+    written=(int)fwrite(csvTable,1,strlen(csvTable),fp);
+    result=((int)strlen(csvTable)==written)?0:1;
     cmeFree(csvTable);
     return(result?3:0);
 }
@@ -944,7 +928,7 @@ static void cmeWebServiceExecParserChild(const char *interpreterPath, char *cons
     };
 
     if ((!interpreterPath)||(!argv)||(!argv[0])||
-        (chdir(cmeDefaultSecureTmpFilePath))||
+        (chdir(CDSE_PARSER_TMP_FILE_PATH))||
         (cmeWebServiceRedirectParserChildStdio()))
     {
         _exit(126);
@@ -983,20 +967,32 @@ static int cmeWebServiceRunPythonParserScript(const char *scriptPath)
     int result=0;
     char *inputPath=NULL;
     char *outputPath=NULL;
+    FILE *inputFile=NULL;
+    FILE *outputFile=NULL;
     char *argv[5];
 
     if (!scriptPath)
     {
         return(1);
     }
-    result=cmeWebServiceCreateSecureTmpPath(&inputPath);
+    result=cmeCreateParserSecureTmpFile(&inputPath,&inputFile,"python-input");
     if (!result)
     {
-        result=cmeWebServiceCreateSecureTmpPath(&outputPath);
+        result=cmeCreateParserSecureTmpFile(&outputPath,&outputFile,"python-output");
     }
     if (!result)
     {
-        result=cmeWebServiceWriteResultMemTableCSV(inputPath);
+        result=cmeWebServiceWriteResultMemTableCSV(inputFile);
+    }
+    if (inputFile)
+    {
+        cmeStorageFileClose(inputFile);
+        inputFile=NULL;
+    }
+    if (outputFile)
+    {
+        cmeStorageFileClose(outputFile);
+        outputFile=NULL;
     }
     if (!result)
     {
@@ -1123,33 +1119,51 @@ static int cmeWebServiceRunPerlParserScript(const char *scriptPath)
     char *inputPath=NULL;
     char *outputPath=NULL;
     char *runnerPath=NULL;
+    FILE *inputFile=NULL;
+    FILE *outputFile=NULL;
+    FILE *runnerFile=NULL;
     char *argv[6];
 
     if (!scriptPath)
     {
         return(1);
     }
-    result=cmeWebServiceCreateSecureTmpPath(&inputPath);
+    result=cmeCreateParserSecureTmpFile(&inputPath,&inputFile,"perl-input");
     if (!result)
     {
-        result=cmeWebServiceCreateSecureTmpPath(&outputPath);
+        result=cmeCreateParserSecureTmpFile(&outputPath,&outputFile,"perl-output");
     }
     if (!result)
     {
-        result=cmeWebServiceCreateSecureTmpPath(&runnerPath);
+        result=cmeCreateParserSecureTmpFile(&runnerPath,&runnerFile,"perl-runner");
     }
     if (!result)
     {
-        result=cmeWebServiceWriteResultMemTableCSV(inputPath);
+        result=cmeWebServiceWriteResultMemTableCSV(inputFile);
     }
     if (!result)
     {
-        result=cmeWriteStrToFile((char *)cmePerlParserChildRunner,runnerPath,
-                                 (int)strlen(cmePerlParserChildRunner));
+        result=(fwrite(cmePerlParserChildRunner,1,strlen(cmePerlParserChildRunner),runnerFile)==
+                strlen(cmePerlParserChildRunner))?0:1;
         if (result)
         {
             result=3;
         }
+    }
+    if (inputFile)
+    {
+        cmeStorageFileClose(inputFile);
+        inputFile=NULL;
+    }
+    if (outputFile)
+    {
+        cmeStorageFileClose(outputFile);
+        outputFile=NULL;
+    }
+    if (runnerFile)
+    {
+        cmeStorageFileClose(runnerFile);
+        runnerFile=NULL;
     }
     if (!result)
     {
@@ -9355,9 +9369,10 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                 {
                     if (numResultRegisters) // Found >0
                     {
-                        result=cmeSecureFileToTmpRAWFile (&tmpRAWFile,pDB,scriptNameValues[0],resultRegisterCols
-                                                          [cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
-                                                          storagePath,urlElements[1],urlElements[3],orgKey);
+                        result=cmeSecureFileToTmpRAWFileInDir (&tmpRAWFile,pDB,scriptNameValues[0],resultRegisterCols
+                                                               [cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
+                                                               storagePath,urlElements[1],urlElements[3],orgKey,
+                                                               CDSE_PARSER_TMP_FILE_PATH);
                         if (result)//Error
                         {
                             cmeStrConstrAppend(responseText,"<b>500 ERROR Internal server error.</b><br>"
@@ -9591,9 +9606,10 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                 {
                     if (numResultRegisters) // Found >0
                     {
-                        result=cmeSecureFileToTmpRAWFile (&tmpRAWFile,pDB,scriptNameValues[0],resultRegisterCols
-                                                          [cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
-                                                          storagePath,urlElements[1],urlElements[3],orgKey);
+                        result=cmeSecureFileToTmpRAWFileInDir (&tmpRAWFile,pDB,scriptNameValues[0],resultRegisterCols
+                                                               [cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
+                                                               storagePath,urlElements[1],urlElements[3],orgKey,
+                                                               CDSE_PARSER_TMP_FILE_PATH);
                         if (result)//Error
                         {
 #ifdef ERROR_LOG


### PR DESCRIPTION
## Summary

- Complete TODO #75 by replacing parser temp-path generation with exclusive temp-file creation.
- Add `CDSE_PARSER_TMP_FILE_PATH` and shared helpers for service-owned `0700` temp directories and `0600` single-link regular files.
- Move parser input/output, Perl runner, and decrypted parser script temp files onto the hardened helper.
- Add DEBUG verifier coverage for cleanup, collision handling, strict modes, and refusal to use symlink temp directories.
- Update README/TUTORIAL parser isolation documentation.

## Security Impact

- Removes the parser temp-file race window from random path generation followed by later open/write.
- Reduces symlink exposure by refusing symlink temp directories and validating created files after `mkstemp()`.
- Keeps non-parser raw temp extraction on the existing API while routing parser script extraction through the parser temp directory.

## Validation

- bash -n TEST/run_debug_components.sh
- git diff --check
- make
- make check
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke: RESULT passed=93 failed=0 skipped=1
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --skip-build --live-only --web-protocol=https: RESULT passed=63 failed=0 skipped=10
