### PR TITLE
Harden diagnostic request logging

### DIFF
--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -407,6 +407,169 @@ wait_for_log_marker() {
     return 1
 }
 
+run_https_startup_failure_redaction_check() {
+    local probe_log="$LOG_ROOT/https-startup-failure.log"
+    local holder_log="$LOG_ROOT/https-port-holder.log"
+    local listener_pid=""
+
+    : > "$probe_log"
+    : > "$holder_log"
+
+    python3 - "$HTTPS_PORT" > "$holder_log" 2>&1 <<'PY' &
+import socket
+import sys
+import time
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", int(sys.argv[1])))
+sock.listen(1)
+print("ready", flush=True)
+time.sleep(30)
+PY
+    listener_pid=$!
+
+    if ! wait_for_log_marker "$holder_log" "ready" 10; then
+        stop_live_service "$listener_pid"
+        record_fail https_startup_failure_redaction "could not reserve HTTPS test port $HTTPS_PORT log=$holder_log"
+        return
+    fi
+
+    (
+        cd "$ROOT_DIR" || exit 1
+        CDSE_DEBUG_TEST_HTTPS_PORT="$HTTPS_PORT" timeout 20s "$PREFIX/cdse/bin/CaumeDSE-debug-tests" --web-service https
+    ) > "$probe_log" 2>&1 || true
+
+    stop_live_service "$listener_pid"
+
+    if grep -Fq "can't start HTTPS server" "$probe_log"; then
+        :
+    else
+        record_fail https_startup_failure_redaction "missing HTTPS startup failure marker log=$probe_log"
+        return
+    fi
+
+    if grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY|END (RSA |EC |)PRIVATE KEY' "$probe_log"; then
+        record_fail https_startup_failure_redaction "private key PEM marker leaked in $probe_log"
+    else
+        record_pass https_startup_failure_redaction
+    fi
+}
+
+check_live_debug_secret_redaction() {
+    local protocol="$1"
+    local service_log="$2"
+    local org_key="$3"
+    local leak_log="$LOG_ROOT/live_${protocol}_debug_secret_leaks.log"
+    local leaked=0
+
+    : > "$leak_log"
+
+    if grep -F "parameter orgKey: '" "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+    if grep -F "parameter newOrgKey: '" "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+    if grep -F " key $org_key" "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+    if grep -F " the key $org_key" "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+    if grep -E "cmeUnprotect(ByteString|DBValue|DBSaltedValue).* -> [^v]" "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+    if grep -E "cmeProtect(ByteString|DBSaltedValue).*: [^v]" "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+    if grep -F "Result: " "$service_log" >> "$leak_log" 2>/dev/null; then
+        leaked=1
+    fi
+
+    if [ "$leaked" -eq 0 ]; then
+        record_pass "live_${protocol}_debug_secret_redaction"
+        rm -f "$leak_log"
+    else
+        redact_file_in_place "$leak_log"
+        record_fail "live_${protocol}_debug_secret_redaction" "secret-bearing DEBUG diagnostic found log=$leak_log"
+    fi
+}
+
+check_live_transaction_log_redaction() {
+    local protocol="$1"
+    local org_key="$2"
+    local long_value="$3"
+    local db_path="$PREFIX/cdse/LogsDB"
+    local query_log="$LOG_ROOT/live_${protocol}_transaction_log_redaction.log"
+    local leaked=0
+
+    : > "$query_log"
+
+    if [ ! -f "$db_path" ]; then
+        record_fail "live_${protocol}_transaction_log_redaction" "LogsDB not found at $db_path"
+        return
+    fi
+    if command -v sqlite3 >/dev/null 2>&1; then
+        sqlite3 "$db_path" "SELECT requestUrl, requestHeaders FROM transactions WHERE authenticated='0' AND requestUrl LIKE '%logProbe%';" > "$query_log" 2>&1
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 - "$db_path" > "$query_log" 2>&1 <<'PY'
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+try:
+    for request_url, request_headers in conn.execute(
+        "SELECT requestUrl, requestHeaders FROM transactions "
+        "WHERE authenticated='0' AND requestUrl LIKE '%logProbe%'"
+    ):
+        print(request_url or "")
+        print(request_headers or "")
+finally:
+    conn.close()
+PY
+    else
+        record_skip "live_${protocol}_transaction_log_redaction" "sqlite3 CLI or python3 is required to inspect LogsDB"
+        return
+    fi
+    if [ "$?" -ne 0 ]; then
+        redact_file_in_place "$query_log"
+        record_fail "live_${protocol}_transaction_log_redaction" "could not query LogsDB log=$query_log"
+        return
+    fi
+    if [ ! -s "$query_log" ]; then
+        record_fail "live_${protocol}_transaction_log_redaction" "missing log redaction probe row in LogsDB"
+        return
+    fi
+
+    if grep -F "$org_key" "$query_log" >/dev/null 2>&1; then
+        leaked=1
+    fi
+    if grep -F "$long_value" "$query_log" >/dev/null 2>&1; then
+        leaked=1
+    fi
+    if ! grep -Fq "orgKey=<redacted>" "$query_log"; then
+        leaked=1
+    fi
+    if ! grep -Fq "newOrgKey=<redacted>" "$query_log"; then
+        leaked=1
+    fi
+    if ! grep -Fq "accessPassword=<redacted>" "$query_log"; then
+        leaked=1
+    fi
+    if ! grep -Fq "...<truncated>" "$query_log"; then
+        leaked=1
+    fi
+
+    if [ "$leaked" -eq 0 ]; then
+        record_pass "live_${protocol}_transaction_log_redaction"
+        rm -f "$query_log"
+    else
+        redact_file_in_place "$query_log"
+        record_fail "live_${protocol}_transaction_log_redaction" "request log secret redaction or truncation check failed log=$query_log"
+    fi
+}
+
 stop_live_service() {
     local pid="$1"
 
@@ -582,6 +745,7 @@ run_live_web_flow() {
     local user_id="User123"
     local role_user="${LIVE_FLOW_ID}_${protocol}_user"
     local auth="userId=$user_id&orgId=$org_name&orgKey=$org_key"
+    local long_query_value=""
     local curl_tls_args=()
     local client_chain
     local client_key
@@ -625,6 +789,8 @@ run_live_web_flow() {
 
     live_api_check "$protocol" auth_missing_all 401 "$base_url/organizations/$org_name" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" auth_missing_org_key 401 "$base_url/organizations/$org_name?userId=$user_id&orgId=$org_name" "" "${curl_tls_args[@]}"
+    long_query_value="$(printf '%*s' 1500 '' | tr ' ' 'x')"
+    live_api_check "$protocol" transaction_log_redaction_probe 401 "$base_url/organizations/${org_name}_logProbe?orgId=$org_name&orgKey=$org_key&newOrgKey=$org_key&accessPassword=$org_key&longParam=$long_query_value" "" "${curl_tls_args[@]}" -H "Authorization: Bearer $org_key"
     if [ "$protocol" = "https" ]; then
         live_api_check "$protocol" auth_missing_client_cert 401 "$base_url/organizations/$org_name?$auth" "" --cacert "$PREFIX/cdse/ca.pem"
         live_api_check "$protocol" auth_client_cert_user_mismatch 401 "$base_url/organizations/$org_name?userId=${user_id}_mismatch&orgId=$org_name&orgKey=$org_key" "" "${curl_tls_args[@]}"
@@ -766,6 +932,8 @@ run_live_web_flow() {
     live_api_check "$protocol" delete_user 200 "$base_url/organizations/$org_name/users/$role_user?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X DELETE
 
     stop_live_service "$service_pid"
+    check_live_debug_secret_redaction "$protocol" "$service_log" "$org_key"
+    check_live_transaction_log_redaction "$protocol" "$org_key" "$long_query_value"
     redact_file_in_place "$service_log"
     if grep -Fq "CaumeDSE Audit: parserExecution event=policy-allow" "$service_log" &&
        grep -Fq "CaumeDSE Audit: parserExecution event=execute-success" "$service_log"; then
@@ -950,7 +1118,7 @@ check_component parser_scripts_resource 'Testing parserScripts resource handlers
 
 check_component parser_temp_files 'Testing parser temporary file hardening|testParserTempFiles|parser temp' "$FULL_LOG" \
     '--- Testing parser temporary file hardening:' \
-    'TESTS: testParserTempFiles(), PASS: parser temp file created as 0600 regular file.' \
+    'PASS: parser temp file created as 0600 regular file.' \
     'TESTS: testParserTempFiles(), PASS: parser temp directory is private.' \
     'TESTS: testParserTempFiles(), PASS: exclusive parser temp creation avoided collision.' \
     'TESTS: testParserTempFiles(), PASS: symlink temp directory was refused.' \
@@ -1016,9 +1184,11 @@ if [ "$SKIP_WEB" -eq 0 ]; then
                 record_fail webservice_certificate_loading "missing nonzero read marker for $marker"
             fi
         done
+        run_https_startup_failure_redaction_check
     else
         record_skip webservice_startup "requested --live-only"
         record_skip webservice_certificate_loading "requested --live-only"
+        record_skip https_startup_failure_redaction "requested --live-only"
     fi
     if protocol_enabled http; then
         run_live_web_flow http "$HTTP_PORT"
@@ -1032,6 +1202,7 @@ if [ "$SKIP_WEB" -eq 0 ]; then
     fi
 else
     record_skip webservice_startup "requested --skip-web"
+    record_skip https_startup_failure_redaction "requested --skip-web"
     record_skip live_http_api_flow "requested --skip-web"
     record_skip live_https_api_flow "requested --skip-web"
 fi

--- a/TODO.md
+++ b/TODO.md
@@ -555,3 +555,42 @@
     scripts, or CSV content. Live verifier uploads reviewed metadata, checks
     audit markers, and can run a reviewed-policy deny case for unreviewed
     scripts.
+
+- [x] #78 Stop HTTPS startup failures from logging TLS private keys.
+  - Source: `engine_admin.c`, DEBUG verifier startup checks.
+  - Goal: ensure web-service startup failures never print PEM certificate/key contents or other TLS key material.
+  - Done:
+    - Replaced PEM-body error logging with file path/context-only diagnostics.
+    - Added a verifier check that forces an HTTPS startup failure and asserts no private-key PEM markers are emitted.
+
+- [x] #79 Redact DEBUG logs that expose org keys and decrypted values.
+  - Source: `engine_interface.c`, `crypto.c`, shared redaction helpers.
+  - Goal: make DEBUG/ERROR diagnostics safe to retain by default.
+  - Done:
+    - Replaced plaintext `orgKey` and `newOrgKey` DEBUG parameter prints with redacted markers.
+    - Replaced protected-value, decrypted-value, and key diagnostics in crypto and secure DB helpers with length-only context.
+    - Added live verifier checks that fail on secret-bearing DEBUG diagnostics.
+
+- [x] #80 Redact request URLs and cap logged request values.
+  - Source: `webservice_interface.c`, transaction logging, live verifier redaction.
+  - Goal: prevent request logs from storing credentials or unbounded user-controlled strings.
+  - Done:
+    - Redacted credential-like query parameters and HTTP headers before constructing transaction log entries.
+    - Added per-value and whole-field caps for logged request URLs, request headers, and response headers.
+    - Added a live unauthenticated LogsDB probe that verifies secret redaction and long-value truncation.
+
+- [ ] #81 Modernize password-based key derivation defaults.
+  - Source: `common.h`, `crypto.c`, storage metadata/version handling.
+  - Goal: replace outdated KDF settings with migration-safe modern defaults.
+  - Plan:
+    - Batch 1: define versioned KDF metadata and select stronger defaults for new data.
+    - Batch 2: preserve read compatibility for existing protected values.
+    - Batch 3: add crypto tests for old/new KDF vectors and upgrade behavior.
+
+- [ ] #82 Harden HTTP TLS-auth bypass controls.
+  - Source: `configure.ac`, `common.h`, `webservice_interface.c`, verifier profiles.
+  - Goal: prevent test-only HTTP TLS-auth bypass from being accidentally enabled in deployable builds.
+  - Plan:
+    - Batch 1: fail startup or emit a hard error when bypass is enabled outside DEBUG/test profiles.
+    - Batch 2: make the bypass setting visible in startup diagnostics without exposing secrets.
+    - Batch 3: add verifier checks for bypass-on and bypass-off HTTP authentication behavior.

--- a/crypto.c
+++ b/crypto.c
@@ -814,14 +814,14 @@ int cmeProtectByteString (const char *value, char **protectedValue, const char *
     {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeProtectByteString(), cmeCipherByteString() Error, can't "
-                "encrypt 'byte string' %s with algorithm %s!\n",value,encAlg);
+                "encrypt 'byte string' len=%d with algorithm %s!\n",valueLen,encAlg);
 #endif
         cmeProtectByteStringFree();
         return(2);
     }
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Debug: cmeProtectByteString(), encrypted 'byte string': "
-            "%s with algorithm %s.\n",value,encAlg);
+            "valueLen=%d with algorithm %s.\n",valueLen,encAlg);
 #endif
     result=cmeStrToB64((unsigned char *)currentEncData,(unsigned char **)protectedValue,
                        written,protectedValueLen);
@@ -849,7 +849,7 @@ int cmeUnprotectByteString (const char *protectedValue, char **value, const char
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
         fprintf(stderr,"CaumeDSE Debug: cmeUnprotectByteString(), cmeCipherByteString() Warning, can't "
-                "decrypt 'byte string' = NULL, with algorithm %s and key %s!\n",encAlg,orgKey);
+                "decrypt 'byte string' = NULL, with algorithm %s and key <redacted>!\n",encAlg);
 #endif
         return(0); //Not an error, just a warning!
     }
