### PR TITLE
Harden HTTP TLS auth bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2279,7 +2279,9 @@ column, upload a `script.perl` document, and execute that parser script
 through both HTTP and HTTPS.  The live flow also asserts negative
 authentication cases for missing credentials on both protocols and missing or
 mismatched client certificates on HTTPS.  HTTPS uses a per-run client
-certificate chain signed by the committed test CA fixture.
+certificate chain signed by the committed test CA fixture.  The verifier also
+checks that HTTP TLS-auth bypass is visible in DEBUG/test startup logs and that
+release configure rejects the bypass flag.
 `CDSE_DEBUG_TEST_TIMEOUT` controls the overall executable timeout and defaults
 to 120s.  Use `--skip-web` only when the local environment cannot bind test
 ports.  Live API runs also write
@@ -2351,10 +2353,14 @@ In release mode the software enters and infinite loop to answer connections;
 right now you need to kill the process to stop it).
 
 If you want to bypass TLS authentication for testing purposes in DEBUG mode
-with HTTP (which will obviously fail), you may enable this feature (FOR
-TESTING PURPOSES ONLY) with:
+with HTTP (where client-certificate authentication cannot run), you may enable
+this feature (FOR TESTING PURPOSES ONLY) with:
 
     --enable-BYPASSTLSAUTHINHTTP
