### PR TITLE
Add agent credential and JSON error support

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -26,13 +26,15 @@ Recommended boundaries:
 
 Use the same shape as the live verifier:
 
-1. Create a temporary organization, storage resource, and least-privilege user.
-2. Add only the role/filter resources needed for the task.
-3. Upload test CSV or script fixtures from known local paths.
-4. Query narrow resources such as a specific row, column, table, or parser
+1. Call `GET /agentCapabilities` to discover supported formats, auth
+   requirements, parser policy, documentation links, and route templates.
+2. Create a temporary organization, storage resource, and least-privilege user.
+3. Add only the role/filter resources needed for the task.
+4. Upload test CSV or script fixtures from known local paths.
+5. Query narrow resources such as a specific row, column, table, or parser
    output.
-5. Delete temporary documents, role/filter rows, users, and storage artifacts.
-6. Review `summary.txt` and `live-api-coverage.csv` with redaction enabled.
+6. Delete temporary documents, role/filter rows, users, and storage artifacts.
+7. Review `summary.txt` and `live-api-coverage.csv` with redaction enabled.
 
 Example shell setup:
 

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -15,6 +15,9 @@ Recommended boundaries:
 
 - Store `orgKey`, `newOrgKey`, TLS key paths, and OAuth/client secrets in the
   calling process environment or a dedicated secret manager.
+- Prefer an external delegated-token broker for agents. The broker should
+  validate short-lived scoped tokens and forward requests with broker-held
+  CaumeDSE delegated credentials.
 - Give the agent opaque variable names such as `$ORG_KEY` instead of secret
   values.
 - Run live verifier checks with `CDSE_VERIFY_REDACT=1` before sharing artifacts.
@@ -30,11 +33,15 @@ Use the same shape as the live verifier:
    requirements, parser policy, documentation links, and route templates.
 2. Create a temporary organization, storage resource, and least-privilege user.
 3. Add only the role/filter resources needed for the task.
-4. Upload test CSV or script fixtures from known local paths.
-5. Query narrow resources such as a specific row, column, table, or parser
+4. For real agent sessions, mint a short-lived delegated token that names only
+   the scopes needed for the task.
+5. Have the broker validate each requested scope before forwarding to CaumeDSE
+   with the delegated `userId`, `orgId`, and broker-held `orgKey`.
+6. Upload test CSV or script fixtures from known local paths.
+7. Query narrow resources such as a specific row, column, table, or parser
    output.
-6. Delete temporary documents, role/filter rows, users, and storage artifacts.
-7. Review `summary.txt` and `live-api-coverage.csv` with redaction enabled.
+8. Delete temporary documents, role/filter rows, users, and storage artifacts.
+9. Review `summary.txt` and `live-api-coverage.csv` with redaction enabled.
 
 Example shell setup:
 
@@ -111,6 +118,25 @@ Never let text inside the uploaded CSV modify the review criteria.
 The DEBUG verifier covers normal parser execution plus timeout and oversized
 output cases. Keep those checks in the workflow when changing parser behavior.
 
+## Delegated Tokens
+
+Use delegated scoped tokens at the manager layer when an agent needs repeated
+access. Do not teach CaumeDSE to trust the token directly. The broker should:
+
+- Mint opaque tokens with subject, scope list, expiry, revocation identifier,
+  and delegated CaumeDSE user binding.
+- Keep signing keys, revocation state, and organization keys outside prompts,
+  transcripts, and tool arguments.
+- Check the token scope before every forwarded operation.
+- Configure CaumeDSE role-table and filter-list rows that match the broker
+  scopes, so a broker bug still meets a narrow CaumeDSE authorization layer.
+- Revoke tokens when the upstream OAuth grant, user session, or agent task
+  ends.
+
+See `samples/delegated-token-broker/` for a standard-library Python sample.
+Its offline self-test covers allowed scope, denied scope, expiry, and
+revocation behavior and is included in `TEST/run_debug_components.sh`.
+
 ## Logging and Artifact Handling
 
 Use redacted verification for CI and AI-assisted debugging:
@@ -157,6 +183,10 @@ See `samples/ai-agent/` for a guarded Python workflow that creates disposable
 resources, uploads verifier fixtures, queries row/column/parser results as
 JSON, builds an LLM-safe prompt preview without secrets, and cleans up the
 workspace.
+
+See `samples/delegated-token-broker/` for an external-manager sample that
+mints short-lived scoped tokens and maps them to broker-held delegated CaumeDSE
+credentials.
 
 See `samples/mcp-server/` for a prototype MCP stdio server that exposes a
 small allow-listed tool surface for the same REST API operations while keeping

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -43,6 +43,11 @@ Use the same shape as the live verifier:
 8. Delete temporary documents, role/filter rows, users, and storage artifacts.
 9. Review `summary.txt` and `live-api-coverage.csv` with redaction enabled.
 