@@ -865,15 +865,15 @@ int cmeUnprotectByteString (const char *protectedValue, char **value, const char
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
         fprintf(stderr,"CaumeDSE Debug: cmeUnprotectByteString(), cmeCipherByteString() Warning, can't "
-                "decrypt 'byte string' %s with algorithm %s and the key %s!\n",
-                protectedValue,encAlg,orgKey);
+                "decrypt 'byte string' len=%d with algorithm %s and key <redacted>!\n",
+                protectedValueLen,encAlg);
 #endif
     }
     else //Decryption successful.
     {
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeUnprotectByteString(), decrypted 'byte string': "
-                "%s with algorithm %s -> %s.\n",protectedValue,encAlg,*value);
+                "protectedLen=%d with algorithm %s -> valueLen=%d.\n",protectedValueLen,encAlg,*valueLen);
 #endif
     }
     cmeUnProtectByteStringFree();

--- a/db.c
+++ b/db.c
@@ -856,7 +856,7 @@ static int cmeMemSecureDBStoreValueHMAC(sqlite3 *memSecureDB, char **memData,
         }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), computed %s"
-                " for 'value' in row id %s. Result: %s.\n",attributeName,currentDataId,currentDataMAC);
+                " for 'value' in row id %s. macLen=%d.\n",attributeName,currentDataId,written);
 #endif
         if (cmeSQLRows(memSecureDB,"BEGIN;",NULL,NULL))
         {
@@ -1146,15 +1146,15 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
                     {
 #ifdef ERROR_LOG
                         fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                                "protect 'rowOrder' in data table: %s with algorithm %s!\n",
-                                memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_rowOrder],currentDataEncAlg);
+                                "protect 'rowOrder' in data table: valueLen=%zu with algorithm %s!\n",
+                                strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_rowOrder]),currentDataEncAlg);
 #endif
                         cmeMemSecureDBProtectFree();
                         return(5);
                     }
 #ifdef DEBUG
                     fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                            " 'rowOrder'. Result: %s.\n",currentEncB64Data);
