### PR TITLE
Add parser child isolation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1772,9 +1772,15 @@ This is a raw file
     rejected above `CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES` before loading,
     and parser result tables are rejected above
     `CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS`. These limits are compile-time
-    macros with conservative defaults. Both parser runtimes still inherit
-    the service user's filesystem and network access unless additional
-    child-process sandboxing is configured outside CaumeDSE.
+    macros with conservative defaults. Optional isolation controls can be
+    requested with compile-time macros or service environment variables:
+    `CDSE_PARSER_NO_NEW_PRIVS=1` requires Linux `no_new_privs`,
+    `CDSE_PARSER_ISOLATE_NETWORK=1` requires a private Linux network
+    namespace via `unshare(CLONE_NEWNET)`, and `CDSE_PARSER_CHROOT_PATH`
+    requires `chroot()` into a deployment-prepared parser jail. Requested
+    isolation fails closed if the platform or service privileges cannot apply
+    it. Chroot deployments must provide the configured interpreter paths,
+    parser temporary files, and required runtime libraries inside the jail.
 
     In AI-assisted workflows, treat CSV contents and parser output as
     untrusted data. CSV cells can contain prompt-injection text that asks an

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -16,6 +16,9 @@ WEB_PROTOCOL_SET=0
 CI_SMOKE=0
 LIVE_FLOW_ID="liveflow$$"
 REDACT_OUTPUT="${CDSE_VERIFY_REDACT:-0}"
+VERIFY_PARSER_NETWORK_ISOLATION="${CDSE_VERIFY_PARSER_NETWORK_ISOLATION:-0}"
+VERIFY_PARSER_CHROOT_ISOLATION="${CDSE_VERIFY_PARSER_CHROOT_ISOLATION:-0}"
+VERIFY_PARSER_NO_NEW_PRIVS="${CDSE_VERIFY_PARSER_NO_NEW_PRIVS:-0}"
 
 PASSED=0
 FAILED=0
@@ -43,6 +46,9 @@ usage() {
     printf '  CDSE_DEBUG_TEST_HTTPS_PORT HTTPS test port, default 18443\n'
     printf '  CDSE_DEBUG_TEST_TIMEOUT    executable timeout, default 120s\n'
     printf '  CDSE_VERIFY_REDACT         redact live verifier secrets from summaries and artifacts when set to 1/true/on\n'
+    printf '  CDSE_VERIFY_PARSER_NO_NEW_PRIVS       run live parser children with Linux no_new_privs when set to 1/true/on\n'
+    printf '  CDSE_VERIFY_PARSER_NETWORK_ISOLATION run optional network-isolation parser check when set to 1/true/on\n'
+    printf '  CDSE_VERIFY_PARSER_CHROOT_ISOLATION  run optional chroot parser filesystem check when set to 1/true/on\n'
 }
 
 while [ "$#" -gt 0 ]; do