+For failures that an agent must parse, include `outputType=json`. Non-HEAD
+error responses include `error.code`, `error.message`, `error.httpStatus`,
+`error.requestId`, and `error.safeForAgent`; the same request ID is returned in
+the `X-Request-Id` response header and recorded in LogsDB response headers.
+
 Example shell setup:
 
 ```sh
@@ -159,6 +164,8 @@ Do not:
 - Paste expanded `curl` URLs containing `orgKey` or `newOrgKey`.
 - Let an agent invent parser scripts and upload them without human review.
 - Use a manager or admin user when a narrow test user is sufficient.
+- Ignore `X-Request-Id` when reporting failures; keep it with status and route
+  context so operators can find the matching LogsDB row.
 - Keep temporary AI-created organizations, users, documents, or parser scripts
   after the task is complete.
 - Share raw DEBUG logs or live request artifacts without redaction.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -38,6 +38,19 @@ The examples use committed verifier fixtures:
 - `TEST/testfiles/test.pl`
 - `TEST/testfiles/test.py`
 
+## Agent Capability Discovery
+
+Agents and MCP clients should discover supported safe automation behavior before
+calling data routes. This public endpoint does not require credentials and does
+not return organization data.
+
+```sh
+curl -s "$BASE_URL/agentCapabilities"
+```
+
+Useful fields include `authentication.requiredParameters`,
+`formats.preferred`, `parserPolicy`, and each entry in `routes`.
+
 ## Negative Authentication Checks
 
 Missing credentials return `401`.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -51,6 +51,28 @@ curl -s "$BASE_URL/agentCapabilities"
 Useful fields include `authentication.requiredParameters`,
 `formats.preferred`, `parserPolicy`, and each entry in `routes`.
 
+Every response includes `X-Request-Id` for correlation with LogsDB response
+headers. For parseable failures, request JSON:
+
+```sh
+curl -i $TLS_ARGS \
+  "$BASE_URL/organizations/$ORG?userId=$USER&orgId=$ORG&outputType=json"
+```
+
+The body uses this shape:
+
+```json
+{
+  "error": {
+    "code": "authentication_required",
+    "message": "Authentication is required.",
+    "httpStatus": 401,
+    "requestId": "cdse-...",
+    "safeForAgent": true
+  }
+}
+```
+
 ## Negative Authentication Checks
 
 Missing credentials return `401`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ For safe AI-agent and automation patterns around the API, see
 For a guarded Python AI-agent workflow sample, see
 [samples/ai-agent/](samples/ai-agent/).
 
+For a delegated scoped-token broker sample that keeps CaumeDSE organization
+keys out of agent prompts, see
+[samples/delegated-token-broker/](samples/delegated-token-broker/).
+
 For a prototype MCP stdio server that wraps a safe REST tool surface, see
 [samples/mcp-server/](samples/mcp-server/).
 
@@ -35,6 +39,7 @@ or exposing CaumeDSE credentials.
 - [AI-Safe API Usage](AI_USAGE.md)
 - [AI Agent Capability Manifest](#ai-agent-capability-manifest)
 - [AI Agent Sample](samples/ai-agent/)
+- [Delegated Token Broker Sample](samples/delegated-token-broker/)
 - [MCP Server Prototype](samples/mcp-server/)
 - [License](#license)
 - [Architecture and Functionality](#architecture-and-functionality)
@@ -2375,6 +2380,17 @@ manager must delete the delegated organization and associated resources.
 CaumeDSE intentionally does not store organization keys or OAuth tokens,
 so the manager must keep its own mapping from OAuth grants to delegated
 CaumeDSE scopes.
+
+For AI-agent integrations, prefer short-lived delegated tokens issued by that
+external manager instead of exposing the CaumeDSE organization key to the
+agent.  A delegated token should be opaque to CaumeDSE and should include, at
+the manager layer, a subject, narrow scopes, expiry, a revocation identifier,
+and the delegated CaumeDSE user/organization binding.  After the manager
+validates the token, it forwards the request to CaumeDSE using the
+manager-held delegated `userId`, `orgId`, and `orgKey`, while role-table and
+filter-list rows enforce the same narrow permissions inside CaumeDSE.  See
+`samples/delegated-token-broker/` for a standard-library Python sample and
+offline allow/deny/expiry/revocation checks.
 
 In release mode the software enters and infinite loop to answer connections;
 right now you need to kill the process to stop it).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ AI agents and MCP clients can discover safe automation capabilities with
 `GET /agentCapabilities`, which returns public JSON metadata without requiring
 or exposing CaumeDSE credentials.
 
+API responses include an `X-Request-Id` header. When `outputType=json` is
+requested and a non-HEAD request fails with common authentication,
+authorization, not-found, method, conflict, not-implemented, or server errors,
+CaumeDSE returns a JSON envelope:
+
+```json
+{
+  "error": {
+    "code": "authentication_required",
+    "message": "Authentication is required.",
+    "httpStatus": 401,
+    "requestId": "cdse-...",
+    "safeForAgent": true
+  }
+}
+```
+
+Use `requestId` to correlate client-side failures with LogsDB response-header
+entries and retained verifier artifacts.
+
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ For a guarded Python AI-agent workflow sample, see
 For a prototype MCP stdio server that wraps a safe REST tool surface, see
 [samples/mcp-server/](samples/mcp-server/).
 
+AI agents and MCP clients can discover safe automation capabilities with
+`GET /agentCapabilities`, which returns public JSON metadata without requiring
+or exposing CaumeDSE credentials.
+
 
 ## Contents
 
@@ -29,6 +33,7 @@ For a prototype MCP stdio server that wraps a safe REST tool surface, see
 - [API Examples](API_EXAMPLES.md)
 - [OpenAPI Route Reference](openapi.yaml)
 - [AI-Safe API Usage](AI_USAGE.md)
+- [AI Agent Capability Manifest](#ai-agent-capability-manifest)
 - [AI Agent Sample](samples/ai-agent/)
 - [MCP Server Prototype](samples/mcp-server/)
 - [License](#license)
@@ -1053,6 +1058,28 @@ vacuumDB
     Specifies the value for the specified 'column_name'. The column name
     must match an existing column name within a document resource of
     type file.csv.
+
+## AI Agent Capability Manifest
+
+`GET /agentCapabilities` returns a public JSON manifest for AI agents, MCP
+clients, SDK generators, and automation supervisors. It does not require
+`userId`, `orgId`, or `orgKey`, and it does not include organization data or
+secrets.
+
+The manifest reports:
+
+- required authentication parameters for data routes;
+- preferred and supported response formats;
+- parser policy settings such as timeout, result limits, isolation profile,
+  and reviewed/profile enforcement;
+- core route names, path templates, supported methods, and whether
+  authentication is required;
+- links to `README.md`, `AI_USAGE.md`, `API_EXAMPLES.md`, `openapi.yaml`,
+  `samples/ai-agent/`, and `samples/mcp-server/`.
+
+Use this endpoint before invoking data routes so an agent can choose JSON
+responses, avoid passing organization keys to an LLM, and respect parser-review
+policy before uploading or executing scripts.
 
 ## REST Resource API Reference
 

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -854,6 +854,8 @@ run_live_web_flow() {
     live_api_check "$protocol" agent_capabilities 200 "$base_url/agentCapabilities" '"capabilityManifestVersion":1' "${curl_tls_args[@]}"
     live_api_check "$protocol" auth_missing_all 401 "$base_url/organizations/$org_name" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" auth_missing_org_key 401 "$base_url/organizations/$org_name?userId=$user_id&orgId=$org_name" "" "${curl_tls_args[@]}"
+    live_api_check "$protocol" json_error_auth_missing_org_key 401 "$base_url/organizations/$org_name?userId=$user_id&orgId=$org_name&outputType=json" '"code":"authentication_required"' "${curl_tls_args[@]}"
+    live_api_check "$protocol" json_error_auth_request_id 401 "$base_url/organizations/$org_name?userId=$user_id&orgId=$org_name&outputType=json" '"requestId":"cdse-' "${curl_tls_args[@]}"
     long_query_value="$(printf '%*s' 1500 '' | tr ' ' 'x')"
     live_api_check "$protocol" transaction_log_redaction_probe 401 "$base_url/organizations/${org_name}_logProbe?orgId=$org_name&orgKey=$org_key&newOrgKey=$org_key&accessPassword=$org_key&longParam=$long_query_value" "" "${curl_tls_args[@]}" -H "Authorization: Bearer $org_key"
     if [ "$protocol" = "https" ]; then
@@ -868,6 +870,7 @@ run_live_web_flow() {
     live_api_check "$protocol" document_types_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
     live_api_check "$protocol" document_type_csv_head 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -I
     live_api_check "$protocol" document_type_unsupported 404 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/unsupported.type?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}"
+    live_api_check "$protocol" json_error_not_found 404 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/unsupported.type?$auth&newOrgKey=$org_key&outputType=json" '"code":"not_found"' "${curl_tls_args[@]}"
     live_api_check "$protocol" role_table_post 201 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key&*_get=1&*_post=0&*_put=1&*_delete=0&*_head=1&*_options=1" "" "${curl_tls_args[@]}" -X POST
     live_api_check "$protocol" role_table_get 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key" "$role_user" "${curl_tls_args[@]}"
     live_api_check "$protocol" role_table_json_get 200 "$base_url/organizations/$org_name/users/$role_user/roleTables/users?$auth&newOrgKey=$org_key&outputType=json" '"rows":[' "${curl_tls_args[@]}"
@@ -889,6 +892,7 @@ run_live_web_flow() {
     live_api_check "$protocol" document_head 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -I
     live_api_check "$protocol" content_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/content?$auth&newOrgKey=$org_key&outputType=csv" "Jacob" "${curl_tls_args[@]}"
     live_api_check "$protocol" content_rows_options 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X OPTIONS
+    live_api_check "$protocol" json_error_method_not_allowed 405 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows?$auth&newOrgKey=$org_key&outputType=json" '"code":"method_not_allowed"' "${curl_tls_args[@]}"
     live_api_check "$protocol" row_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows/1?$auth&newOrgKey=$org_key&outputType=csv" "Jacob" "${curl_tls_args[@]}"
     live_api_check "$protocol" row_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentRows/1?$auth&newOrgKey=$org_key&outputType=json" '"name":"Jacob"' "${curl_tls_args[@]}"
     live_api_check "$protocol" content_columns_options 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/contentColumns?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}" -X OPTIONS
@@ -905,6 +909,7 @@ run_live_web_flow() {
     live_api_check "$protocol" table_column_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableColumns/name?$auth&newOrgKey=$org_key" "Jacob" "${curl_tls_args[@]}"
     live_api_check "$protocol" table_column_json_get 200 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableColumns/name?$auth&newOrgKey=$org_key&outputType=json" '"name":"Jacob"' "${curl_tls_args[@]}"
     live_api_check "$protocol" db_browse_bad_row 403 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableRows/0?$auth&newOrgKey=$org_key" "" "${curl_tls_args[@]}"
+    live_api_check "$protocol" json_error_forbidden 403 "$base_url/organizations/$org_name/storage/$storage_name/dbNames/$csv_name/dbTables/data/tableRows/0?$auth&newOrgKey=$org_key&outputType=json" '"code":"forbidden"' "${curl_tls_args[@]}"
     live_api_check "$protocol" upload_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.perl/documents/$script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test.pl" \
         -F "userId=$user_id" \

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -830,6 +830,7 @@ run_live_web_flow() {
         return 1
     fi
 
+    live_api_check "$protocol" agent_capabilities 200 "$base_url/agentCapabilities" '"capabilityManifestVersion":1' "${curl_tls_args[@]}"
     live_api_check "$protocol" auth_missing_all 401 "$base_url/organizations/$org_name" "" "${curl_tls_args[@]}"
     live_api_check "$protocol" auth_missing_org_key 401 "$base_url/organizations/$org_name?userId=$user_id&orgId=$org_name" "" "${curl_tls_args[@]}"
     long_query_value="$(printf '%*s' 1500 '' | tr ' ' 'x')"

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -346,6 +346,27 @@ run_release_bypass_config_guard() {
     return 1
 }
 
+run_delegated_token_broker_self_test() {
+    local log="$LOG_ROOT/delegated_token_broker_self_test.log"
+    local start
+    local rc
+
+    note "RUN  delegated_token_broker_self_test"
+    start="$(date +%s)"
+    (
+        cd "$ROOT_DIR" || exit 1
+        python3 samples/delegated-token-broker/delegated_token_broker.py self-test
+    ) > "$log" 2>&1
+    rc=$?
+    redact_file_in_place "$log"
+    if [ "$rc" -eq 0 ] && grep -Fq "PASS delegated token broker self-test" "$log"; then
+        record_pass "delegated_token_broker_self_test ($(elapsed_seconds "$start"))"
+        return 0
+    fi
+    record_fail delegated_token_broker_self_test "exit=$rc elapsed=$(elapsed_seconds "$start") log=$log"
+    return 1
+}
+
 protocol_enabled() {
     local protocol="$1"
 
@@ -1058,6 +1079,12 @@ if [ "$SKIP_WEB" -eq 0 ]; then
     fi
 else
     record_skip webservice_ports "requested --skip-web"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    run_delegated_token_broker_self_test
+else
+    record_skip delegated_token_broker_self_test "python3 not available"
 fi
 
 FULL_LOG="$LOG_ROOT/full-debug-run.log"

--- a/TEST/validate_openapi_routes.sh
+++ b/TEST/validate_openapi_routes.sh
@@ -42,6 +42,7 @@ require_pattern "$EXAMPLES" "openapi.yaml" "API examples OpenAPI link"
 require_pattern "$VERIFIER" "validate_openapi_routes.sh" "verifier OpenAPI validation"
 
 required_paths=(
+    "/agentCapabilities:"
     "/organizations:"
     "/organizations/{organization}:"
     "/organizations/{organization}/users/{user}:"
@@ -68,6 +69,7 @@ for path in "${required_paths[@]}"; do
 done
 
 live_markers=(
+    "agent_capabilities"
     "create_org"
     "create_storage"
     "create_user"

--- a/TODO.md
+++ b/TODO.md
@@ -603,13 +603,22 @@
     - Documented the manifest in README/API examples and OpenAPI.
     - Added live verifier and OpenAPI route validation coverage for the manifest.
 
-- [ ] #84 Add delegated scoped agent tokens.
+- [x] #84 Add delegated scoped agent tokens.
   - Source: auth boundary docs, external manager integration, roles/filter setup helpers.
   - Goal: let agents use short-lived least-privilege delegated credentials instead of full organization keys.
   - Plan:
     - Batch 1: define delegated-token semantics, scope claims, expiry, revocation, and how external managers map tokens to CaumeDSE delegated users.
     - Batch 2: add a sample token broker workflow that creates narrow user/role/filter resources and never exposes `orgKey` to the model.
     - Batch 3: add verifier coverage for allowed and denied delegated scopes.
+  - Done: documented delegated tokens as an external-manager concern rather
+    than an in-engine bearer-token validator, added
+    `samples/delegated-token-broker/` with a standard-library Python broker
+    sample that mints signed opaque tokens, validates scopes/expiry/revocation,
+    maps them to broker-held delegated CaumeDSE user/org credentials, and can
+    provision read-only role/filter rows. Added verifier coverage through the
+    broker offline self-test for allowed scope, denied scope, expiry, and
+    revocation, and linked the sample from README, AI usage, AI-agent, and MCP
+    docs.
 
 - [ ] #85 Add JSON error envelopes and request IDs.
   - Source: `webservice_interface.c`, transaction logging, OpenAPI.

--- a/TODO.md
+++ b/TODO.md
@@ -594,3 +594,67 @@
     - Added configure and compile-time guards so `--enable-BYPASSTLSAUTHINHTTP` is accepted only with DEBUG/test builds.
     - Made HTTP TLS-auth bypass state visible in DEBUG startup and request diagnostics without logging secrets.
     - Added verifier checks for release-profile bypass rejection and DEBUG HTTP bypass diagnostics.
+
+- [x] #83 Add a machine-readable AI agent capability manifest.
+  - Source: `webservice_interface.c`, `openapi.yaml`, AI/MCP docs, live verifier.
+  - Goal: let AI agents and MCP clients discover safe CaumeDSE capabilities before sending credentials or invoking data routes.
+  - Done:
+    - Added public `GET /agentCapabilities` and `OPTIONS /agentCapabilities` JSON responses with auth requirements, preferred formats, parser policy state, route summaries, and documentation links.
+    - Documented the manifest in README/API examples and OpenAPI.
+    - Added live verifier and OpenAPI route validation coverage for the manifest.
+
+- [ ] #84 Add delegated scoped agent tokens.
+  - Source: auth boundary docs, external manager integration, roles/filter setup helpers.
+  - Goal: let agents use short-lived least-privilege delegated credentials instead of full organization keys.
+  - Plan:
+    - Batch 1: define delegated-token semantics, scope claims, expiry, revocation, and how external managers map tokens to CaumeDSE delegated users.
+    - Batch 2: add a sample token broker workflow that creates narrow user/role/filter resources and never exposes `orgKey` to the model.
+    - Batch 3: add verifier coverage for allowed and denied delegated scopes.
+
+- [ ] #85 Add JSON error envelopes and request IDs.
+  - Source: `webservice_interface.c`, transaction logging, OpenAPI.
+  - Goal: make API failures easy for agents to parse and correlate with audit logs.
+  - Plan:
+    - Batch 1: define stable `error.code`, `error.message`, `httpStatus`, `requestId`, and `safeForAgent` fields.
+    - Batch 2: add request-id generation/propagation to response headers and transaction logs.
+    - Batch 3: convert common authentication, authorization, not-found, and method errors to JSON when `outputType=json`.
+
+- [ ] #86 Add agent-safe paginated read and schema metadata endpoints.
+  - Source: resource handlers, `openapi.yaml`, AI/MCP samples.
+  - Goal: reduce large unbounded responses and give agents stable schemas before reading data.
+  - Plan:
+    - Batch 1: document and validate pagination parameters for JSON reads.
+    - Batch 2: add document/table schema metadata routes for columns, row counts, document types, and parser policy metadata.
+    - Batch 3: extend MCP and AI-agent samples to use schema discovery before row/column reads.
+
+- [ ] #87 Add an AI-generated parser upload/review workflow.
+  - Source: parser script resources, parser policy metadata, verifier fixtures.
+  - Goal: keep generated parser scripts pending until reviewed and allow safe sample execution before full runs.
+  - Plan:
+    - Batch 1: define pending/reviewed parser metadata and provenance fields such as generator, prompt hash, reviewer, and review time.
+    - Batch 2: add static checks and sample-row preview execution for parser candidates.
+    - Batch 3: add live verifier coverage for pending deny, reviewed allow, and preview-only execution.
+
+- [ ] #88 Add structured JSON audit logs for agent activity.
+  - Source: transaction logging, parser audit lines, docs.
+  - Goal: make agent actions, policy decisions, and parser execution reviewable by machines without scraping text logs.
+  - Plan:
+    - Batch 1: define JSON audit event schemas for auth, authorization, parser policy, parser execution, and cleanup.
+    - Batch 2: emit structured audit events alongside existing text diagnostics.
+    - Batch 3: add an agent-readable recent-audit sample and verifier checks for redaction.
+
+- [ ] #89 Promote the MCP prototype into a supported read-only tool surface.
+  - Source: `samples/mcp-server/`, `AI_USAGE.md`, live verifier.
+  - Goal: provide a stable MCP interface for agents to inspect CaumeDSE data with narrow permissions.
+  - Plan:
+    - Batch 1: align MCP tools with `/agentCapabilities` and OpenAPI route names.
+    - Batch 2: add schema validation, pagination, and safer result truncation to read tools.
+    - Batch 3: add a smoke test that runs MCP initialize/tools/list/tool calls against the live verifier service.
+
+- [ ] #90 Add an AI agent cookbook and operational checklist.
+  - Source: `AI_USAGE.md`, `samples/`, README.
+  - Goal: make safe agent deployments repeatable for integrators.
+  - Plan:
+    - Batch 1: add recipes for read-only document inspection, parser review/upload, audit review, and cleanup.
+    - Batch 2: add deployment checklist entries for HTTPS, scoped delegated users, parser isolation, log redaction, and model prompt boundaries.
+    - Batch 3: cross-link cookbook recipes from README, API examples, MCP docs, and OpenAPI.

--- a/TODO.md
+++ b/TODO.md
@@ -620,13 +620,22 @@
     revocation, and linked the sample from README, AI usage, AI-agent, and MCP
     docs.
 
-- [ ] #85 Add JSON error envelopes and request IDs.
+- [x] #85 Add JSON error envelopes and request IDs.
   - Source: `webservice_interface.c`, transaction logging, OpenAPI.
   - Goal: make API failures easy for agents to parse and correlate with audit logs.
   - Plan:
     - Batch 1: define stable `error.code`, `error.message`, `httpStatus`, `requestId`, and `safeForAgent` fields.
     - Batch 2: add request-id generation/propagation to response headers and transaction logs.
     - Batch 3: convert common authentication, authorization, not-found, and method errors to JSON when `outputType=json`.
+  - Done: added per-connection `X-Request-Id` generation in the web-service
+    response path and included the header in the same response-header list
+    logged to LogsDB. Added centralized JSON error envelopes for non-HEAD
+    failures when `outputType=json` is requested, mapping common status codes
+    to stable `error.code`, `error.message`, `httpStatus`, `requestId`, and
+    `safeForAgent` fields. Extended live verifier coverage for JSON
+    authentication, not-found, method-not-allowed, forbidden, and request-id
+    markers, and documented the contract in README, API examples, AI usage,
+    and OpenAPI.
 
 - [ ] #86 Add agent-safe paginated read and schema metadata endpoints.
   - Source: resource handlers, `openapi.yaml`, AI/MCP samples.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,6 +13,7 @@ servers:
   - url: https://localhost:18443
     description: DEBUG HTTPS verifier server
 tags:
+  - name: Agent capabilities
   - name: Authentication
   - name: Organizations
   - name: Users
@@ -25,6 +26,54 @@ tags:
   - name: Secure DB browsing
 
 paths:
+  /agentCapabilities:
+    get:
+      tags: [Agent capabilities]
+      summary: Return a public machine-readable manifest for AI agents and MCP clients.
+      description: |
+        Describes safe automation guidance, supported auth modes, preferred
+        response formats, parser policy settings, documentation links, and core
+        data routes. This route is intentionally public and does not expose
+        organization data or secrets.
+      responses:
+        "200":
+          description: JSON capability manifest.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [capabilityManifestVersion, engine, safeForAgents, authentication, routes]
+                properties:
+                  capabilityManifestVersion:
+                    type: integer
+                    example: 1
+                  engine:
+                    type: string
+                    example: CaumeDSE
+                  safeForAgents:
+                    type: boolean
+                    example: true
+                  authentication:
+                    type: object
+                  formats:
+                    type: object
+                  parserPolicy:
+                    type: object
+                  routes:
+                    type: array
+                    items:
+                      type: object
+                  docs:
+                    type: array
+                    items:
+                      type: string
+    options:
+      tags: [Agent capabilities]
+      summary: Return supported methods for the agent capability manifest.
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonResponse"
+
   /organizations:
     get:
       tags: [Organizations]
@@ -1459,6 +1508,12 @@ components:
           description: Optional secure CSV import flag.
 
   responses:
+    JsonResponse:
+      description: JSON response.
+      content:
+        application/json:
+          schema:
+            type: object
     TableResponse:
       description: Matching resources as an HTML or CSV-style table.
       headers:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,7 +6,11 @@ info:
     Machine-readable reference for the stable CaumeDSE routes documented in
     README.md and exercised by TEST/run_debug_components.sh. Responses are
     currently HTML, CSV, or JSON-oriented text tables unless a route returns
-    only a status code.
+    only a status code. Responses include an `X-Request-Id` header for log
+    correlation. When `outputType=json` is requested and a non-HEAD request
+    fails, common errors return a JSON envelope with `error.code`,
+    `error.message`, `error.httpStatus`, `error.requestId`, and
+    `error.safeForAgent`.
 servers:
   - url: http://localhost:18080
     description: DEBUG HTTP verifier server
@@ -1472,6 +1476,29 @@ components:
       description: Allow or deny OPTIONS depending on role/filter resource type.
 
   schemas:
+    ErrorEnvelope:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message, httpStatus, requestId, safeForAgent]
+          properties:
+            code:
+              type: string
+              example: authentication_required
+            message:
+              type: string
+              example: Authentication is required.
+            httpStatus:
+              type: integer
+              example: 401
+            requestId:
+              type: string
+              example: cdse-1774470000-123456789-A1B2C3D4E5F60708
+            safeForAgent:
+              type: boolean
+              example: true
     TextTable:
       type: string
       description: HTML or CSV-style table text returned by current handlers.
@@ -1510,6 +1537,11 @@ components:
   responses:
     JsonResponse:
       description: JSON response.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Per-request correlation identifier also recorded in LogsDB response headers.
       content:
         application/json:
           schema:
@@ -1517,6 +1549,10 @@ components:
     TableResponse:
       description: Matching resources as an HTML or CSV-style table.
       headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Per-request correlation identifier also recorded in LogsDB response headers.
         Engine-results:
           schema:
             type: integer
@@ -1545,6 +1581,9 @@ components:
     CsvResponse:
       description: CSV-formatted response body.
       headers:
+        X-Request-Id:
+          schema:
+            type: string
         Engine-results:
           schema:
             type: integer
@@ -1572,6 +1611,9 @@ components:
     FileContentResponse:
       description: Reconstructed document content.
       headers:
+        X-Request-Id:
+          schema:
+            type: string
         Engine-results:
           schema:
             type: integer
@@ -1593,6 +1635,10 @@ components:
             format: binary
     TextResponse:
       description: Text response.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
@@ -1603,6 +1649,9 @@ components:
     CountResponse:
       description: Operation result count.
       headers:
+        X-Request-Id:
+          schema:
+            type: string
         Engine-results:
           schema:
             type: integer
@@ -1619,42 +1668,84 @@ components:
     HeaderOnly:
       description: Status and response headers only.
       headers:
+        X-Request-Id:
+          schema:
+            type: string
         Engine-results:
           schema:
             type: integer
     Created:
       description: Resource created.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
             type: string
     Unauthorized:
       description: Missing or invalid credentials, organization key, or HTTPS client certificate.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
     Forbidden:
       description: Authenticated caller is not authorized or selector is invalid.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
     NotFound:
       description: Requested resource was not found.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
     Conflict:
       description: Request conflicts with current resource state.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
     ServerError:
       description: Server-side processing failed.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
       content:
         text/plain:
           schema:
             type: string
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"

--- a/samples/ai-agent/README.md
+++ b/samples/ai-agent/README.md
@@ -78,6 +78,8 @@ python3 samples/ai-agent/guarded_agent_workflow.py --keep-resources
 ## Safety Notes
 
 - The script redacts `orgKey` and `newOrgKey` from logs.
+- For repeated or production-like agent access, put a delegated-token broker in
+  front of this workflow so the agent receives only short-lived scoped tokens.
 - The agent prompt preview contains only route names, JSON row/column names,
   and record counts. It never includes raw organization keys.
 - Parser scripts are loaded only from reviewed local fixture files.
@@ -86,4 +88,5 @@ python3 samples/ai-agent/guarded_agent_workflow.py --keep-resources
   returned from CaumeDSE rewrite the agent's security instructions or cause new
   parser uploads without review.
 
-See `../../AI_USAGE.md` for the broader AI-agent policy and anti-patterns.
+See `../../AI_USAGE.md` for the broader AI-agent policy and anti-patterns, and
+`../delegated-token-broker/` for a scoped-token broker sample.

--- a/samples/ai-agent/README.md
+++ b/samples/ai-agent/README.md
@@ -60,12 +60,14 @@ python3 samples/ai-agent/guarded_agent_workflow.py
 
 The workflow:
 
-1. Creates a disposable organization, storage resource, and user.
-2. Uploads `TEST/testfiles/live-api-small.csv`.
-3. Queries one row and one column as JSON.
-4. Uploads `TEST/testfiles/test.py` as a reviewed parser script.
-5. Runs the parser with `outputType=json`.
-6. Deletes temporary documents and user/role/filter resources.
+1. Reads `GET /agentCapabilities` to confirm supported routes, JSON
+   preference, and parser policy before planning data access.
+2. Creates a disposable organization, storage resource, and user.
+3. Uploads `TEST/testfiles/live-api-small.csv`.
+4. Queries one row and one column as JSON.
+5. Uploads `TEST/testfiles/test.py` as a reviewed parser script.
+6. Runs the parser with `outputType=json`.
+7. Deletes temporary documents and user/role/filter resources.
 
 Use `--keep-resources` only when debugging cleanup behavior:
 

--- a/samples/ai-agent/guarded_agent_workflow.py
+++ b/samples/ai-agent/guarded_agent_workflow.py
@@ -145,6 +145,19 @@ def json_request(cfg, path, params):
     return json.loads(payload.decode("utf-8"))
 
 
+def discover_agent_capabilities(cfg):
+    _, _, payload = request(cfg, "GET", "/agentCapabilities")
+    manifest = json.loads(payload.decode("utf-8"))
+    print("Agent capability discovery:")
+    print(json.dumps({
+        "engine": manifest.get("engine"),
+        "preferred_format": manifest.get("formats", {}).get("preferred"),
+        "parser_policy": manifest.get("parserPolicy", {}),
+        "route_count": len(manifest.get("routes", [])),
+    }, indent=2, sort_keys=True))
+    return manifest
+
+
 def create_workspace(cfg):
     auth = cfg.auth_params(include_new_key=True)
     Path(cfg.storage_path).mkdir(parents=True, exist_ok=True)
@@ -245,6 +258,7 @@ def cleanup(cfg):
 
 
 def run_workflow(cfg):
+    discover_agent_capabilities(cfg)
     create_workspace(cfg)
     upload_file(cfg, "file.csv", cfg.csv_doc, cfg.csv_fixture, "reviewed AI-agent CSV fixture")
     upload_file(cfg, "script.python", cfg.parser_doc, cfg.parser_fixture, "reviewed AI-agent parser fixture")

--- a/samples/delegated-token-broker/README.md
+++ b/samples/delegated-token-broker/README.md
@@ -1,0 +1,105 @@
+# CaumeDSE Delegated Token Broker Sample
+
+CaumeDSE does not validate bearer tokens, OAuth grants, scopes, expiry, or
+revocation internally. This sample demonstrates the external-manager pattern
+for AI agents: a broker validates a short-lived opaque token and then calls
+CaumeDSE with broker-held delegated `userId`, `orgId`, and `orgKey`
+parameters.
+
+The token is intentionally not a CaumeDSE credential. It is meaningful only to
+the broker that signs it.
+
+## Token Model
+
+The sample token contains:
+
+- `sub`: the external subject or agent session.
+- `scope`: allowed broker actions such as `documents:read` or
+  `parserScripts:run`.
+- `exp`: expiry time as a Unix timestamp.
+- `jti`: revocation identifier stored in a broker-owned deny list.
+- `cdse`: the delegated CaumeDSE organization and user binding.
+
+Production brokers should store signing keys and revocation state in a secret
+manager or database, rotate signing keys, audit every authorization decision,
+and rate-limit callers.
+
+## Configure
+
+```sh
+export CDSE_BROKER_BASE_URL="http://localhost:18080"
+export CDSE_BROKER_SIGNING_SECRET="$(openssl rand -hex 32)"
+export CDSE_BROKER_ADMIN_ORG="AgentBrokerOrg"
+export CDSE_BROKER_ADMIN_USER="AgentBrokerAdmin"
+export CDSE_BROKER_ADMIN_ORG_KEY="$(openssl rand -hex 32)"
+export CDSE_BROKER_DELEGATED_USER="AgentReader"
+export CDSE_BROKER_STORAGE="AgentBrokerStorage"
+export CDSE_BROKER_STORAGE_PATH="/tmp/caumedse-broker-storage"
+```
+
+For HTTPS, also set `CDSE_BROKER_CA_CERT`, `CDSE_BROKER_CLIENT_CERT`, and
+`CDSE_BROKER_CLIENT_KEY`.
+
+## Provision
+
+Create the delegated CaumeDSE user and read-only role/filter rows:
+
+```sh
+python3 samples/delegated-token-broker/delegated_token_broker.py provision-readonly
+```
+
+The broker sends real `orgKey` and `newOrgKey` values only from its process
+environment. Request logs redact those values.
+
+## Mint and Authorize
+
+Mint a short-lived token:
+
+```sh
+TOKEN="$(
+  python3 samples/delegated-token-broker/delegated_token_broker.py mint \
+    --subject agent-session-123 \
+    --scopes documents:read,contentRows:read,contentColumns:read,parserScripts:run \
+    --ttl 900
+)"
+```
+
+Validate a requested action before forwarding it to CaumeDSE:
+
+```sh
+python3 samples/delegated-token-broker/delegated_token_broker.py authorize \
+  --token "$TOKEN" \
+  --scope contentRows:read
+```
+
+The authorize command prints only a redacted CaumeDSE credential preview. A
+real broker would use the broker-held `orgKey` internally to make the REST
+request and return a bounded, non-secret response to the agent.
+
+Revoke the token:
+
+```sh
+python3 samples/delegated-token-broker/delegated_token_broker.py revoke \
+  --token "$TOKEN"
+```
+
+## Offline Smoke Test
+
+```sh
+python3 samples/delegated-token-broker/delegated_token_broker.py self-test
+```
+
+The self-test verifies that a read scope is allowed, a write scope is denied,
+an expired token is denied, and a revoked token is denied. It does not contact
+a CaumeDSE service.
+
+## Boundaries
+
+- Do not pass delegated tokens, organization keys, TLS keys, or revocation
+  stores to an LLM.
+- Keep the `orgKey` in the broker or secret manager. The agent receives only
+  opaque token handles and bounded results.
+- Use short TTLs and revoke tokens immediately when the upstream OAuth grant,
+  user session, or agent task ends.
+- Use role-table and filter-list rows to make CaumeDSE enforce the same narrow
+  permissions that the broker checks before forwarding.

--- a/samples/delegated-token-broker/delegated_token_broker.py
+++ b/samples/delegated-token-broker/delegated_token_broker.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+Delegated scoped-token broker sample for CaumeDSE.
+
+CaumeDSE does not validate bearer tokens internally. This sample shows the
+external-manager pattern: validate an opaque short-lived token in the broker,
+then forward the request to CaumeDSE with broker-held delegated credentials.
+"""
+
+import argparse
+import base64
+import fnmatch
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+DEFAULT_TOKEN_TTL = 900
+DEFAULT_REVOKED_STORE = Path("/tmp/caumedse-delegated-revoked.json")
+READ_ONLY_SCOPES = (
+    "agentCapabilities:read",
+    "documentTypes:read",
+    "documents:read",
+    "contentRows:read",
+    "contentColumns:read",
+    "dbBrowse:read",
+    "parserScripts:run",
+)
+
+
+class BrokerError(Exception):
+    pass
+
+
+class Config:
+    def __init__(self, args):
+        run_id = os.environ.get("CDSE_BROKER_RUN_ID") or str(int(time.time()))
+        self.base_url = os.environ.get("CDSE_BROKER_BASE_URL", "http://localhost:18080").rstrip("/")
+        self.admin_org = os.environ.get("CDSE_BROKER_ADMIN_ORG", f"BrokerAdminOrg{run_id}")
+        self.admin_user = os.environ.get("CDSE_BROKER_ADMIN_USER", f"BrokerAdminUser{run_id}")
+        self.admin_key = os.environ.get("CDSE_BROKER_ADMIN_ORG_KEY")
+        self.delegated_org = os.environ.get("CDSE_BROKER_DELEGATED_ORG", self.admin_org)
+        self.delegated_user = os.environ.get("CDSE_BROKER_DELEGATED_USER", f"BrokerAgentUser{run_id}")
+        self.delegated_key = os.environ.get("CDSE_BROKER_DELEGATED_ORG_KEY", self.admin_key)
+        self.storage = os.environ.get("CDSE_BROKER_STORAGE", f"BrokerAgentStorage{run_id}")
+        self.storage_path = os.environ.get("CDSE_BROKER_STORAGE_PATH", f"/tmp/caumedse-broker-storage-{run_id}")
+        self.signing_secret = os.environ.get("CDSE_BROKER_SIGNING_SECRET")
+        self.revoked_store = Path(os.environ.get("CDSE_BROKER_REVOKED_STORE", str(DEFAULT_REVOKED_STORE)))
+        self.ca_cert = os.environ.get("CDSE_BROKER_CA_CERT")
+        self.client_cert = os.environ.get("CDSE_BROKER_CLIENT_CERT")
+        self.client_key = os.environ.get("CDSE_BROKER_CLIENT_KEY")
+        self.now = args.now or int(time.time())
+
+    def require_signing_secret(self):
+        if not self.signing_secret:
+            raise SystemExit("Set CDSE_BROKER_SIGNING_SECRET before minting or validating tokens.")
+
+    def require_admin_credentials(self):
+        if not self.admin_key:
+            raise SystemExit("Set CDSE_BROKER_ADMIN_ORG_KEY before provisioning delegated CaumeDSE resources.")
+
+    def admin_auth(self):
+        return {
+            "userId": self.admin_user,
+            "orgId": self.admin_org,
+            "orgKey": self.admin_key,
+            "newOrgKey": self.admin_key,
+        }
+
+    def delegated_auth(self):
+        return {
+            "userId": self.delegated_user,
+            "orgId": self.delegated_org,
+            "orgKey": self.delegated_key,
+        }
+
+
+def b64url_encode(data):
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def b64url_decode(text):
+    padding = "=" * ((4 - len(text) % 4) % 4)
+    return base64.urlsafe_b64decode((text + padding).encode("ascii"))
+
+
+def sign_payload(payload, secret):
+    return hmac.new(secret.encode("utf-8"), payload.encode("ascii"), hashlib.sha256).digest()
+
+
+def mint_token(cfg, subject, scopes, ttl):
+    issued_at = cfg.now
+    claims = {
+        "iss": "caumedse-delegated-token-broker-sample",
+        "sub": subject,
+        "iat": issued_at,
+        "exp": issued_at + ttl,
+        "jti": secrets.token_urlsafe(16),
+        "scope": sorted(set(scopes)),
+        "cdse": {
+            "orgId": cfg.delegated_org,
+            "userId": cfg.delegated_user,
+        },
+    }
+    payload = b64url_encode(json.dumps(claims, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    signature = b64url_encode(sign_payload(payload, cfg.signing_secret))
+    return f"{payload}.{signature}"
+
+
+def load_revoked(path):
+    if not path.exists():
+        return set()
+    return set(json.loads(path.read_text(encoding="utf-8")))
+
+
+def save_revoked(path, revoked):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sorted(revoked), indent=2) + "\n", encoding="utf-8")
+    os.chmod(path, 0o600)
+
+
+def verify_token(cfg, token, required_scope):
+    try:
+        payload, signature = token.split(".", 1)
+        expected = b64url_encode(sign_payload(payload, cfg.signing_secret))
+        if not hmac.compare_digest(signature, expected):
+            raise BrokerError("bad signature")
+        claims = json.loads(b64url_decode(payload).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise BrokerError("malformed token") from exc
+
+    if int(claims.get("exp", 0)) <= cfg.now:
+        raise BrokerError("expired token")
+    if claims.get("jti") in load_revoked(cfg.revoked_store):
+        raise BrokerError("revoked token")
+    scopes = claims.get("scope", [])
+    if required_scope != "*" and not any(fnmatch.fnmatchcase(required_scope, scope) for scope in scopes):
+        raise BrokerError(f"missing scope: {required_scope}")
+    cdse = claims.get("cdse", {})
+    if cdse.get("orgId") != cfg.delegated_org or cdse.get("userId") != cfg.delegated_user:
+        raise BrokerError("token is not bound to the configured delegated CaumeDSE user")
+    return claims
+
+
+def revoke_token(cfg, token):
+    claims = verify_token(cfg, token, "*")
+    revoked = load_revoked(cfg.revoked_store)
+    revoked.add(claims["jti"])
+    save_revoked(cfg.revoked_store, revoked)
+    return claims["jti"]
+
+
+def ssl_context(cfg):
+    if not cfg.base_url.startswith("https://"):
+        return None
+    context = ssl.create_default_context(cafile=cfg.ca_cert) if cfg.ca_cert else ssl.create_default_context()
+    if cfg.client_cert and cfg.client_key:
+        context.load_cert_chain(cfg.client_cert, cfg.client_key)
+    return context
+
+
+def encode_query(params):
+    return urllib.parse.urlencode(params, doseq=True, safe="*[]")
+
+
+def build_url(cfg, path, params=None):
+    query = encode_query(params or {})
+    url = f"{cfg.base_url}{path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+def redact_url(url):
+    parsed = urllib.parse.urlsplit(url)
+    pairs = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    redacted = []
+    for key, value in pairs:
+        if key in {"orgKey", "newOrgKey", "*accessPassword", "*oauthConsumerSecret"}:
+            value = "<redacted>"
+        redacted.append((key, value))
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(redacted), parsed.fragment)
+    )
+
+
+def request(cfg, method, path, params=None, expected=(200,)):
+    url = build_url(cfg, path, params)
+    print(f"{method:<6} {redact_url(url)}", file=sys.stderr)
+    req = urllib.request.Request(url, method=method)
+    try:
+        with urllib.request.urlopen(req, context=ssl_context(cfg), timeout=30) as response:
+            payload = response.read()
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        payload = exc.read()
+        status = exc.code
+    if status not in expected:
+        text = payload.decode("utf-8", errors="replace")
+        raise BrokerError(f"{method} {path} returned {status}, expected {expected}: {text[:500]}")
+    return status, payload
+
+
+def provision_read_only_scope(cfg):
+    cfg.require_admin_credentials()
+    Path(cfg.storage_path).mkdir(parents=True, exist_ok=True)
+    auth = cfg.admin_auth()
+    request(
+        cfg,
+        "POST",
+        f"/organizations/{urllib.parse.quote(cfg.admin_org)}",
+        {
+            **auth,
+            "*resourceInfo": "delegated token broker manager organization",
+            "*certificate": "undefined",
+            "*publicKey": "undefined",
+        },
+        expected=(201, 409),
+    )
+    request(
+        cfg,
+        "POST",
+        f"/organizations/{urllib.parse.quote(cfg.admin_org)}/storage/{urllib.parse.quote(cfg.storage)}",
+        {
+            **auth,
+            "*resourceInfo": "delegated token broker storage",
+            "*location": "localhost",
+            "*type": "local",
+            "*accessPath": cfg.storage_path,
+            "*accessUser": "undefined",
+            "*accessPassword": "undefined",
+        },
+        expected=(201, 409),
+    )
+    request(
+        cfg,
+        "POST",
+        f"/organizations/{urllib.parse.quote(cfg.delegated_org)}/users/{urllib.parse.quote(cfg.delegated_user)}",
+        {
+            **auth,
+            "*resourceInfo": "short-lived delegated agent user",
+            "*certificate": "undefined",
+            "*publicKey": "undefined",
+            "*basicAuthPwdHash": "undefined",
+            "*oauthConsumerKey": "external-broker",
+            "*oauthConsumerSecret": "undefined",
+        },
+        expected=(201, 409),
+    )
+    for table in ("documentTypes", "documents", "data", "meta"):
+        request(
+            cfg,
+            "POST",
+            (
+                f"/organizations/{urllib.parse.quote(cfg.delegated_org)}"
+                f"/users/{urllib.parse.quote(cfg.delegated_user)}/roleTables/{urllib.parse.quote(table)}"
+            ),
+            {
+                **auth,
+                "*_get": "1",
+                "*_post": "0",
+                "*_put": "0",
+                "*_delete": "0",
+                "*_head": "1",
+                "*_options": "1",
+            },
+            expected=(201, 409),
+        )
+    request(
+        cfg,
+        "POST",
+        (
+            f"/organizations/{urllib.parse.quote(cfg.delegated_org)}"
+            f"/users/{urllib.parse.quote(cfg.delegated_user)}/filterWhitelist/{urllib.parse.quote(cfg.delegated_user)}"
+        ),
+        {
+            **auth,
+            "*_get": "1",
+            "*_post": "0",
+            "*_put": "0",
+            "*_delete": "0",
+            "*_head": "1",
+            "*_options": "1",
+        },
+        expected=(201, 409),
+    )
+
+
+def delegated_request_preview(cfg, token, required_scope):
+    claims = verify_token(cfg, token, required_scope)
+    return {
+        "subject": claims["sub"],
+        "scope": required_scope,
+        "expiresAt": claims["exp"],
+        "caumedseAuth": {
+            "userId": cfg.delegated_user,
+            "orgId": cfg.delegated_org,
+            "orgKey": "<held by broker>",
+        },
+    }
+
+
+def run_self_test():
+    old_env = os.environ.copy()
+    try:
+        os.environ["CDSE_BROKER_SIGNING_SECRET"] = "self-test-secret"
+        os.environ["CDSE_BROKER_ADMIN_ORG_KEY"] = "self-test-org-key"
+        os.environ["CDSE_BROKER_REVOKED_STORE"] = "/tmp/caumedse-delegated-token-self-test-revoked.json"
+        cfg = Config(argparse.Namespace(now=1000))
+        if cfg.revoked_store.exists():
+            cfg.revoked_store.unlink()
+        token = mint_token(cfg, "agent-a", ["documents:read", "contentRows:read"], 60)
+        verify_token(cfg, token, "documents:read")
+        try:
+            verify_token(cfg, token, "documents:delete")
+        except BrokerError:
+            pass
+        else:
+            raise AssertionError("write scope was incorrectly allowed")
+        expired_cfg = Config(argparse.Namespace(now=2000))
+        try:
+            verify_token(expired_cfg, token, "documents:read")
+        except BrokerError:
+            pass
+        else:
+            raise AssertionError("expired token was incorrectly allowed")
+        revoke_token(cfg, token)
+        try:
+            verify_token(cfg, token, "documents:read")
+        except BrokerError:
+            pass
+        else:
+            raise AssertionError("revoked token was incorrectly allowed")
+    finally:
+        os.environ.clear()
+        os.environ.update(old_env)
+    print("PASS delegated token broker self-test")
+
+
+def parse_scopes(value):
+    scopes = [scope.strip() for scope in value.split(",") if scope.strip()]
+    if not scopes:
+        raise SystemExit("At least one scope is required.")
+    return scopes
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Mint and validate delegated CaumeDSE agent tokens.")
+    parser.add_argument("--now", type=int, help=argparse.SUPPRESS)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    mint = sub.add_parser("mint", help="Mint a short-lived opaque token.")
+    mint.add_argument("--subject", required=True)
+    mint.add_argument("--scopes", default=",".join(READ_ONLY_SCOPES))
+    mint.add_argument("--ttl", type=int, default=DEFAULT_TOKEN_TTL)
+
+    check = sub.add_parser("authorize", help="Validate a token for one requested scope.")
+    check.add_argument("--token", required=True)
+    check.add_argument("--scope", required=True)
+
+    revoke = sub.add_parser("revoke", help="Revoke a token by jti.")
+    revoke.add_argument("--token", required=True)
+
+    sub.add_parser("provision-readonly", help="Create a delegated read-only CaumeDSE user and role/filter rows.")
+    sub.add_parser("self-test", help="Run offline allow, deny, expiry, and revocation checks.")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    if args.command == "self-test":
+        run_self_test()
+        return 0
+
+    cfg = Config(args)
+    cfg.require_signing_secret()
+    if args.command == "mint":
+        print(mint_token(cfg, args.subject, parse_scopes(args.scopes), args.ttl))
+    elif args.command == "authorize":
+        print(json.dumps(delegated_request_preview(cfg, args.token, args.scope), indent=2, sort_keys=True))
+    elif args.command == "revoke":
+        print(revoke_token(cfg, args.token))
+    elif args.command == "provision-readonly":
+        provision_read_only_scope(cfg)
+        print("Provisioned delegated read-only scope.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/mcp-server/README.md
+++ b/samples/mcp-server/README.md
@@ -92,6 +92,9 @@ A typical local flow is:
 
 - Do not pass `orgKey`, `newOrgKey`, TLS keys, or certificate material through
   tool arguments. Use environment variables controlled by the host process.
+- For repeated agent sessions, put a delegated-token broker in front of the MCP
+  server so each tool call is authorized by a short-lived scoped token before
+  the server forwards broker-held CaumeDSE credentials.
 - Do not expose this prototype directly to untrusted clients. Put any
   production MCP bridge behind authentication, authorization, audit logging,
   rate limits, and route-level allow lists.
@@ -120,3 +123,5 @@ printf '%s\n' \
 ```
 
 Use `CDSE_VERIFY_REDACT=1` when sharing logs from live verifier runs.
