### PR TITLE
Add parser execution policy audit

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -70,7 +70,7 @@ curl -i $TLS_ARGS \
   -F "orgId=$ORG" \
   -F "orgKey=$ORG_KEY" \
   -F "newOrgKey=$ORG_KEY" \
-  -F "*resourceInfo=reviewed Python parser" \
+  -F "*resourceInfo=reviewed Python parser parser.reviewed:true parser.interpreter:/usr/bin/python3 parser.timeout:10 parser.isolation:none" \
   "$BASE_URL/organizations/$ORG/storage/$STORAGE/documentTypes/script.python/documents/$SCRIPT_PYTHON"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1781,6 +1781,18 @@ This is a raw file
     isolation fails closed if the platform or service privileges cannot apply
     it. Chroot deployments must provide the configured interpreter paths,
     parser temporary files, and required runtime libraries inside the jail.
+    Parser policy metadata can be stored in the script document's
+    `*resourceInfo`, for example `parser.reviewed:true`,
+    `parser.interpreter:/usr/bin/python3`, `parser.timeout:10`, and
+    `parser.isolation:none`. The policy matcher also accepts existing
+    `key=value` metadata already stored in a resources DB. Deployments can
+    enforce this metadata with
+    `CDSE_PARSER_REQUIRE_REVIEWED=1`,
+    `CDSE_PARSER_REQUIRE_POLICY_PROFILES=1`, and
+    `CDSE_PARSER_ALLOWED_TYPES=script.perl,script.python`. Parser upload,
+    policy allow/deny, execution success, timeout, limit rejection, and
+    cleanup-failure events are written as structured audit log lines without org
+    keys, script bodies, or CSV content.
 
     In AI-assisted workflows, treat CSV contents and parser output as
     untrusted data. CSV cells can contain prompt-injection text that asks an

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -19,6 +19,8 @@ REDACT_OUTPUT="${CDSE_VERIFY_REDACT:-0}"
 VERIFY_PARSER_NETWORK_ISOLATION="${CDSE_VERIFY_PARSER_NETWORK_ISOLATION:-0}"
 VERIFY_PARSER_CHROOT_ISOLATION="${CDSE_VERIFY_PARSER_CHROOT_ISOLATION:-0}"
 VERIFY_PARSER_NO_NEW_PRIVS="${CDSE_VERIFY_PARSER_NO_NEW_PRIVS:-0}"
+VERIFY_PARSER_REQUIRE_REVIEWED="${CDSE_VERIFY_PARSER_REQUIRE_REVIEWED:-0}"
+VERIFY_PARSER_REQUIRE_POLICY_PROFILES="${CDSE_VERIFY_PARSER_REQUIRE_POLICY_PROFILES:-0}"
 
 PASSED=0
 FAILED=0
@@ -49,6 +51,8 @@ usage() {
     printf '  CDSE_VERIFY_PARSER_NO_NEW_PRIVS       run live parser children with Linux no_new_privs when set to 1/true/on\n'
     printf '  CDSE_VERIFY_PARSER_NETWORK_ISOLATION run optional network-isolation parser check when set to 1/true/on\n'
     printf '  CDSE_VERIFY_PARSER_CHROOT_ISOLATION  run optional chroot parser filesystem check when set to 1/true/on\n'
+    printf '  CDSE_VERIFY_PARSER_REQUIRE_REVIEWED  require parser.reviewed:true metadata in live parser checks\n'
+    printf '  CDSE_VERIFY_PARSER_REQUIRE_POLICY_PROFILES require parser interpreter/timeout/isolation metadata in live parser checks\n'
 }
 
 while [ "$#" -gt 0 ]; do