@@ -131,6 +137,24 @@ csv_escape() {
 
 redaction_enabled() {
     case "$REDACT_OUTPUT" in
+        1|true|TRUE|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+parser_network_isolation_enabled() {
+    case "$VERIFY_PARSER_NETWORK_ISOLATION" in
+        1|true|TRUE|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+parser_chroot_isolation_enabled() {
+    case "$VERIFY_PARSER_CHROOT_ISOLATION" in
         1|true|TRUE|yes|YES|on|ON)
             return 0
             ;;
@@ -537,6 +561,8 @@ run_live_web_flow() {
     local python_script_name="${LIVE_FLOW_ID}_${protocol}.py"
     local python_timeout_script_name="${LIVE_FLOW_ID}_${protocol}_timeout.py"
     local python_oversize_script_name="${LIVE_FLOW_ID}_${protocol}_oversize.py"
+    local python_network_script_name="${LIVE_FLOW_ID}_${protocol}_network.py"
+    local python_outside_file_script_name="${LIVE_FLOW_ID}_${protocol}_outside_file.py"
     local user_id="User123"
     local role_user="${LIVE_FLOW_ID}_${protocol}_user"
     local auth="userId=$user_id&orgId=$org_name&orgKey=$org_key"
@@ -565,6 +591,9 @@ run_live_web_flow() {
         env CDSE_DEBUG_TEST_SKIP_AUTHZ=1 \
             CDSE_DEBUG_TEST_HTTP_PORT="$HTTP_PORT" \
             CDSE_DEBUG_TEST_HTTPS_PORT="$HTTPS_PORT" \
+            CDSE_PARSER_NO_NEW_PRIVS="$VERIFY_PARSER_NO_NEW_PRIVS" \
+            CDSE_PARSER_ISOLATE_NETWORK="$VERIFY_PARSER_NETWORK_ISOLATION" \
+            CDSE_PARSER_CHROOT_PATH="${CDSE_VERIFY_PARSER_CHROOT_PATH:-}" \
             "$PREFIX/cdse/bin/CaumeDSE-debug-tests" --web-service "$protocol"
     ) > "$service_log" 2>&1 &
     service_pid=$!
@@ -678,6 +707,30 @@ run_live_web_flow() {
         -F "newOrgKey=$org_key" \
         -F "*resourceInfo=live $protocol oversize Python script"
     live_api_check "$protocol" python_parser_oversize 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_oversize_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
+    if parser_network_isolation_enabled; then
+        if [ "$protocol" = "http" ]; then
+            live_api_check "$protocol" upload_python_network_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_network_script_name" "" "${curl_tls_args[@]}" \
+                -F "file=@$ROOT_DIR/TEST/testfiles/test_network_access.py" \
+                -F "userId=$user_id" \
+                -F "orgId=$org_name" \
+                -F "orgKey=$org_key" \
+                -F "newOrgKey=$org_key" \
+                -F "*resourceInfo=live $protocol network isolation Python script"
+            live_api_check "$protocol" python_parser_network_isolation 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_network_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
+        else
+            record_skip "live_${protocol}_python_parser_network_isolation" "network fixture targets HTTP port $HTTP_PORT"
+        fi
+    fi
+    if parser_chroot_isolation_enabled; then
+        live_api_check "$protocol" upload_python_outside_file_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_outside_file_script_name" "" "${curl_tls_args[@]}" \
+            -F "file=@$ROOT_DIR/TEST/testfiles/test_outside_file_access.py" \
+            -F "userId=$user_id" \
+            -F "orgId=$org_name" \
+            -F "orgKey=$org_key" \
+            -F "newOrgKey=$org_key" \
+            -F "*resourceInfo=live $protocol chroot isolation Python script"
+        live_api_check "$protocol" python_parser_chroot_isolation 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_outside_file_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
+    fi
     live_api_check "$protocol" document_delete 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
     live_api_check "$protocol" role_table_delete 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
     live_api_check "$protocol" filter_whitelist_delete 200 "$base_url/organizations/$org_name/users/$role_user/filterWhitelist/$role_user?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE

--- a/TEST/testfiles/test_network_access.py
+++ b/TEST/testfiles/test_network_access.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Negative parser fixture: requires access to the live HTTP verifier port."""
+import csv
+import socket
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        return 2
+
+    input_path, output_path = sys.argv[1], sys.argv[2]
+    try:
+        with socket.create_connection(("127.0.0.1", 18080), timeout=2):
+            pass
+    except OSError:
+        return 9
+
+    with open(input_path, newline="") as src:
+        rows = list(csv.reader(src))
+    with open(output_path, "w", newline="") as dst:
+        csv.writer(dst).writerows(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TEST/testfiles/test_outside_file_access.py
+++ b/TEST/testfiles/test_outside_file_access.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Negative parser fixture: requires read access to a host file outside parser temp."""
+import csv
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        return 2
+
+    input_path, output_path = sys.argv[1], sys.argv[2]
+    try:
+        with open("/etc/passwd", "rb") as host_file:
+            host_file.read(1)
+    except OSError:
+        return 9
+
+    with open(input_path, newline="") as src:
+        rows = list(csv.reader(src))
+    with open(output_path, "w", newline="") as dst:
+        csv.writer(dst).writerows(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TODO.md
+++ b/TODO.md
@@ -522,13 +522,21 @@
     the exclusive helper. Added DEBUG verifier coverage for cleanup, collision
     handling, strict modes, and refusal to use a symlink temp directory.
 
-- [ ] #76 Add optional network and filesystem isolation for parser child processes.
+- [x] #76 Add optional network and filesystem isolation for parser child processes.
   - Source: parser child launcher, deployment docs, verifier environment.
   - Goal: enforce the existing guidance that parser scripts must not open network connections or read arbitrary host files.
   - Plan:
     - Batch 1: evaluate portable containment options and Linux-specific hardening such as unprivileged users, namespaces, chroot, seccomp, or container profiles.
     - Batch 2: add opt-in isolation settings that fail closed when requested isolation cannot be applied.
     - Batch 3: document operational requirements and add negative fixtures for network and outside-file access where the platform supports enforcement.
+  - Done: added opt-in parser child isolation controls that can be set at
+    compile time or through service environment variables. `no_new_privs` and
+    private network namespace isolation are supported on Linux, and optional
+    `chroot()` filesystem isolation is supported when deployments provide a
+    prepared parser jail. Requested isolation fails closed when the OS or
+    service privileges cannot apply it. Added optional live verifier fixtures
+    for network access and outside-file access, plus deployment documentation
+    for platform and jail requirements.
 
 - [ ] #77 Add parser execution audit and policy controls.
   - Source: `webservice_interface.c`, resources/roles DB handling, AI usage docs.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -375,9 +375,12 @@ Security considerations:
   an output-file size cap,
   and OS resource limits for CPU time, file size, address space, open files,
   and process count where supported. Perl and Python parser outputs share the
-  parser result-table cap. The child processes still inherit the service
-  user's filesystem and network privileges, so stricter filesystem and network
-  sandboxing remain separate hardening work.
+  parser result-table cap. Deployments can opt into fail-closed parser child
+  isolation with `CDSE_PARSER_NO_NEW_PRIVS=1`,
+  `CDSE_PARSER_ISOLATE_NETWORK=1`, and `CDSE_PARSER_CHROOT_PATH=/path/to/jail`.
+  Network isolation requires Linux network namespaces. Chroot filesystem
+  isolation requires a prepared jail containing the configured interpreters,
+  parser temp paths, and runtime libraries.
 
 Prompt-injection boundary:
 

--- a/common.h
+++ b/common.h
@@ -95,6 +95,15 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #ifndef CDSE_PARSER_SCRIPT_MAX_PROCESSES
 #define CDSE_PARSER_SCRIPT_MAX_PROCESSES 16 //Max parser child process count where RLIMIT_NPROC is available.
 #endif
+#ifndef CDSE_PARSER_SCRIPT_NO_NEW_PRIVS
+#define CDSE_PARSER_SCRIPT_NO_NEW_PRIVS 0 //Set to 1 to require Linux no_new_privs for parser children.
+#endif
+#ifndef CDSE_PARSER_SCRIPT_ISOLATE_NETWORK
+#define CDSE_PARSER_SCRIPT_ISOLATE_NETWORK 0 //Set to 1 to require a private Linux network namespace for parser children.
+#endif
+#ifndef CDSE_PARSER_SCRIPT_CHROOT_PATH
+#define CDSE_PARSER_SCRIPT_CHROOT_PATH "" //Set to a prepared parser jail path to chroot parser children.
+#endif
 #define cmeDefaultContentReaderCallbackPageSize (1024*64)   //Default Page size for ContentReaderCallback functions.
 #ifndef CDSE_SECURE_OVERWRITE_PASSES
 #define CDSE_SECURE_OVERWRITE_PASSES 1  //Compile-time overwrite passes for temporary file deletion. Set >1 to enable multi-round overwrites.

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -50,6 +50,10 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #if defined(__unix__) || defined(__APPLE__)
 #include <sys/resource.h>
 #endif
+#ifdef __linux__
+#include <sched.h>
+#include <sys/prctl.h>
+#endif
 
 static void cmeWebServiceSetThreadStatus(struct cmeWebServiceConnectionInfoStruct *con_info, int threadStatus)
 {
@@ -878,6 +882,88 @@ static int cmeWebServiceApplyParserChildLimits(void)
     return(0);
 }
 
+static int cmeWebServiceParserEnvFlag(const char *envName, int defaultValue)
+{
+    const char *value;
+
+    value=getenv(envName);
+    if ((!value)||(!value[0]))
+    {
+        return(defaultValue?1:0);
+    }
+    if ((!strcmp(value,"1"))||(!strcmp(value,"true"))||(!strcmp(value,"TRUE"))||
+        (!strcmp(value,"on"))||(!strcmp(value,"ON"))||(!strcmp(value,"yes"))||
+        (!strcmp(value,"YES")))
+    {
+        return(1);
+    }
+    if ((!strcmp(value,"0"))||(!strcmp(value,"false"))||(!strcmp(value,"FALSE"))||
+        (!strcmp(value,"off"))||(!strcmp(value,"OFF"))||(!strcmp(value,"no"))||
+        (!strcmp(value,"NO")))
+    {
+        return(0);
+    }
+    return(defaultValue?1:0);
+}
+
+static const char *cmeWebServiceParserChrootPath(void)
+{
+    const char *envPath=getenv("CDSE_PARSER_CHROOT_PATH");
+
+    if (envPath&&envPath[0])
+    {
+        return(envPath);
+    }
+    if (CDSE_PARSER_SCRIPT_CHROOT_PATH[0])
+    {
+        return(CDSE_PARSER_SCRIPT_CHROOT_PATH);
+    }
+    return(NULL);
+}
+
+static int cmeWebServiceApplyParserChildIsolation(void)
+{
+    const char *chrootPath;
+
+    if (cmeWebServiceParserEnvFlag("CDSE_PARSER_NO_NEW_PRIVS",
+                                   CDSE_PARSER_SCRIPT_NO_NEW_PRIVS))
+    {
+#ifdef __linux__
+        if (prctl(PR_SET_NO_NEW_PRIVS,1,0,0,0))
+        {
+            return(1);
+        }
+#else
+        return(1);
+#endif
+    }
+    if (cmeWebServiceParserEnvFlag("CDSE_PARSER_ISOLATE_NETWORK",
+                                   CDSE_PARSER_SCRIPT_ISOLATE_NETWORK))
+    {
+#if defined(__linux__) && defined(CLONE_NEWNET)
+        if (unshare(CLONE_NEWNET))
+        {
+            return(2);
+        }
+#else
+        return(2);
+#endif
+    }
+    chrootPath=cmeWebServiceParserChrootPath();
+    if (chrootPath)
+    {
+#if defined(__unix__) || defined(__APPLE__)
+        if ((chroot(chrootPath))||(chdir("/")))
+        {
+            return(3);
+        }
+#else
+        return(3);
+#endif
+    }
+    return(0);
+}
+
 static void cmeWebServiceCloseParserChildFds(void)
 {
     long maxFd=sysconf(_SC_OPEN_MAX);
@@ -934,6 +1020,10 @@ static void cmeWebServiceExecParserChild(const char *interpreterPath, char *cons
         _exit(126);
     }
     cmeWebServiceCloseParserChildFds();
+    if (cmeWebServiceApplyParserChildIsolation())
+    {
+        _exit(126);
+    }
     if (cmeWebServiceApplyParserChildLimits())
     {
         _exit(126);


### PR DESCRIPTION
## Summary

- Complete TODO #76 with opt-in parser child isolation controls.
- Add runtime and compile-time knobs for Linux `no_new_privs`, Linux network namespace isolation, and optional `chroot()` filesystem isolation.
- Make requested isolation fail closed when the OS or service privileges cannot apply it.
- Add optional live verifier hooks plus negative parser fixtures for network and outside-file access.
- Document platform requirements and parser jail expectations.

## Security Impact

- Deployments can now require parser children to run with stricter OS containment instead of relying only on review guidance.
- `CDSE_PARSER_NO_NEW_PRIVS=1` prevents privilege-gaining exec behavior on Linux.
- `CDSE_PARSER_ISOLATE_NETWORK=1` requires `unshare(CLONE_NEWNET)` and fails parser execution if denied.
- `CDSE_PARSER_CHROOT_PATH=/path/to/jail` requires a prepared filesystem jail containing configured interpreters, parser temp paths, and runtime libraries.

## Validation

- bash -n TEST/run_debug_components.sh
- python3 -m py_compile TEST/testfiles/test_network_access.py TEST/testfiles/test_outside_file_access.py
- make
- make check
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke: RESULT passed=93 failed=0 skipped=1
- CDSE_VERIFY_REDACT=1 CDSE_VERIFY_PARSER_NO_NEW_PRIVS=1 TEST/run_debug_components.sh --skip-build --live-only --web-protocol=http: RESULT passed=61 failed=0 skipped=10
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --skip-build --live-only --web-protocol=https: RESULT passed=63 failed=0 skipped=10
- git diff --check

## Notes

- `unshare -n true` returns `Operation not permitted` on this host, so the optional network namespace verifier was not runnable here. The implementation is fail-closed when requested isolation cannot be applied.