+
+See `../delegated-token-broker/` for the delegated scoped-token sample.

--- a/samples/mcp-server/README.md
+++ b/samples/mcp-server/README.md
@@ -9,6 +9,7 @@ environment variables and are never part of MCP tool arguments or tool results.
 
 ## Tools
 
+- `get_agent_capabilities`: reads the public `/agentCapabilities` manifest.
 - `create_workspace`: creates the configured disposable organization, storage,
   and user.
 - `list_document_types`: lists document types in the configured storage.
@@ -76,13 +77,16 @@ Configure an MCP client to launch the stdio server:
 
 A typical local flow is:
 
-1. `create_workspace`
-2. `upload_csv`
-3. `upload_parser`
-4. `list_document_types`
-5. `query_column`
-6. `run_parser`
-7. `cleanup_workspace`
+1. Read `GET /agentCapabilities` from `CDSE_MCP_BASE_URL` so the host can
+   confirm supported routes, JSON preference, and parser policy before
+   exposing tools.
+2. `create_workspace`
+3. `upload_csv`
+4. `upload_parser`
+5. `list_document_types`
+6. `query_column`
+7. `run_parser`
+8. `cleanup_workspace`
 
 ## Security Boundaries
 

--- a/samples/mcp-server/caumedse_mcp_server.py
+++ b/samples/mcp-server/caumedse_mcp_server.py
@@ -155,6 +155,11 @@ def resolve_file(path_value, default_path):
     return path
 
 