+                            " 'rowOrder'. protectedLen=%d.\n",written);
 #endif
                     result=sqlite3_bind_text(updateDataFullStmt,1,memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_userId],-1,SQLITE_TRANSIENT);
                     if (result==SQLITE_OK) result=sqlite3_bind_text(updateDataFullStmt,2,memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_orgId],-1,SQLITE_TRANSIENT);
@@ -1209,8 +1209,8 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
                 {
 #ifdef ERROR_LOG
                     fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), Error, can't "
-                            "protect 'rowOrder' in data table: %s with algorithm %s!\n",
-                            memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value],currentDataEncAlg);
+                            "protect 'rowOrder' in data table: valueLen=%zu with algorithm %s!\n",
+                            strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value]),currentDataEncAlg);
 #endif
                     cmeMemSecureDBProtectFree();
                     return(7);
@@ -1251,15 +1251,15 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
                     {
 #ifdef ERROR_LOG
                         fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                                "protect 'value' in data table: %s with algorithm %s!\n",
-                                memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value],currentDataEncAlg);
+                                "protect 'value' in data table: valueLen=%zu with algorithm %s!\n",
+                                strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDColumnFileData_value]),currentDataEncAlg);
 #endif
                         cmeMemSecureDBProtectFree();
                         return(8);
                     }
 #ifdef DEBUG
                     fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                            " 'value'. Result: %s.\n",currentEncB64Data);