@@ -155,6 +159,15 @@ parser_network_isolation_enabled() {
 
 parser_chroot_isolation_enabled() {
     case "$VERIFY_PARSER_CHROOT_ISOLATION" in
+        1|true|TRUE|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+parser_review_policy_enabled() {
+    case "$VERIFY_PARSER_REQUIRE_REVIEWED" in
         1|true|TRUE|yes|YES|on|ON)
             return 0
             ;;
@@ -563,6 +576,9 @@ run_live_web_flow() {
     local python_oversize_script_name="${LIVE_FLOW_ID}_${protocol}_oversize.py"
     local python_network_script_name="${LIVE_FLOW_ID}_${protocol}_network.py"
     local python_outside_file_script_name="${LIVE_FLOW_ID}_${protocol}_outside_file.py"
+    local python_unreviewed_script_name="${LIVE_FLOW_ID}_${protocol}_unreviewed.py"
+    local perl_policy_meta="parser.reviewed:true parser.interpreter:/usr/bin/perl parser.timeout:10 parser.isolation:none"
+    local python_policy_meta="parser.reviewed:true parser.interpreter:/usr/bin/python3 parser.timeout:10 parser.isolation:none"
     local user_id="User123"
     local role_user="${LIVE_FLOW_ID}_${protocol}_user"
     local auth="userId=$user_id&orgId=$org_name&orgKey=$org_key"
@@ -594,6 +610,8 @@ run_live_web_flow() {
             CDSE_PARSER_NO_NEW_PRIVS="$VERIFY_PARSER_NO_NEW_PRIVS" \
             CDSE_PARSER_ISOLATE_NETWORK="$VERIFY_PARSER_NETWORK_ISOLATION" \
             CDSE_PARSER_CHROOT_PATH="${CDSE_VERIFY_PARSER_CHROOT_PATH:-}" \
+            CDSE_PARSER_REQUIRE_REVIEWED="$VERIFY_PARSER_REQUIRE_REVIEWED" \
+            CDSE_PARSER_REQUIRE_POLICY_PROFILES="$VERIFY_PARSER_REQUIRE_POLICY_PROFILES" \
             "$PREFIX/cdse/bin/CaumeDSE-debug-tests" --web-service "$protocol"
     ) > "$service_log" 2>&1 &
     service_pid=$!
@@ -662,7 +680,7 @@ run_live_web_flow() {
         -F "orgId=$org_name" \
         -F "orgKey=$org_key" \
         -F "newOrgKey=$org_key" \
-        -F "*resourceInfo=live $protocol Perl script"
+        -F "*resourceInfo=live $protocol Perl script $perl_policy_meta"
     live_api_check "$protocol" parser_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$script_name?$auth&newOrgKey=$org_key&outputType=csv" "82400" "${curl_tls_args[@]}"
     live_api_check "$protocol" parser_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$script_name?$auth&newOrgKey=$org_key&outputType=json" '"salary":"82400"' "${curl_tls_args[@]}"
     live_api_check "$protocol" parser_missing_head 404 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/missing.pl?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}" -I
@@ -672,7 +690,7 @@ run_live_web_flow() {
         -F "orgId=$org_name" \
         -F "orgKey=$org_key" \
         -F "newOrgKey=$org_key" \
-        -F "*resourceInfo=live $protocol timeout Perl script"
+        -F "*resourceInfo=live $protocol timeout Perl script $perl_policy_meta"
     live_api_check "$protocol" perl_parser_timeout 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$perl_timeout_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_perl_oversize_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.perl/documents/$perl_oversize_script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test_oversize.pl" \
@@ -680,7 +698,7 @@ run_live_web_flow() {
         -F "orgId=$org_name" \
         -F "orgKey=$org_key" \
         -F "newOrgKey=$org_key" \
-        -F "*resourceInfo=live $protocol oversize Perl script"
+        -F "*resourceInfo=live $protocol oversize Perl script $perl_policy_meta"
     live_api_check "$protocol" perl_parser_oversize 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$perl_oversize_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_python_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test.py" \
@@ -688,7 +706,7 @@ run_live_web_flow() {
         -F "orgId=$org_name" \
         -F "orgKey=$org_key" \
         -F "newOrgKey=$org_key" \
-        -F "*resourceInfo=live $protocol Python script"
+        -F "*resourceInfo=live $protocol Python script $python_policy_meta"
     live_api_check "$protocol" python_parser_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_script_name?$auth&newOrgKey=$org_key&outputType=csv" "82400" "${curl_tls_args[@]}"
     live_api_check "$protocol" python_parser_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_script_name?$auth&newOrgKey=$org_key&outputType=json" '"salary":"82400"' "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_python_timeout_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_timeout_script_name" "" "${curl_tls_args[@]}" \
@@ -697,7 +715,7 @@ run_live_web_flow() {
         -F "orgId=$org_name" \
         -F "orgKey=$org_key" \
         -F "newOrgKey=$org_key" \
-        -F "*resourceInfo=live $protocol timeout Python script"
+        -F "*resourceInfo=live $protocol timeout Python script $python_policy_meta"
     live_api_check "$protocol" python_parser_timeout 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_timeout_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_python_oversize_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_oversize_script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test_oversize.py" \
@@ -705,7 +723,7 @@ run_live_web_flow() {
         -F "orgId=$org_name" \
         -F "orgKey=$org_key" \
         -F "newOrgKey=$org_key" \
-        -F "*resourceInfo=live $protocol oversize Python script"
+        -F "*resourceInfo=live $protocol oversize Python script $python_policy_meta"
     live_api_check "$protocol" python_parser_oversize 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_oversize_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
     if parser_network_isolation_enabled; then
         if [ "$protocol" = "http" ]; then
@@ -715,7 +733,7 @@ run_live_web_flow() {
                 -F "orgId=$org_name" \
                 -F "orgKey=$org_key" \
                 -F "newOrgKey=$org_key" \
-                -F "*resourceInfo=live $protocol network isolation Python script"
+                -F "*resourceInfo=live $protocol network isolation Python script $python_policy_meta"
             live_api_check "$protocol" python_parser_network_isolation 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_network_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
         else
             record_skip "live_${protocol}_python_parser_network_isolation" "network fixture targets HTTP port $HTTP_PORT"
@@ -728,8 +746,18 @@ run_live_web_flow() {
             -F "orgId=$org_name" \
             -F "orgKey=$org_key" \
             -F "newOrgKey=$org_key" \
-            -F "*resourceInfo=live $protocol chroot isolation Python script"
+            -F "*resourceInfo=live $protocol chroot isolation Python script $python_policy_meta"
         live_api_check "$protocol" python_parser_chroot_isolation 500 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_outside_file_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
+    fi
+    if parser_review_policy_enabled; then
+        live_api_check "$protocol" upload_python_unreviewed_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_unreviewed_script_name" "" "${curl_tls_args[@]}" \
+            -F "file=@$ROOT_DIR/TEST/testfiles/test.py" \
+            -F "userId=$user_id" \
+            -F "orgId=$org_name" \
+            -F "orgKey=$org_key" \
+            -F "newOrgKey=$org_key" \
+            -F "*resourceInfo=live $protocol unreviewed Python script"
+        live_api_check "$protocol" python_parser_policy_unreviewed 403 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_unreviewed_script_name?$auth&newOrgKey=$org_key&outputType=csv" "" "${curl_tls_args[@]}"
     fi
     live_api_check "$protocol" document_delete 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
     live_api_check "$protocol" role_table_delete 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
@@ -739,6 +767,12 @@ run_live_web_flow() {
 
     stop_live_service "$service_pid"
     redact_file_in_place "$service_log"
+    if grep -Fq "CaumeDSE Audit: parserExecution event=policy-allow" "$service_log" &&
+       grep -Fq "CaumeDSE Audit: parserExecution event=execute-success" "$service_log"; then
+        record_pass "live_${protocol}_parser_audit"
+    else
+        record_fail "live_${protocol}_parser_audit" "missing parser audit markers log=$service_log"
+    fi
 
     if [ "$LIVE_FLOW_FAILED" -eq 0 ]; then
         record_pass "live_${protocol}_api_flow"

--- a/TODO.md
+++ b/TODO.md
@@ -538,10 +538,20 @@
     for network access and outside-file access, plus deployment documentation
     for platform and jail requirements.
 
-- [ ] #77 Add parser execution audit and policy controls.
+- [x] #77 Add parser execution audit and policy controls.
   - Source: `webservice_interface.c`, resources/roles DB handling, AI usage docs.
   - Goal: make parser execution decisions visible and policy-driven so deployments can restrict high-risk scripts before runtime.
   - Plan:
     - Batch 1: add parser policy metadata for allowed script types, reviewed status, interpreter path, timeout profile, and isolation profile.
     - Batch 2: record structured audit events for parser upload, execution, timeout, limit rejection, and cleanup failure without logging secrets or raw CSV contents.
     - Batch 3: document least-privilege parser roles and extend verifier checks for policy allow/deny behavior.
+  - Done: parser execution now evaluates policy metadata from the script
+    document `resourceInfo` before decrypting or running the script. Deployments
+    can restrict allowed parser document types, require `parser.reviewed:true`,
+    and require interpreter, timeout, and isolation profile metadata to match
+    runtime settings. Parser upload, policy allow/deny, execution success,
+    timeout, limit rejection, and decrypted-temp cleanup failure audit lines
+    include IDs, script type, method, and result status without org keys, raw
+    scripts, or CSV content. Live verifier uploads reviewed metadata, checks
+    audit markers, and can run a reviewed-policy deny case for unreviewed
+    scripts.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -381,6 +381,18 @@ Security considerations:
   Network isolation requires Linux network namespaces. Chroot filesystem
   isolation requires a prepared jail containing the configured interpreters,
   parser temp paths, and runtime libraries.
+- Parser policy metadata can be stored in the script document `*resourceInfo`.
+  Use `parser.reviewed:true`, `parser.interpreter:/usr/bin/python3` or
+  `/usr/bin/perl`, `parser.timeout:10`, and `parser.isolation:none` or the
+  enabled isolation profile. The policy matcher also accepts existing
+  `key=value` metadata already stored in a resources DB. Deployments can
+  enforce reviewed scripts and exact profiles with `CDSE_PARSER_REQUIRE_REVIEWED=1`,
+  `CDSE_PARSER_REQUIRE_POLICY_PROFILES=1`, and
+  `CDSE_PARSER_ALLOWED_TYPES=script.perl,script.python`.
+- Parser upload, policy allow/deny, execution success, timeout, limit rejection,
+  and cleanup-failure audit lines identify user, organization, storage,
+  document, script, type, method, and result status without logging org keys,
+  script bodies, or CSV content.
 
 Prompt-injection boundary:
 

--- a/common.h
+++ b/common.h
@@ -104,6 +104,15 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #ifndef CDSE_PARSER_SCRIPT_CHROOT_PATH
 #define CDSE_PARSER_SCRIPT_CHROOT_PATH "" //Set to a prepared parser jail path to chroot parser children.
 #endif
+#ifndef CDSE_PARSER_REQUIRE_REVIEWED
+#define CDSE_PARSER_REQUIRE_REVIEWED 0 //Set to 1 to require parser.reviewed:true metadata before execution.
+#endif
+#ifndef CDSE_PARSER_ALLOWED_TYPES
+#define CDSE_PARSER_ALLOWED_TYPES "script.perl,script.python" //Comma-separated parser script document types allowed for execution.
+#endif
+#ifndef CDSE_PARSER_REQUIRE_POLICY_PROFILES
+#define CDSE_PARSER_REQUIRE_POLICY_PROFILES 0 //Set to 1 to require parser timeout/interpreter/isolation metadata match runtime settings.
+#endif
 #define cmeDefaultContentReaderCallbackPageSize (1024*64)   //Default Page size for ContentReaderCallback functions.
 #ifndef CDSE_SECURE_OVERWRITE_PASSES
 #define CDSE_SECURE_OVERWRITE_PASSES 1  //Compile-time overwrite passes for temporary file deletion. Set >1 to enable multi-round overwrites.

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -964,6 +964,259 @@ static int cmeWebServiceApplyParserChildIsolation(void)
     return(0);
 }
 
+static const char *cmeWebServiceParserEnvString(const char *envName, const char *defaultValue)
+{
+    const char *value=getenv(envName);
+
+    if (value&&value[0])
+    {
+        return(value);
+    }
+    return(defaultValue);
+}
+
+static int cmeWebServiceParserListHasValue(const char *list, const char *value)
+{
+    const char *start;
+    const char *end;
+    size_t valueLen;
+
+    if ((!list)||(!value))
+    {
+        return(0);
+    }
+    valueLen=strlen(value);
+    start=list;
+    while (*start)
+    {
+        while ((*start==',')||(*start==' ')||(*start=='\t'))
+        {
+            start++;
+        }
+        end=start;
+        while ((*end)&&(*end!=','))
+        {
+            end++;
+        }
+        while ((end>start)&&((end[-1]==' ')||(end[-1]=='\t')))
+        {
+            end--;
+        }
+        if (((size_t)(end-start)==valueLen)&&(!strncmp(start,value,valueLen)))
+        {
+            return(1);
+        }
+        start=(*end)?end+1:end;
+    }
+    return(0);
+}
+
+static int cmeWebServiceParserMetadataHasToken(const char *metadata, const char *token)
+{
+    const char *match;
+    size_t tokenLen;
+
+    if ((!metadata)||(!token)||(!token[0]))
+    {
+        return(0);
+    }
+    tokenLen=strlen(token);
+    match=metadata;
+    while ((match=strstr(match,token)))
+    {
+        if (((match==metadata)||(match[-1]==' ')||(match[-1]=='\t')||
+             (match[-1]==',')||(match[-1]==';'))&&
+            ((!match[tokenLen])||(match[tokenLen]==' ')||(match[tokenLen]=='\t')||
+             (match[tokenLen]==',')||(match[tokenLen]==';')))
+        {
+            return(1);
+        }
+        match+=tokenLen;
+    }
+    return(0);
+}
+
+static int cmeWebServiceParserMetadataKeyMatches(const char *metadata, const char *key, const char *value)
+{
+    char *token=NULL;
+    int result=0;
+
+    if ((!key)||(!value))
+    {
+        return(0);
+    }
+    cmeStrConstrAppend(&token,"%s=%s",key,value);
+    if (token)
+    {
+        result=cmeWebServiceParserMetadataHasToken(metadata,token);
+    }
+    cmeFree(token);
+    if (!result)
+    {
+        cmeStrConstrAppend(&token,"%s:%s",key,value);
+        if (token)
+        {
+            result=cmeWebServiceParserMetadataHasToken(metadata,token);
+        }
+        cmeFree(token);
+    }
+    return(result);
+}
+
+static const char *cmeWebServiceParserInterpreterForType(const char *scriptType)
+{
+    if (!scriptType)
+    {
+        return("");
+    }
+    if (!strcmp(scriptType,"script.perl"))
+    {
+        return(CDSE_PARSER_PERL_PATH);
+    }
+    if (!strcmp(scriptType,"script.python"))
+    {
+        return(CDSE_PARSER_PYTHON_PATH);
+    }
+    return("");
+}
+
+static void cmeWebServiceParserIsolationProfile(char *profile, size_t profileLen)
+{
+    int added=0;
+
+    if ((!profile)||(!profileLen))
+    {
+        return;
+    }
+    profile[0]='\0';
+    if (cmeWebServiceParserEnvFlag("CDSE_PARSER_NO_NEW_PRIVS",
+                                   CDSE_PARSER_SCRIPT_NO_NEW_PRIVS))
+    {
+        strncat(profile,"no_new_privs",profileLen-strlen(profile)-1);
+        added=1;
+    }
+    if (cmeWebServiceParserEnvFlag("CDSE_PARSER_ISOLATE_NETWORK",
+                                   CDSE_PARSER_SCRIPT_ISOLATE_NETWORK))
+    {
+        if (added)
+        {
+            strncat(profile,"+",profileLen-strlen(profile)-1);
+        }
+        strncat(profile,"network",profileLen-strlen(profile)-1);
+        added=1;
+    }
+    if (cmeWebServiceParserChrootPath())
+    {
+        if (added)
+        {
+            strncat(profile,"+",profileLen-strlen(profile)-1);
+        }
+        strncat(profile,"chroot",profileLen-strlen(profile)-1);
+        added=1;
+    }
+    if (!added)
+    {
+        strncat(profile,"none",profileLen-strlen(profile)-1);
+    }
+}
+
+static int cmeWebServiceParserPolicyAllows(const char *metadata, const char *scriptType, const char *userId,
+                                           const char *orgId, const char *storageId, const char *documentId,
+                                           const char *scriptId, const char *method)
+{
+    char isolationProfile[128];
+    char timeoutProfile[32];
+    const char *allowedTypes;
+    const char *interpreterPath;
+    int reviewed;
+    int requireReviewed;
+    int requireProfiles;
+
+    allowedTypes=cmeWebServiceParserEnvString("CDSE_PARSER_ALLOWED_TYPES",CDSE_PARSER_ALLOWED_TYPES);
+    interpreterPath=cmeWebServiceParserInterpreterForType(scriptType);
+    reviewed=(cmeWebServiceParserMetadataHasToken(metadata,"parser.reviewed=true")||
+              cmeWebServiceParserMetadataHasToken(metadata,"parser.reviewed:true"));
+    requireReviewed=cmeWebServiceParserEnvFlag("CDSE_PARSER_REQUIRE_REVIEWED",CDSE_PARSER_REQUIRE_REVIEWED);
+    requireProfiles=cmeWebServiceParserEnvFlag("CDSE_PARSER_REQUIRE_POLICY_PROFILES",
+                                               CDSE_PARSER_REQUIRE_POLICY_PROFILES);
+    cmeWebServiceParserIsolationProfile(isolationProfile,sizeof(isolationProfile));
+    snprintf(timeoutProfile,sizeof(timeoutProfile),"%d",CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS);
+    if (!cmeWebServiceParserListHasValue(allowedTypes,scriptType))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=type userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
+                userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
+                scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+#endif
+        return(1);
+    }
+    if (requireReviewed&&(!reviewed))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=unreviewed userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
+                userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
+                scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+#endif
+        return(2);
+    }
+    if (requireProfiles&&
+        ((!cmeWebServiceParserMetadataKeyMatches(metadata,"parser.interpreter",interpreterPath))||
+         (!cmeWebServiceParserMetadataKeyMatches(metadata,"parser.timeout",timeoutProfile))||
+         (!cmeWebServiceParserMetadataKeyMatches(metadata,"parser.isolation",isolationProfile))))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=profile userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s' isolationProfile='%s'\n",
+                userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
+                scriptId?scriptId:"",scriptType?scriptType:"",method?method:"",isolationProfile);
+#endif
+        return(3);
+    }
+#ifdef ERROR_LOG
+    fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-allow userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s' reviewed='%d' isolationProfile='%s'\n",
+            userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
+            scriptId?scriptId:"",scriptType?scriptType:"",method?method:"",reviewed,isolationProfile);
+#endif
+    return(0);
+}
+
+static void cmeWebServiceParserAuditResult(const char *event, int result, const char *scriptType,
+                                           const char *userId, const char *orgId, const char *storageId,
+                                           const char *documentId, const char *scriptId, const char *method)
+{
+#ifdef ERROR_LOG
+    fprintf(stderr,"CaumeDSE Audit: parserExecution event=%s result=%d userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
+            event?event:"unknown",result,userId?userId:"",orgId?orgId:"",storageId?storageId:"",
+            documentId?documentId:"",scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+#else
+    (void)event;
+    (void)result;
+    (void)scriptType;
+    (void)userId;
+    (void)orgId;
+    (void)storageId;
+    (void)documentId;
+    (void)scriptId;
+    (void)method;
+#endif
+}
+
+static const char *cmeWebServiceParserAuditExecutionEvent(int result)
+{
+    if (!result)
+    {
+        return("execute-success");
+    }
+    if (result==6)
+    {
+        return("timeout");
+    }
+    if ((result==7)||(result==8))
+    {
+        return("limit-reject");
+    }
+    return("execute-fail");
+}
+
 static void cmeWebServiceCloseParserChildFds(void)
 {
     long maxFd=sysconf(_SC_OPEN_MAX);
@@ -7880,6 +8133,11 @@ int cmeWebServiceProcessDocumentResource (char **responseText, char ***responseH
                                                             urlElements[3], //storageId
                                                             storagePath);   //storagePath
                         }
+                        if (cmeWebServiceIsParserScriptDocumentType(urlElements[5]))
+                        {
+                            cmeWebServiceParserAuditResult(result?"upload-fail":"upload-success",result,urlElements[5],
+                                                           userId,orgId,urlElements[3],NULL,urlElements[7],method);
+                        }
                         if (result) //Error, File couldn't be imported
                         {
                             cmeStrConstrAppend(responseText,"<b>500 ERROR Internal server error.</b><br>"
@@ -9334,6 +9592,8 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
     char *tmpRAWFile=NULL;              //Full path to temporal, unencrypted script file.
     char *dbFilePath=NULL;
     char **resultRegisterCols=NULL;
+    const char *scriptType=NULL;
+    const char *scriptResourceInfo=NULL;
     const int numColumns=15;            //Number of columns in corresponding resource table.
     const int numValidGETALLMatch=9;    //9 parameters + 4 (storageId,orgResourceId,documentId,type) from URL
     const char *tableName="documents";
@@ -9350,7 +9610,12 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
             cmeFree(dbFilePath); \
             if(tmpRAWFile) \
             { \
-                cmeFileOverwriteAndDelete(tmpRAWFile); \
+                int parserCleanupResult=cmeFileOverwriteAndDelete(tmpRAWFile); \
+                if (parserCleanupResult) \
+                { \
+                    cmeWebServiceParserAuditResult("cleanup-fail",parserCleanupResult,scriptType, \
+                                                   userId,orgId,urlElements[3],urlElements[7],urlElements[9],method); \
+                } \
             } \
             cmeFree(tmpRAWFile); \
             if (resultRegisterCols) \
@@ -9459,6 +9724,22 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                 {
                     if (numResultRegisters) // Found >0
                     {
+                        scriptType=resultRegisterCols[cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type];
+                        scriptResourceInfo=resultRegisterCols[cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_resourceInfo];
+                        if ((!cmeWebServiceIsParserScriptDocumentType(scriptType))||
+                            (cmeWebServiceParserPolicyAllows(scriptResourceInfo,scriptType,userId,orgId,urlElements[3],
+                                                             urlElements[7],urlElements[9],method)))
+                        {
+                            cmeStrConstrAppend(responseText,"<b>403 FORBIDDEN parser policy denied execution.</b><br>"
+                                               "METHOD: '%s' URL: '%s'."
+                                                "%sLatest IDD version: <code>%s</code>",method,url,cmeWSMsgParserScriptResourceOptions,
+                                                cmeInternalDBDefinitionsVersion);
+                            cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
+                            cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",0);
+                            cmeWebServiceProcessParserScriptResourceFree();
+                            *responseCode=403;
+                            return(0);
+                        }
                         result=cmeSecureFileToTmpRAWFileInDir (&tmpRAWFile,pDB,scriptNameValues[0],resultRegisterCols
                                                                [cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
                                                                storagePath,urlElements[1],urlElements[3],orgKey,
@@ -9493,6 +9774,7 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                         cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
                         cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",0);
                         cmeFileOverwriteAndDelete(tmpRAWFile);
+                        tmpRAWFile=NULL;
                         cmeWebServiceProcessParserScriptResourceFree();
                         *responseCode=404;
                         return(0);
@@ -9565,6 +9847,9 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                             result=cmeWebServiceRunPythonParserScript(tmpRAWFile);
                         }
                     }
+                    cmeWebServiceParserAuditResult(cmeWebServiceParserAuditExecutionEvent(result),result,
+                                                   resultRegisterCols[cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
+                                                   userId,orgId,urlElements[3],urlElements[7],urlElements[9],method);
                     if (!result) //OK
                     {
                         //Construct responseText and create response headers according to the user's outputType (optional) request:
@@ -9696,6 +9981,16 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                 {
                     if (numResultRegisters) // Found >0
                     {
+                        scriptType=resultRegisterCols[cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type];
+                        scriptResourceInfo=resultRegisterCols[cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_resourceInfo];
+                        if ((!cmeWebServiceIsParserScriptDocumentType(scriptType))||
+                            (cmeWebServiceParserPolicyAllows(scriptResourceInfo,scriptType,userId,orgId,urlElements[3],
+                                                             urlElements[7],urlElements[9],method)))
+                        {
+                            cmeWebServiceProcessParserScriptResourceFree();
+                            *responseCode=403; //No responseText in HEAD!
+                            return(0);
+                        }
                         result=cmeSecureFileToTmpRAWFileInDir (&tmpRAWFile,pDB,scriptNameValues[0],resultRegisterCols
                                                                [cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
                                                                storagePath,urlElements[1],urlElements[3],orgKey,
@@ -9772,6 +10067,9 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                             result=cmeWebServiceRunPythonParserScript(tmpRAWFile);
                         }
                     }
+                    cmeWebServiceParserAuditResult(cmeWebServiceParserAuditExecutionEvent(result),result,
+                                                   resultRegisterCols[cmeIDDResourcesDBDocumentsNumCols+cmeIDDResourcesDBDocuments_type],
+                                                   userId,orgId,urlElements[3],urlElements[7],urlElements[9],method);
                     if (!result) //OK
                     {
                         if (cmeResultMemTableRows) // Found >0 rows.
@@ -9793,6 +10091,7 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                         cmeStrConstrAppend(&((*responseHeaders)[0]),"Engine-results");
                         cmeStrConstrAppend(&((*responseHeaders)[1]),"%d",cmeResultMemTableRows);
                         cmeFileOverwriteAndDelete(tmpRAWFile);
+                        tmpRAWFile=NULL;
                         cmeWebServiceProcessParserScriptResourceFree();
                         return(0);  //No responseText in HEAD!
                     }


### PR DESCRIPTION
## Summary
- Add parser execution policy controls for allowed script types, reviewed metadata, interpreter path, timeout, and isolation profile matching.
- Audit parser uploads, policy allow/deny decisions, execution success, timeout, limit rejection, and decrypted-temp cleanup failures without logging org keys, raw scripts, or CSV content.
- Extend the live verifier with parser policy metadata, strict reviewed/profile policy toggles, unreviewed-script deny coverage, and parser audit marker checks.
- Document parser policy metadata and audit behavior in README, tutorial, and AI usage guidance.

## Validation
- bash -n TEST/run_debug_components.sh
- make
- make check
- CDSE_VERIFY_REDACT=1 CDSE_VERIFY_PARSER_REQUIRE_REVIEWED=1 CDSE_VERIFY_PARSER_REQUIRE_POLICY_PROFILES=1 TEST/run_debug_components.sh --skip-build --live-only --web-protocol=http (passed=64 failed=0)
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --skip-build --live-only --web-protocol=https (passed=64 failed=0)
- git diff --check