+
+The bypass is rejected unless `--enable-DEBUG` is also present, and DEBUG
+startup logs print whether HTTP TLS-auth bypass is enabled.  Do not use this
+flag for deployable builds.
 
 If you want to enable the use of the old Password Based Key Derivation
 Function `PBKDF1` (i.e.  `PKCS5v1.5`, which is compatible with openssl's command

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -325,6 +325,27 @@ run_step() {
     return "$rc"
 }
 
+run_release_bypass_config_guard() {
+    local log="$LOG_ROOT/configure_release_bypass_guard.log"
+    local start
+    local rc
+
+    note "RUN  configure_release_bypass_guard"
+    start="$(date +%s)"
+    (
+        cd "$ROOT_DIR" || exit 1
+        ./configure --prefix="$PREFIX-release-bypass-guard" --enable-BYPASSTLSAUTHINHTTP
+    ) > "$log" 2>&1
+    rc=$?
+    redact_file_in_place "$log"
+    if [ "$rc" -ne 0 ] && grep -Fq -- "--enable-BYPASSTLSAUTHINHTTP requires --enable-DEBUG" "$log"; then
+        record_pass "configure_release_bypass_guard ($(elapsed_seconds "$start"))"
+        return 0
+    fi
+    record_fail configure_release_bypass_guard "expected release configure to reject --enable-BYPASSTLSAUTHINHTTP rc=$rc log=$log"
+    return 1
+}
+
 protocol_enabled() {
     local protocol="$1"
 
@@ -957,6 +978,14 @@ run_live_web_flow() {
     check_live_debug_secret_redaction "$protocol" "$service_log" "$org_key"
     check_live_transaction_log_redaction "$protocol" "$org_key" "$long_query_value"
     redact_file_in_place "$service_log"
+    if [ "$protocol" = "http" ]; then
+        if grep -Fq "HTTP TLS authentication bypass active for DEBUG/test profile only." "$service_log" &&
+           grep -Fq "bypassing TLS authentication in an HTTP session (DEBUG/test profile only)." "$service_log"; then
+            record_pass "live_http_tls_auth_bypass_diagnostic"
+        else
+            record_fail "live_http_tls_auth_bypass_diagnostic" "missing DEBUG/test bypass startup or request marker log=$service_log"
+        fi
+    fi
     if grep -Fq "CaumeDSE Audit: parserExecution event=policy-allow" "$service_log" &&
        grep -Fq "CaumeDSE Audit: parserExecution event=execute-success" "$service_log"; then
         record_pass "live_${protocol}_parser_audit"
@@ -979,6 +1008,7 @@ note "logs=$LOG_ROOT"
 note "http_port=$HTTP_PORT https_port=$HTTPS_PORT timeout=$RUN_TIMEOUT web_protocol=$WEB_PROTOCOL live_only=$LIVE_ONLY ci_smoke=$CI_SMOKE redact=$REDACT_OUTPUT"
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
+    run_release_bypass_config_guard || exit 1
     run_step configure ./configure --prefix="$PREFIX" --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP || exit 1
     run_step make_clean make clean || exit 1
     run_step make make || exit 1

--- a/TODO.md
+++ b/TODO.md
@@ -587,10 +587,10 @@
     - Preserved read compatibility by retrying decrypt operations with the legacy PBKDF2-HMAC-SHA1/2,000 profile when the default profile fails.
     - Added DEBUG verifier coverage for the new default profile and legacy decrypt fallback, and updated PBKDF documentation.
 
-- [ ] #82 Harden HTTP TLS-auth bypass controls.
+- [x] #82 Harden HTTP TLS-auth bypass controls.
   - Source: `configure.ac`, `common.h`, `webservice_interface.c`, verifier profiles.
   - Goal: prevent test-only HTTP TLS-auth bypass from being accidentally enabled in deployable builds.
-  - Plan:
-    - Batch 1: fail startup or emit a hard error when bypass is enabled outside DEBUG/test profiles.
-    - Batch 2: make the bypass setting visible in startup diagnostics without exposing secrets.
-    - Batch 3: add verifier checks for bypass-on and bypass-off HTTP authentication behavior.
+  - Done:
+    - Added configure and compile-time guards so `--enable-BYPASSTLSAUTHINHTTP` is accepted only with DEBUG/test builds.
+    - Made HTTP TLS-auth bypass state visible in DEBUG startup and request diagnostics without logging secrets.
+    - Added verifier checks for release-profile bypass rejection and DEBUG HTTP bypass diagnostics.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -315,6 +315,10 @@ Relevant source:
 - `TEST/run_debug_components.sh`: generated client certificate chain for live
   HTTPS verification.
 
+The HTTP TLS-auth bypass exists only for DEBUG/test verification. Configure
+rejects `--enable-BYPASSTLSAUTHINHTTP` unless `--enable-DEBUG` is also used,
+and DEBUG startup diagnostics report whether the bypass is enabled.
+
 Authorization uses protected resource tables:
 
 - `roleTables` define allowed methods for resource types.
@@ -490,6 +494,9 @@ role/filter resources, document routes, secure CSV round trips, MAC-protected
 values, web startup, live API flows, parser execution, DB browsing, and
 negative routes. The live API flow asserts missing-credential failures on HTTP
 and HTTPS plus missing and mismatched client certificate failures on HTTPS.
+It also verifies that the DEBUG-only HTTP TLS-auth bypass is rejected for
+release configure profiles and is explicitly logged when enabled for HTTP
+tests.
 Live API runs write `live-api-coverage.csv` and `live-api-coverage.txt` under
 the verifier log directory so route coverage, expected/actual statuses, marker
 checks, elapsed time, and response log paths can be reviewed without reading

--- a/common.h
+++ b/common.h
@@ -58,8 +58,11 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #ifdef BYPASS_TLS_IN_HTTP
 #define cmeBypassTLSAuthenticationInHTTP BYPASS_TLS_IN_HTTP //Enable/disable bypassing TLS authentication with non TLS sessions {i.e. HTTP} with config. script {1=ON, 0=OFF}.
 #else
-#define cmeBypassTLSAuthenticationInHTTP 1 //Allows bypassing TLS authentication with non TLS sessions {e.g. when testing HTTP connections with TLS auth. enabled, where TLS authentication would allways fail obvoiusly}.
+#define cmeBypassTLSAuthenticationInHTTP 0 //Safe default: do not bypass TLS authentication for HTTP sessions unless configure explicitly enables the DEBUG/test profile.
 #endif /*BYPASS_TLS_IN_HTTP*/
+#if (cmeBypassTLSAuthenticationInHTTP == 1) && !defined(DEBUG)
+#error "HTTP TLS authentication bypass requires a DEBUG/test build profile"
+#endif
 #define cmeUseTLSAuthentication 1       //TLS user authentication module {1=ON, 0=OFF}.
 #define cmeUseOAUTHAuthentication 0     //OAuth is delegated to an external engine manager; no internal OAuth module is enabled.
 #define cmeCSVRowBuffer 5000            //Buffer for processing CSV files - reads at most this # of rows at a time {RECOMMENDED: 5000} and processes them before reading more.

--- a/configure
+++ b/configure
@@ -8056,6 +8056,9 @@ else case e in #(
 esac
 fi
 
+if test "$BYTLS" = "1" && test "$compile_mode" != "DEBUG"; then
+	as_fn_error $? "--enable-BYPASSTLSAUTHINHTTP requires --enable-DEBUG; HTTP TLS-auth bypass is test-only" "$LINENO" 5
+fi
 # Check whether --enable-OLDPBKDF1 was given.
 if test ${enable_OLDPBKDF1+y}
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -192,6 +192,9 @@ AC_ARG_ENABLE([BYPASSTLSAUTHINHTTP],
 	[  --enable-BYPASSTLSAUTHINHTTP		Accepts sessions in HTTP when TLS authentication is used (for testing; NOT RECOMMENDED!)],
 	[BYTLS=1],
 	[BYTLS=0])
+if test "$BYTLS" = "1" && test "$compile_mode" != "DEBUG"; then
+	AC_MSG_ERROR([--enable-BYPASSTLSAUTHINHTTP requires --enable-DEBUG; HTTP TLS-auth bypass is test-only])
+fi
 AC_ARG_ENABLE([OLDPBKDF1],
 	[  --enable-OLDPBKDF1			Uses PBKDF1 (i.e. PKCS5v1.5, compatible with openssl's command line tool) instead of PBKDF2 (for testing; NOT RECOMMENDED!)],
 	[PBKDF=1],

--- a/engine_admin.c
+++ b/engine_admin.c
@@ -1141,6 +1141,13 @@ int cmeWebServiceSetup (unsigned short port, int useSSL, const char *sslKeyFile,
     }
     cmeWebServiceStopRequested=0;
 #ifdef DEBUG
+    fprintf(stdout,"CaumeDSE Debug: cmeWebServiceSetup(), auth profile: tlsAuthentication=%s httpTlsAuthBypass=%s build=DEBUG.\n",
+            cmeUseTLSAuthentication ? "enabled" : "disabled",
+            cmeBypassTLSAuthenticationInHTTP ? "enabled" : "disabled");
+    if ((!useSSL)&&(cmeUseTLSAuthentication)&&(cmeBypassTLSAuthenticationInHTTP))
+    {
+        fprintf(stdout,"CaumeDSE Debug: cmeWebServiceSetup(), WARNING: HTTP TLS authentication bypass active for DEBUG/test profile only.\n");
+    }
     fprintf(stdout,"CaumeDSE Debug: cmeWebServiceSetup(), %s server started on port %d.\n",
             useSSL ? "HTTPS" : "HTTP",port);
 #endif

--- a/function_tests.c
+++ b/function_tests.c
@@ -2340,6 +2340,7 @@ void testWebServices ()
     int httpPort = cmeDefaultWebservicePort;
     int httpsPort = cmeDefaultWebServiceSSLPort;
     int result;
+    char marker[160];
 
     if (skipWebEnv && *skipWebEnv && strcmp(skipWebEnv,"0"))
     {
@@ -2361,9 +2362,10 @@ void testWebServices ()
         httpsPort = atoi(httpsEnv);
     }
 
-    printf("--- Testing Web server HTTP port %d%s (thread pool: %d)\n",httpPort,
-           cmeDebugTestsNonInteractiveEnabled() ? " (non-interactive)" : " (press enter to continue)",
-           cmeDefaultMaxThreads);
+    snprintf(marker,sizeof(marker),"--- Testing Web server HTTP port %d%s (thread pool: %d)\n",httpPort,
+             cmeDebugTestsNonInteractiveEnabled() ? " (non-interactive)" : " (press enter to continue)",
+             cmeDefaultMaxThreads);
+    cmeTestPrintMarker(marker);
     result=cmeWebServiceSetup(httpPort,0,NULL,NULL,NULL,0);
     if (result)
     {
@@ -2371,11 +2373,13 @@ void testWebServices ()
     }
     else
     {
-        printf("TESTS: testWebServices(), PASS: HTTP startup and shutdown verified on port %d\n",httpPort);
+        snprintf(marker,sizeof(marker),"TESTS: testWebServices(), PASS: HTTP startup and shutdown verified on port %d\n",httpPort);
+        cmeTestPrintMarker(marker);
     }
-    printf("--- Testing Web server HTTPS port %d%s (thread pool: %d)\n",httpsPort,
-           cmeDebugTestsNonInteractiveEnabled() ? " (non-interactive)" : " (press enter to continue)",
-           cmeDefaultMaxThreads);
+    snprintf(marker,sizeof(marker),"--- Testing Web server HTTPS port %d%s (thread pool: %d)\n",httpsPort,
+             cmeDebugTestsNonInteractiveEnabled() ? " (non-interactive)" : " (press enter to continue)",
+             cmeDefaultMaxThreads);
+    cmeTestPrintMarker(marker);
     result=cmeWebServiceSetup(httpsPort,1,cmeDefaultHTTPSKeyFile,cmeDefaultHTTPSCertFile,cmeDefaultCACertFile,0);
     if (result)
     {
@@ -2383,6 +2387,7 @@ void testWebServices ()
     }
     else
     {
-        printf("TESTS: testWebServices(), PASS: HTTPS startup and shutdown verified on port %d\n",httpsPort);
+        snprintf(marker,sizeof(marker),"TESTS: testWebServices(), PASS: HTTPS startup and shutdown verified on port %d\n",httpsPort);
+        cmeTestPrintMarker(marker);
     }
 }

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -1921,7 +1921,7 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
             if ((cmeBypassTLSAuthenticationInHTTP)&&(cmeUseTLSAuthentication))
             {
 #ifdef DEBUG
-            fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessRequest(), WARNING: bypassing TLS authentication in an HTTP session.\n");
+            fprintf(stdout,"CaumeDSE Debug: cmeWebServiceProcessRequest(), WARNING: bypassing TLS authentication in an HTTP session (DEBUG/test profile only).\n");
 #endif
                 authentication+=4; //If TLS authentication is required but session is not HTTPS/TLS, assume authentication is correct. (For testing purposes only, e.g. HTTP in DEBUG mode)
             }


### PR DESCRIPTION
## Summary
- reject `--enable-BYPASSTLSAUTHINHTTP` unless DEBUG/test builds are enabled
- default the HTTP TLS-auth bypass off when configure metadata is absent and compile-fail non-DEBUG bypass builds
- add DEBUG startup/request diagnostics for TLS authentication and HTTP bypass state without exposing secrets
- add verifier coverage for release-profile bypass rejection and live HTTP bypass diagnostics
- update docs and mark TODO #82 complete

## Security Impact
- prevents the test-only HTTP TLS-auth bypass from being accidentally enabled in deployable builds
- keeps existing DEBUG verifier HTTP flows available while making the bypass explicit in logs

## Validation
- `./configure --enable-BYPASSTLSAUTHINHTTP` fails with the intended hard error
- `./configure --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP`
- `bash -n TEST/run_debug_components.sh`
- `make`
- `make check`
- `CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke`
  - RESULT passed=100 failed=0 skipped=1