+                            " 'value'. protectedLen=%d.\n",written);
 #endif
                     result=sqlite3_bind_text(updateDataProtectStmt,1,currentEncB64Data,-1,SQLITE_TRANSIENT);
                     cmeFree(currentEncB64Data);
@@ -1279,15 +1279,15 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
                     {
 #ifdef ERROR_LOG
                         fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                                "protect 'userId' in data table: %s with algorithm %s!\n",
-                                memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_userId],currentDataEncAlg);
+                                "protect 'userId' in data table: valueLen=%zu with algorithm %s!\n",
+                                strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_userId]),currentDataEncAlg);
 #endif
                         cmeMemSecureDBProtectFree();
                         return(9);
                     }
 #ifdef DEBUG
                     fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                            " 'userId'. Result: %s.\n",currentEncB64Data);
+                            " 'userId'. protectedLen=%d.\n",written);
 #endif
                     if (result==SQLITE_OK) result=sqlite3_bind_text(updateDataProtectStmt,2,currentEncB64Data,-1,SQLITE_TRANSIENT);
                     cmeFree(currentEncB64Data);
@@ -1307,15 +1307,15 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
                     {
 #ifdef ERROR_LOG
                         fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                                "protect 'orgId' in data table: %s with algorithm %s!\n",
-                                memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_orgId],currentDataEncAlg);
+                                "protect 'orgId' in data table: valueLen=%zu with algorithm %s!\n",
+                                strlen(memData[cmeIDDColumnFileDataNumCols*cont2+cmeIDDanydb_orgId]),currentDataEncAlg);
 #endif
                         cmeMemSecureDBProtectFree();
                         return(10);
                     }
 #ifdef DEBUG
                     fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                            " 'orgId'. Result: %s.\n",currentEncB64Data);
+                            " 'orgId'. protectedLen=%d.\n",written);
 #endif
                     if (result==SQLITE_OK) result=sqlite3_bind_text(updateDataProtectStmt,3,currentEncB64Data,-1,SQLITE_TRANSIENT);
                     if (result==SQLITE_OK) result=sqlite3_bind_int(updateDataProtectStmt,4,atoi(currentDataId));
@@ -1463,14 +1463,14 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                    "protect Meta attribute: %s with algorithm %s!\n",currentMetaAttribute,cmeDefaultEncAlg);
+                    "protect Meta attribute: valueLen=%zu with algorithm %s!\n",strlen(currentMetaAttribute),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBProtectFree();
             return(13);
         }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                " Meta attribute. Result: %s.\n",currentEncB64Data);
+                " Meta attribute. protectedLen=%d.\n",written);
 #endif
         result=sqlite3_bind_text(updateMetaProtectStmt,1,currentEncB64Data,-1,SQLITE_TRANSIENT);
         cmeFree(currentEncB64Data);
@@ -1490,14 +1490,14 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                    "protect Meta attributeData: %s with algorithm %s!\n",currentMetaAttributeData,cmeDefaultEncAlg);
+                    "protect Meta attributeData: valueLen=%zu with algorithm %s!\n",strlen(currentMetaAttributeData),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBProtectFree();
             return(14);
         }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                " Meta attributeData. Result: %s.\n",currentEncB64Data);
+                " Meta attributeData. protectedLen=%d.\n",written);
 #endif
         result=sqlite3_bind_text(updateMetaProtectStmt,2,currentEncB64Data,-1,SQLITE_TRANSIENT);
         cmeFree(currentEncB64Data);
@@ -1517,14 +1517,14 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                    "protect Meta userId: %s with algorithm %s!\n",currentMetaUserId,cmeDefaultEncAlg);
+                    "protect Meta userId: valueLen=%zu with algorithm %s!\n",strlen(currentMetaUserId),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBProtectFree();
             return(15);
         }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                " Meta userId. Result: %s.\n",currentEncB64Data);
+                " Meta userId. protectedLen=%d.\n",written);
 #endif
         result=sqlite3_bind_text(updateMetaProtectStmt,3,currentEncB64Data,-1,SQLITE_TRANSIENT);
         cmeFree(currentEncB64Data);
@@ -1544,14 +1544,14 @@ int cmeMemSecureDBProtect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBProtect(), cmeProtectDBSaltedValue() Error, can't "
-                    "protect Meta orgId: %s with algorithm %s!\n",currentMetaOrgId,cmeDefaultEncAlg);
+                    "protect Meta orgId: valueLen=%zu with algorithm %s!\n",strlen(currentMetaOrgId),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBProtectFree();
             return(16);
         }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBProtect(), protected"