+def get_agent_capabilities(cfg, _args):
+    _, _, payload = request(cfg, "GET", "/agentCapabilities")
+    return json.loads(payload.decode("utf-8"))
+
+
 def clamp_limit(value, default=3, maximum=10):
     try:
         parsed = int(value)
@@ -306,6 +311,7 @@ def cleanup_workspace(cfg, args):
 
 
 TOOLS = {
+    "get_agent_capabilities": get_agent_capabilities,
     "create_workspace": create_workspace,
     "list_document_types": list_document_types,
     "upload_csv": upload_csv,
@@ -317,6 +323,11 @@ TOOLS = {
 
 
 TOOL_SCHEMAS = [
+    {
+        "name": "get_agent_capabilities",
+        "description": "Read the public CaumeDSE AI-agent capability manifest without credentials.",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
     {
         "name": "create_workspace",
         "description": "Create the configured disposable organization, storage, and user.",

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -47,6 +47,7 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #if defined(__unix__) || defined(__APPLE__)
 #include <sys/resource.h>
 #endif
@@ -60,6 +61,141 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 #define cmeWSLogMaxValueLen 512
 #define cmeWSLogRedactedValue "<redacted>"
 #define cmeWSLogTruncatedMarker "...<truncated>"
+
+static void cmeWebServiceGenerateRequestId(char **requestId)
+{
+    struct timespec ts;
+    char *rndHex=NULL;
+
+    if (!requestId)
+    {
+        return;
+    }
+    clock_gettime(CLOCK_REALTIME,&ts);
+    if (!cmeGetRndSaltAnySize(&rndHex,8))
+    {
+        cmeStrConstrAppend(requestId,"cdse-%lld-%ld-%s",
+                           (long long)ts.tv_sec,ts.tv_nsec,rndHex);
+        cmeFree(rndHex);
+        return;
+    }
+    cmeStrConstrAppend(requestId,"cdse-%lld-%ld", (long long)ts.tv_sec,ts.tv_nsec);
+}
+
+static int cmeWebServiceSetResponseHeader(char ***responseHeaders,
+                                          const char *name, const char *value)
+{
+    int cont;
+
+    if ((!responseHeaders)||(!(*responseHeaders))||(!name)||(!value))
+    {
+        return(1);
+    }
+    for (cont=0;cont<(cmeWSHTTPMaxResponseHeaders*2);cont+=2)
+    {
+        if ((*responseHeaders)[cont]&&(!strcasecmp((*responseHeaders)[cont],name)))
+        {
+            cmeFree((*responseHeaders)[cont+1]);
+            (*responseHeaders)[cont+1]=NULL;
+            cmeStrConstrAppend(&((*responseHeaders)[cont+1]),"%s",value);
+            return(0);
+        }
+        if (!(*responseHeaders)[cont])
+        {
+            cmeStrConstrAppend(&((*responseHeaders)[cont]),"%s",name);
+            cmeStrConstrAppend(&((*responseHeaders)[cont+1]),"%s",value);
+            return(0);
+        }
+    }
+    return(2);
+}
+
+static int cmeWebServiceRequestWantsJSON(const char **argumentElements)
+{
+    const char *outputType=NULL;
+
+    return((argumentElements)&&
+           (!cmeFindInArgPairList(argumentElements,"outputType",&outputType))&&
+           outputType&&(!strcmp(outputType,"json")));
+}
+
+static const char *cmeWebServiceErrorCodeForStatus(int responseCode)
+{
+    switch (responseCode)
+    {
+        case 400:
+            return("bad_request");
+        case 401:
+            return("authentication_required");
+        case 403:
+            return("forbidden");
+        case 404:
+            return("not_found");
+        case 405:
+            return("method_not_allowed");
+        case 409:
+            return("conflict");
+        case 501:
+            return("not_implemented");
+        default:
+            if (responseCode>=500)
+            {
+                return("internal_error");
+            }
+            return("request_failed");
+    }
+}
+
+static const char *cmeWebServiceErrorMessageForStatus(int responseCode)
+{
+    switch (responseCode)
+    {
+        case 400:
+            return("The request is invalid.");
+        case 401:
+            return("Authentication is required.");
+        case 403:
+            return("The request is forbidden.");
+        case 404:
+            return("The requested resource was not found.");
+        case 405:
+            return("The HTTP method is not allowed for this resource.");
+        case 409:
+            return("The request conflicts with the current resource state or required arguments.");
+        case 501:
+            return("The requested functionality is not implemented.");
+        default:
+            if (responseCode>=500)
+            {
+                return("An internal server error occurred.");
+            }
+            return("The request failed.");
+    }
+}
+
+static int cmeWebServiceApplyJSONErrorEnvelope(char **responseText,
+                                               char ***responseHeaders,
+                                               int responseCode,
+                                               const char *requestId)
+{
+    char *jsonError=NULL;
+
+    if ((!responseText)||(responseCode<400))
+    {
+        return(0);
+    }
+    cmeStrConstrAppend(&jsonError,
+                       "{\"error\":{\"code\":\"%s\",\"message\":\"%s\",\"httpStatus\":%d,"
+                       "\"requestId\":\"%s\",\"safeForAgent\":true}}",
+                       cmeWebServiceErrorCodeForStatus(responseCode),
+                       cmeWebServiceErrorMessageForStatus(responseCode),
+                       responseCode,
+                       requestId?requestId:"");
+    cmeFree(*responseText);
+    *responseText=jsonError;
+    cmeWebServiceSetResponseHeader(responseHeaders,"Content-Type","application/json");
+    return(0);
+}
 
 static int cmeWebServiceLogIsSensitiveField(const char *name)
 {
@@ -299,6 +435,8 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
         }
         con_info->answerString=NULL;
         con_info->answerCode=0;
+        con_info->requestId=NULL;
+        cmeWebServiceGenerateRequestId(&(con_info->requestId));
         con_info->filePointer=NULL;
         con_info->fileName=NULL;
         con_info->connectionType=0;
@@ -401,6 +539,11 @@ int cmeWebServiceAnswerConnection (void *cls, struct MHD_Connection *connection,
                                         url,(const char **)urlElements,numUrlElements,
                                         (const char **)headerElements,(const char **)argumentElements,method,connection);
     con_info->answerCode=responseCode;
+    cmeWebServiceSetResponseHeader(&responseHeaders,"X-Request-Id",con_info->requestId?con_info->requestId:"");
+    if (strcmp(method,"HEAD")&&cmeWebServiceRequestWantsJSON((const char **)argumentElements))
+    {
+        cmeWebServiceApplyJSONErrorEnvelope(&responseText,&responseHeaders,responseCode,con_info->requestId);
+    }
     if (responseFilePath) //We have a response File.
     {
         cr_info=(struct cmeWebServiceContentReaderStruct *) malloc (sizeof (struct cmeWebServiceContentReaderStruct)); //Create structure to pass among ContentReader iterations.
@@ -9056,6 +9199,7 @@ void cmeWebServiceRequestCompleted (void *cls, struct MHD_Connection *connection
         }
     }
     cmeFree(con_info->answerString);
+    cmeFree(con_info->requestId);
     pthread_cond_destroy(&(con_info->threadStatusCond));
     pthread_mutex_destroy(&(con_info->threadStatusMutex));
     cmeFree(con_info);

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -1775,6 +1775,9 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
     char *orgKey=NULL;
     char *newOrgKey=NULL;
     char *storagePath=NULL;
+    char agentIsolationProfile[128];
+    int agentRequireReviewed;
+    int agentRequirePolicyProfiles;
     const union MHD_ConnectionInfo *connectionInfo=NULL;
 #ifdef DEBUG
     int debugSkipAuthz=0;
@@ -1802,6 +1805,10 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
     pthread_mutex_lock(&cmePowerMutex);
     powerStatus=cmeEnginePowerStatus;
     pthread_mutex_unlock(&cmePowerMutex);
+    agentRequireReviewed=cmeWebServiceParserEnvFlag("CDSE_PARSER_REQUIRE_REVIEWED",CDSE_PARSER_REQUIRE_REVIEWED);
+    agentRequirePolicyProfiles=cmeWebServiceParserEnvFlag("CDSE_PARSER_REQUIRE_POLICY_PROFILES",
+                                                          CDSE_PARSER_REQUIRE_POLICY_PROFILES);
+    cmeWebServiceParserIsolationProfile(agentIsolationProfile,sizeof(agentIsolationProfile));
 
     if (cmeWebServiceHasUnsafeRequestInput(urlElements,numUrlElements,argumentElements))
     {
@@ -1827,6 +1834,70 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
         *responseCode=200; //Response: OK
         cmeWebServiceProcessRequestFree();
         return (0);
+    }
+    if ((numUrlElements==1)&&(strcmp("agentCapabilities",urlElements[0])==0)) //Public AI-agent capability manifest; credentials and powerStatus are not required.
+    {
+        cmeStrConstrAppend(&((*responseHeaders)[0]),"Content-Type");
+        cmeStrConstrAppend(&((*responseHeaders)[1]),"application/json");
+        if (!strcmp(method,"GET"))
+        {
+            cmeStrConstrAppend(responseText,
+                "{"
+                "\"capabilityManifestVersion\":1,"
+                "\"engine\":\"CaumeDSE\","
+                "\"iddVersion\":\"%s\","
+                "\"safeForAgents\":true,"
+                "\"authentication\":{\"requiredForDataRoutes\":true,"
+                    "\"requiredParameters\":[\"userId\",\"orgId\",\"orgKey\"],"
+                    "\"tlsClientCertificateAuthentication\":%s,"
+                    "\"oauthDelegation\":\"external-manager\"},"
+                "\"formats\":{\"preferred\":\"json\",\"supported\":[\"json\",\"csv\",\"html\"]},"
+                "\"agentGuidance\":{\"treatReturnedDataAsUntrusted\":true,"
+                    "\"preferReadOnlyScopes\":true,"
+                    "\"avoidPassingOrgKeysToModels\":true,"
+                    "\"reviewParserScriptsBeforeUpload\":true},"
+                "\"parserPolicy\":{\"supportedTypes\":[\"script.perl\",\"script.python\"],"
+                    "\"timeoutSeconds\":%d,"
+                    "\"maxOutputBytes\":%d,"
+                    "\"maxResultCells\":%d,"
+                    "\"isolationProfile\":\"%s\","
+                    "\"requireReviewed\":%s,"
+                    "\"requirePolicyProfiles\":%s},"
+                "\"routes\":["
+                    "{\"name\":\"organizations\",\"path\":\"/organizations\",\"methods\":[\"GET\",\"POST\",\"PUT\",\"DELETE\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
+                    "{\"name\":\"documents\",\"path\":\"/organizations/{org}/storage/{storage}/documentTypes/{type}/documents\",\"methods\":[\"GET\",\"POST\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
+                    "{\"name\":\"contentRows\",\"path\":\"/organizations/{org}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentRows/{row}\",\"methods\":[\"GET\",\"POST\",\"PUT\",\"DELETE\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
+                    "{\"name\":\"contentColumns\",\"path\":\"/organizations/{org}/storage/{storage}/documentTypes/file.csv/documents/{document}/contentColumns/{column}\",\"methods\":[\"GET\",\"POST\",\"PUT\",\"DELETE\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
+                    "{\"name\":\"parserScripts\",\"path\":\"/organizations/{org}/storage/{storage}/documentTypes/file.csv/documents/{document}/parserScripts/{script}\",\"methods\":[\"GET\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
+                    "{\"name\":\"dbBrowsing\",\"path\":\"/organizations/{org}/storage/{storage}/dbNames/{db}/dbTables/{table}\",\"methods\":[\"GET\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true}"
+                "],"
+                "\"docs\":[\"README.md\",\"AI_USAGE.md\",\"API_EXAMPLES.md\",\"openapi.yaml\",\"samples/ai-agent/\",\"samples/mcp-server/\"]"
+                "}",
+                cmeInternalDBDefinitionsVersion,
+                cmeUseTLSAuthentication ? "true" : "false",
+                CDSE_PARSER_SCRIPT_TIMEOUT_SECONDS,
+                CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES,
+                CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS,
+                agentIsolationProfile,
+                agentRequireReviewed ? "true" : "false",
+                agentRequirePolicyProfiles ? "true" : "false");
+            *responseCode=200;
+            cmeWebServiceProcessRequestFree();
+            return(0);
+        }
+        if (!strcmp(method,"OPTIONS"))
+        {
+            cmeStrConstrAppend(responseText,
+                "{\"methods\":[\"GET\",\"OPTIONS\"],\"contentType\":\"application/json\"}");
+            *responseCode=200;
+            cmeWebServiceProcessRequestFree();
+            return(0);
+        }
+        cmeStrConstrAppend(responseText,
+            "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Only GET and OPTIONS are supported for agentCapabilities.\"}}");
+        *responseCode=405;
+        cmeWebServiceProcessRequestFree();
+        return(1);
     }
     if (numUrlElements==0) //Error; depth does not match a valid value
     {

--- a/webservice_interface.h
+++ b/webservice_interface.h
@@ -57,6 +57,7 @@ struct cmeWebServiceConnectionInfoStruct
     char **postArglist;        //Note: this will be dynamically allocated! cmeWebServicePOSTIterationCompleted must free it.
     int postArgCont;
     int answerCode;
+    char *requestId;           //Per-connection request correlation id, returned in X-Request-Id and LogsDB response headers.
     int threadStatus;          //signal to the thread that it is ok to clean stuff here. 0=in progress, 1=thread done,waiting, 2=thread done, closing.
     pthread_mutex_t threadStatusMutex;
     pthread_cond_t threadStatusCond;


### PR DESCRIPTION
## Summary

- Add a delegated scoped-token broker sample for AI-agent workflows, including offline scope, expiry, and revocation checks.
- Add per-request `X-Request-Id` response headers and JSON error envelopes for common failures when `outputType=json` is requested.
- Extend live verifier coverage and document the new agent-facing contracts in README, AI usage, API examples, TODO, and OpenAPI.

## Security impact

- Keeps CaumeDSE organization keys out of agent prompts by documenting and sampling an external broker pattern.
- Makes API failures parseable by agents without exposing sensitive details, while preserving request correlation through LogsDB response headers.
- Avoids pointer/address exposure in request IDs by using timestamp plus random hex.

## Validation

- `python3 -m py_compile samples/delegated-token-broker/delegated_token_broker.py`
- `python3 samples/delegated-token-broker/delegated_token_broker.py self-test`
- `bash -n TEST/run_debug_components.sh`
- `TEST/validate_openapi_routes.sh`
- `make` after clean rebuild
- `CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke` passed with `107 passed, 0 failed, 1 skipped`

## Notes

Local `gh auth status` reports an invalid token for account `omarherrera`, so this PR was opened through the GitHub connector after `git push origin devtest` succeeded.