-                " Meta orgId. Result: %s.\n",currentEncB64Data);
+                " Meta orgId. protectedLen=%d.\n",written);
 #endif
         result=sqlite3_bind_text(updateMetaProtectStmt,4,currentEncB64Data,-1,SQLITE_TRANSIENT);
         cmeFree(currentEncB64Data);
@@ -1729,8 +1729,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                    "decrypt 'attribute' in meta table, B64str: %s with algorithm %s!\n",
-                    currentEncB64Data,cmeDefaultEncAlg);
+                    "decrypt 'attribute' in meta table, protectedLen=%zu with algorithm %s!\n",
+                    strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBUnprotectFree();
             return(3);
@@ -1743,8 +1743,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                    "decrypt 'attributeData' in meta table, B64str: %s with algorithm %s!\n",
-                    currentEncB64Data,cmeDefaultEncAlg);
+                    "decrypt 'attributeData' in meta table, protectedLen=%zu with algorithm %s!\n",
+                    strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBUnprotectFree();
             return(4);
@@ -1757,8 +1757,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                    "decrypt 'userId' in meta table, B64str: %s with algorithm %s!\n",
-                    currentEncB64Data,cmeDefaultEncAlg);
+                    "decrypt 'userId' in meta table, protectedLen=%zu with algorithm %s!\n",
+                    strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBUnprotectFree();
             return(5);
@@ -1771,8 +1771,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
         {
 #ifdef ERROR_LOG
             fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                    "decrypt 'orgId' in meta table, B64str: %s with algorithm %s!\n",
-                    currentEncB64Data,cmeDefaultEncAlg);
+                    "decrypt 'orgId' in meta table, protectedLen=%zu with algorithm %s!\n",
+                    strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
             cmeMemSecureDBUnprotectFree();
             return(6);
@@ -1875,7 +1875,7 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
                 }
 #ifdef DEBUG
                 fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBUnprotect(), decrypted 'rowOrder' in data table row: "
-                        "%s, with algorithm: %s.\n",currentData,currentDataEncAlg);
+                        "valueLen=%d, with algorithm: %s.\n",written,currentDataEncAlg);
 #endif
                 result=sqlite3_bind_int(updateDataRowOrderStmt,1,atoi(currentData));
                 if (result==SQLITE_OK)
@@ -2043,8 +2043,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
                 {
 #ifdef ERROR_LOG
                     fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                            "decrypt 'userId' in data table, B64str: %s with algorithm %s!\n",
-                            currentEncB64Data,cmeDefaultEncAlg);
+                            "decrypt 'userId' in data table, protectedLen=%zu with algorithm %s!\n",
+                            strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
                     cmeMemSecureDBUnprotectFree();
                     return(14);
@@ -2057,8 +2057,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
                 {
 #ifdef ERROR_LOG
                     fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                            "decrypt 'orgId' in data table, B64str: %s with algorithm %s!\n",
-                            currentEncB64Data,cmeDefaultEncAlg);
+                            "decrypt 'orgId' in data table, protectedLen=%zu with algorithm %s!\n",
+                            strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
                     cmeMemSecureDBUnprotectFree();
                     return(15);
@@ -2121,8 +2121,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
             {
 #ifdef ERROR_LOG
                 fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                        "decrypt encryption algorithm in meta table: %s with algorithm %s!\n",
-                        currentEncB64Data,cmeDefaultEncAlg);
+                        "decrypt encryption algorithm in meta table: protectedLen=%zu with algorithm %s!\n",
+                        strlen(currentEncB64Data),cmeDefaultEncAlg);
 #endif
                 cmeMemSecureDBUnprotectFree();
                 return(17);
@@ -2154,8 +2154,8 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
                     {
 #ifdef ERROR_LOG
                         fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBUnprotect(), cmeUnprotectDBSaltedValue() Error, can't "
-                                "decrypt 'value' in data table: %s with algorithm %s!\n",
-                                currentEncB64Data,currentDataEncAlg);
+                                "decrypt 'value' in data table: protectedLen=%zu with algorithm %s!\n",
+                                strlen(currentEncB64Data),currentDataEncAlg);
 #endif
                         cmeMemSecureDBUnprotectFree();
                         return(18);
@@ -2163,7 +2163,7 @@ int cmeMemSecureDBUnprotect (sqlite3 *memSecureDB, const char *orgKey)
                     cmeFree(currentEncB64Data);
 #ifdef DEBUG
 	                    fprintf(stdout,"CaumeDSE Debug: cmeMemSecureDBUnprotect(), decrypted 'value' in data table: "
-	                            "%s with algorithm %s.\n",currentData,currentDataEncAlg);
+	                            "valueLen=%d with algorithm %s.\n",written,currentDataEncAlg);
 #endif
                     if (cmeSQLRows(memSecureDB,"BEGIN;",NULL,NULL))
                     {
@@ -2469,13 +2469,13 @@ int cmeProtectDBValue (const char *value, char **protectedValue, const char *enc
     {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeProtectDBValue(), cmeProtectByteString() Error, can't "
-                "protect 'value' %s with algorithm %s!\n",value,encAlg);
+                "protect 'value' len=%zu with algorithm %s!\n",strlen(value),encAlg);
 #endif
         return(2);
     }
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Debug: cmeProtectDBValue(), protected 'value': "
-            "%s with algorithm %s.\n",value,encAlg);
+            "valueLen=%zu with algorithm %s.\n",strlen(value),encAlg);
 #endif
     return (0);
 }
@@ -2492,7 +2492,7 @@ int cmeUnprotectDBValue (const char *protectedValue, char **value, const char *e
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
         fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBValue(), Warning, can't "
-                "decrypt 'protectedValue'=NULL with algorithm %s and key %s!\n",encAlg,orgKey);
+                "decrypt 'protectedValue'=NULL with algorithm %s and key <redacted>!\n",encAlg);
 #endif
         return(0); //Not an error, just a warning!
     }
@@ -2504,14 +2504,14 @@ int cmeUnprotectDBValue (const char *protectedValue, char **value, const char *e
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
         fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBValue(), cmeUnprotectByteString() Warning, can't "
-                "unprotect 'protectedValue' %s with algorithm %s and the key %s!\n",protectedValue,encAlg,orgKey);
+                "unprotect 'protectedValue' len=%zu with algorithm %s and key <redacted>!\n",strlen(protectedValue),encAlg);
 #endif
     }
     else //Unprotect successful.
     {
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeUnprotectDBValue(), unprotected 'protectedValue': "
-                "%s with algorithm %s -> %s.\n",protectedValue,encAlg,*value);
+                "protectedLen=%zu with algorithm %s -> valueLen=%d.\n",strlen(protectedValue),encAlg,*valueLen);
 #endif
     }
     return (0);
@@ -2545,14 +2545,14 @@ int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const cha
     {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeProtectDBSaltedValue(), cmeProtectDBValue() Error, can't "
-                "protect 'salted value' %s with algorithm %s!\n",saltedValue,encAlg);
+                "protect 'salted value' len=%zu with algorithm %s!\n",strlen(saltedValue),encAlg);
 #endif
         cmeProtectDBSaltedValueFree();
         return(2);
     }
 #ifdef DEBUG
     fprintf(stdout,"CaumeDSE Debug: cmeProtectDBSaltedValue(), protected 'salted value': "
-            "%s with algorithm %s.\n",saltedValue,encAlg);
+            "valueLen=%zu with algorithm %s.\n",strlen(saltedValue),encAlg);
 #endif
     cmeProtectDBSaltedValueFree();
     return (0);
@@ -2575,7 +2575,7 @@ int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const c
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
         fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBSaltedValue(), Warning, can't unprotect 'protectedValue'=NULL "
-                "with algorithm %s and key %s!\n",encAlg,orgKey);
+                "with algorithm %s and key <redacted>!\n",encAlg);
 #endif
         cmeUnProtectDBSaltedValueFree();
         return(0); //No error, just a warning.
@@ -2587,7 +2587,7 @@ int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const c
         cmeStrConstrAppend(value,"");
 #ifdef DEBUG
         fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBSaltedValue(), cmeUnprotectDBValue() Warning, can't "
-                "unprotect 'protectedValue' %s with algorithm %s and the key %s!\n",protectedValue,encAlg,orgKey);
+                "unprotect 'protectedValue' len=%zu with algorithm %s and key <redacted>!\n",strlen(protectedValue),encAlg);
 #endif
     }
     else //Unprotect successful.
@@ -2601,13 +2601,13 @@ int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const c
         {
             cmeStrConstrAppend(value,"%s",saltedValue); //We don't skip the first 16 characters of the 8 byte hexstr salt that is included at the beginning.
 #ifdef DEBUG
-            fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBSaltedValue() Warning, value '%s' "
-                    "has incorrect valuesalt size!. Unprotected it assuming it wasn't valueSalted\n",saltedValue);
+            fprintf(stderr,"CaumeDSE Debug: cmeUnprotectDBSaltedValue() Warning, valueLen=%d "
+                    "has incorrect valuesalt size. Unprotected it assuming it wasn't valueSalted\n",*valueLen);
 #endif
         }
 #ifdef DEBUG
         fprintf(stdout,"CaumeDSE Debug: cmeUnprotectDBSaltedValue(), unprotected 'protectedValue': "
-                "%s with algorithm %s -> %s.\n",protectedValue,encAlg,*value);
+                "protectedLen=%zu with algorithm %s -> valueLen=%d.\n",strlen(protectedValue),encAlg,*valueLen);
 #endif
     }
     cmeUnProtectDBSaltedValueFree();
@@ -2864,8 +2864,8 @@ int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
             {
     #ifdef ERROR_LOG
                 fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), cmeUnprotectDBSaltedValue() Error, can't "
-                        "unprotect 'attribute' in meta table, B64str: %s with algorithm %s!\n",
-                        currentEncB64Data,cmeDefaultEncAlg);
+                        "unprotect 'attribute' in meta table, protectedLen=%zu with algorithm %s!\n",
+                        strlen(currentEncB64Data),cmeDefaultEncAlg);
     #endif
                 cmeMemSecureDBReintegrateFree();
                 return(3);
@@ -2878,8 +2878,8 @@ int cmeMemSecureDBReintegrate (sqlite3 **memSecureDB, const char *orgKey,
             {
     #ifdef ERROR_LOG
                 fprintf(stderr,"CaumeDSE Error: cmeMemSecureDBReintegrate(), cmeUnprotectDBSaltedValue() Error, can't "
-                        "decrypt 'attributeData' in meta table, B64str: %s with algorithm %s!\n",
-                        currentEncB64Data,cmeDefaultEncAlg);
+                        "decrypt 'attributeData' in meta table, protectedLen=%zu with algorithm %s!\n",
+                        strlen(currentEncB64Data),cmeDefaultEncAlg);
     #endif
                 cmeMemSecureDBReintegrateFree();
                 return(4);

--- a/engine_admin.c
+++ b/engine_admin.c
@@ -1110,7 +1110,8 @@ int cmeWebServiceSetup (unsigned short port, int useSSL, const char *sslKeyFile,
         {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeWebServiceSetup(), Error, can't "
-                "start HTTPS server on port %d. Cert file: %s. Key file: %s.\n",port,cert_pem,key_pem);
+                "start HTTPS server on port %d. Cert path: %s. Key path: %s. "
+                "CA path: %s.\n",port,sslCertFile,sslKeyFile,caCertFile);
 #endif
             cmeWebServiceSetupFree();
             return (2);

--- a/engine_interface.c
+++ b/engine_interface.c
@@ -1368,8 +1368,8 @@ int cmeProcessURLMatchSaveParameters (const char *urlMethod, const char **argume
         {
             cmeStrConstrAppend(orgKey,"%s",argumentElements[cont+1]); //special case; we pass it as a function parameter; not in columnValues.
 #ifdef DEBUG
-            fprintf(stdout,"CaumeDSE Debug: cmeProcessURLMatchSaveParameters(), %s, parameter orgKey: '%s'.\n",
-                    urlMethod, argumentElements[cont+1]);
+            fprintf(stdout,"CaumeDSE Debug: cmeProcessURLMatchSaveParameters(), %s, parameter orgKey: <redacted>.\n",
+                    urlMethod);
 #endif
             *keyArg=1;
         }
@@ -1377,8 +1377,8 @@ int cmeProcessURLMatchSaveParameters (const char *urlMethod, const char **argume
         {
             cmeStrConstrAppend(newOrgKey,"%s",argumentElements[cont+1]); //special case; we pass it as a function parameter; not in columnValues.
 #ifdef DEBUG
-            fprintf(stdout,"CaumeDSE Debug: cmeProcessURLMatchSaveParameters(), %s, parameter newOrgKey: '%s'.\n",
-                    urlMethod, argumentElements[cont+1]);
+            fprintf(stdout,"CaumeDSE Debug: cmeProcessURLMatchSaveParameters(), %s, parameter newOrgKey: <redacted>.\n",
+                    urlMethod);
 #endif
             *newKeyArg=1;
         }

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -55,6 +55,83 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #include <sys/prctl.h>
 #endif
 
+#define cmeWSLogMaxURLLen 2048
+#define cmeWSLogMaxHeaderBlockLen 4096
+#define cmeWSLogMaxValueLen 512
+#define cmeWSLogRedactedValue "<redacted>"
+#define cmeWSLogTruncatedMarker "...<truncated>"
+
+static int cmeWebServiceLogIsSensitiveField(const char *name)
+{
+    const char *fieldName=name;
+
+    if (!fieldName)
+    {
+        return(0);
+    }
+    if (*fieldName=='*')
+    {
+        fieldName++;
+    }
+    return((!strcasecmp(fieldName,"orgKey")) ||
+           (!strcasecmp(fieldName,"newOrgKey")) ||
+           (!strcasecmp(fieldName,"accessPath")) ||
+           (!strcasecmp(fieldName,"accessUser")) ||
+           (!strcasecmp(fieldName,"accessPassword")) ||
+           (!strcasecmp(fieldName,"basicAuthPwdHash")) ||
+           (!strcasecmp(fieldName,"oauthConsumerKey")) ||
+           (!strcasecmp(fieldName,"oauthConsumerSecret")) ||
+           (!strcasecmp(fieldName,"certificate")) ||
+           (!strcasecmp(fieldName,"publicKey")) ||
+           (!strcasecmp(fieldName,"authorization")) ||
+           (!strcasecmp(fieldName,"proxy-authorization")) ||
+           (!strcasecmp(fieldName,"cookie")) ||
+           (!strcasecmp(fieldName,"set-cookie")) ||
+           (!strcasecmp(fieldName,"x-api-key")));
+}
+
+static int cmeWebServiceLogAppendBoundedValue(char **resultStr, const char *value, size_t maxLen)
+{
+    const char *safeValue=value?value:"";
+    size_t valueLen=strlen(safeValue);
+
+    if (valueLen<=maxLen)
+    {
+        return(cmeStrConstrAppend(resultStr,"%s",safeValue));
+    }
+    return(cmeStrConstrAppend(resultStr,"%.*s%s",(int)maxLen,safeValue,cmeWSLogTruncatedMarker));
+}
+
+static int cmeWebServiceLogAppendFieldValue(char **resultStr, const char *name, const char *value)
+{
+    if (cmeWebServiceLogIsSensitiveField(name))
+    {
+        return(cmeStrConstrAppend(resultStr,"%s",cmeWSLogRedactedValue));
+    }
+    return(cmeWebServiceLogAppendBoundedValue(resultStr,value,cmeWSLogMaxValueLen));
+}
+
+static void cmeWebServiceLogTruncateInPlace(char *value, size_t maxLen)
+{
+    size_t valueLen;
+    size_t markerLen=strlen(cmeWSLogTruncatedMarker);
+
+    if (!value)
+    {
+        return;
+    }
+    valueLen=strlen(value);
+    if (valueLen<=maxLen)
+    {
+        return;
+    }
+    if (maxLen>markerLen)
+    {
+        memcpy(value+maxLen-markerLen,cmeWSLogTruncatedMarker,markerLen);
+    }
+    value[maxLen]='\0';
+}
+
 static void cmeWebServiceSetThreadStatus(struct cmeWebServiceConnectionInfoStruct *con_info, int threadStatus)
 {
     pthread_mutex_lock(&(con_info->threadStatusMutex));
@@ -6013,8 +6090,7 @@ int cmeWebServiceProcessOrgClass (char **responseText, char **responseFilePath, 
             {
                 cmeStrConstrAppend(&orgKey,"%s",argumentElements[cont+1]); //special case; we pass it as a function parameter; not in columnValues.
 #ifdef DEBUG
-                fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessOrgClass(), OPTIONS, parameter orgKey: '%s'.\n",
-                        argumentElements[cont+1]);
+                fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessOrgClass(), OPTIONS, parameter orgKey: <redacted>.\n");
 #endif
                 keyArg=1;
             }
@@ -7251,8 +7327,7 @@ int cmeWebServiceProcessStorageClass (char **responseText, char ***responseHeade
             {
                 cmeStrConstrAppend(&orgKey,"%s",argumentElements[cont+1]); //special case; we pass it as a function parameter; not in columnValues.
 #ifdef DEBUG
-                fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessStorageClass(), OPTIONS, parameter orgKey: '%s'.\n",
-                        argumentElements[cont+1]);
+                fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessStorageClass(), OPTIONS, parameter orgKey: <redacted>.\n");
 #endif
                 keyArg=1;
             }
@@ -14369,7 +14444,8 @@ int cmeWebServiceLogConnection (struct MHD_Connection *connection, void *con_cls
             cmeStrConstrAppend(&requestUrl,"?");
             while ((requestArgumentsList[cont])&&(cont<cmeWSURIMaxArguments))
             {
-                cmeStrConstrAppend(&requestUrl,"%s=%s",requestArgumentsList[cont],requestArgumentsList[cont+1]);
+                cmeStrConstrAppend(&requestUrl,"%s=",requestArgumentsList[cont]);
+                cmeWebServiceLogAppendFieldValue(&requestUrl,requestArgumentsList[cont],requestArgumentsList[cont+1]);
                 cont+=2;
                 if (cont<cmeWSURIMaxArguments)
                 {
@@ -14379,12 +14455,14 @@ int cmeWebServiceLogConnection (struct MHD_Connection *connection, void *con_cls
                     }
                 }
             }
+            cmeWebServiceLogTruncateInPlace(requestUrl,cmeWSLogMaxURLLen);
         }
     }
     else //If undefined, set to empty.
     {
         cmeStrConstrAppend(&requestUrl,"");
     }
+    cmeWebServiceLogTruncateInPlace(requestUrl,cmeWSLogMaxURLLen);
     //Set orgResourceId:
     cmeStrConstrAppend(&orgResourceId,"");
     if ((numUrlElements>2)&&(strcmp(urlElements[0],"organizations")==0)) //We have an organization in the URL
@@ -14437,17 +14515,23 @@ int cmeWebServiceLogConnection (struct MHD_Connection *connection, void *con_cls
     cont=0;
     while ((responseHeadersList[cont])&&(cont<cmeWSHTTPMaxResponseHeaders))
     {
-        cmeStrConstrAppend(&responseHeaders,"%s=%s\n",responseHeadersList[cont],responseHeadersList[cont+1]);
+        cmeStrConstrAppend(&responseHeaders,"%s=",responseHeadersList[cont]);
+        cmeWebServiceLogAppendFieldValue(&responseHeaders,responseHeadersList[cont],responseHeadersList[cont+1]);
+        cmeStrConstrAppend(&responseHeaders,"\n");
         cont+=2;
     }
+    cmeWebServiceLogTruncateInPlace(responseHeaders,cmeWSLogMaxHeaderBlockLen);
     //Set requestHeaders:
     cmeStrConstrAppend(&requestHeaders,""); //Start with an empty string.
     cont=0;
     while ((requestHeadersList[cont])&&(cont<cmeWSHTTPMaxHeaders))
     {
-        cmeStrConstrAppend(&requestHeaders,"%s=%s\n",requestHeadersList[cont],requestHeadersList[cont+1]);
+        cmeStrConstrAppend(&requestHeaders,"%s=",requestHeadersList[cont]);
+        cmeWebServiceLogAppendFieldValue(&requestHeaders,requestHeadersList[cont],requestHeadersList[cont+1]);
+        cmeStrConstrAppend(&requestHeaders,"\n");
         cont+=2;
     }
+    cmeWebServiceLogTruncateInPlace(requestHeaders,cmeWSLogMaxHeaderBlockLen);
     //Log transaction:
     result= cmeWebServiceLogRequest (userId, orgId, requestMethod, requestUrl, requestHeaders,
                                      startTimestamp, endTimestamp, requestDataSize, responseDataSize,


### PR DESCRIPTION
## Summary

- Added TODO tracking for the local security assessment findings and completed #78-#80.
- Stopped HTTPS startup failure logs from printing TLS PEM key material.
- Redacted DEBUG/ERROR diagnostics that exposed org keys, protected values, and decrypted values.
- Redacted credential-like request parameters/headers before transaction logging and capped logged URL/header/value sizes.
- Added verifier coverage for HTTPS startup redaction, live DEBUG secret redaction, and transaction log redaction/truncation.

## Security Impact

This reduces retained-log exposure of TLS private keys, organization keys, decrypted database values, protected-value ciphertexts, credential-bearing URLs, authorization headers, and oversized user-controlled request strings.

## Validation

- bash -n TEST/run_debug_components.sh
- ./configure --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP
- make
- make check
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke -> passed=98 failed=0 skipped=1
- git diff --check