### PR TITLE
Add structured agent audit events

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -171,6 +171,18 @@ parameters, and generated certificate/key paths in retained verifier artifacts.
 It preserves status codes, markers, elapsed times, and artifact names so
 failures remain diagnosable.
 
+CaumeDSE DEBUG service logs also include structured audit lines prefixed with
+`CaumeDSE AuditJSON: `. Version 1 events cover `auth`, `authorization`,
+`request`, `parserPolicy`, `parserUpload`, `parserExecution`, and `cleanup`
+categories. The JSON fields are limited to identifiers, routes, decisions,
+status/result codes, and parser metadata labels; org keys, authorization
+headers, script bodies, and CSV content are not emitted. For a bounded local
+summary, run:
+
+```sh
+python3 samples/ai-agent/recent_audit_reader.py /tmp/cdse-debug-components-*/live_http_service.log --limit 20
+```
+
 ## Anti-Patterns
 
 Do not:

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -332,3 +332,9 @@ when saving verifier artifacts in CI or AI-assisted debugging sessions; this
 masks organization keys, `newOrgKey` values, selected credential-style request
 parameters, and generated certificate/key paths in summaries and live request
 artifacts.
+
+DEBUG service logs emit machine-readable audit entries prefixed with
+`CaumeDSE AuditJSON: `. Use
+`samples/ai-agent/recent_audit_reader.py` to parse recent version 1 events for
+auth, authorization, request, parser policy, parser execution, and cleanup
+review without scraping the older text diagnostics.

--- a/README.md
+++ b/README.md
@@ -1863,8 +1863,11 @@ This is a raw file
     `CDSE_PARSER_REQUIRE_POLICY_PROFILES=1`, and
     `CDSE_PARSER_ALLOWED_TYPES=script.perl,script.python`. Parser upload,
     policy allow/deny, execution success, timeout, limit rejection, and
-    cleanup-failure events are written as structured audit log lines without org
-    keys, script bodies, or CSV content.
+    cleanup-failure events are written as `CaumeDSE AuditJSON: ` structured
+    audit lines without org keys, authorization headers, script bodies, or CSV
+    content. Version 1 audit categories include `auth`, `authorization`,
+    `request`, `parserPolicy`, `parserUpload`, `parserExecution`, and
+    `cleanup`.
 
     In AI-assisted workflows, treat CSV contents and parser output as
     untrusted data. CSV cells can contain prompt-injection text that asks an

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -634,6 +634,69 @@ PY
     fi
 }
 
+check_live_structured_audit_redaction() {
+    local protocol="$1"
+    local service_log="$2"
+    local org_key="$3"
+    local audit_log="$LOG_ROOT/live_${protocol}_structured_audit.log"
+
+    : > "$audit_log"
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        record_skip "live_${protocol}_structured_audit_redaction" "python3 is required to inspect structured audit JSON"
+        return
+    fi
+    if ! python3 "$ROOT_DIR/samples/ai-agent/recent_audit_reader.py" "$service_log" --limit 5 >> "$audit_log" 2>&1; then
+        redact_file_in_place "$audit_log"
+        record_fail "live_${protocol}_structured_audit_redaction" "sample audit reader failed log=$audit_log"
+        return
+    fi
+    if ! python3 - "$service_log" "$org_key" >> "$audit_log" 2>&1 <<'PY'
+import json
+import sys
+
+prefix = "CaumeDSE AuditJSON: "
+service_log, org_key = sys.argv[1], sys.argv[2]
+required = {"auth", "authorization", "request", "parserPolicy", "parserUpload", "parserExecution"}
+seen = set()
+count = 0
+with open(service_log, "r", encoding="utf-8", errors="replace") as handle:
+    for line in handle:
+        if prefix not in line:
+            continue
+        payload = line.split(prefix, 1)[1].strip()
+        if not payload.startswith("{"):
+            continue
+        event, _ = json.JSONDecoder().raw_decode(payload)
+        if not isinstance(event, dict):
+            continue
+        count += 1
+        if event.get("auditSchemaVersion") != 1:
+            raise SystemExit("unexpected audit schema version")
+        if event.get("safeForAgent") is not True:
+            raise SystemExit("audit event is not marked safeForAgent")
+        seen.add(event.get("category"))
+        serialized = json.dumps(event, sort_keys=True)
+        for marker in (org_key, "Authorization:", "Bearer "):
+            if marker and marker in serialized:
+                raise SystemExit(f"structured audit leaked marker: {marker}")
+if count == 0:
+    raise SystemExit("no structured audit events found")
+missing = sorted(required - seen)
+if missing:
+    raise SystemExit("missing structured audit categories: " + ",".join(missing))
+print(f"structured audit events={count} categories={','.join(sorted(str(x) for x in seen if x))}")
+PY
+    then
+        redact_file_in_place "$audit_log"
+        record_fail "live_${protocol}_structured_audit_redaction" "structured audit JSON validation failed log=$audit_log"
+        return
+    fi
+
+    record_pass "live_${protocol}_structured_audit_redaction"
+    rm -f "$audit_log"
+}
+
 stop_live_service() {
     local pid="$1"
 
@@ -1030,6 +1093,7 @@ run_live_web_flow() {
     stop_live_service "$service_pid"
     check_live_debug_secret_redaction "$protocol" "$service_log" "$org_key"
     check_live_transaction_log_redaction "$protocol" "$org_key" "$long_query_value"
+    check_live_structured_audit_redaction "$protocol" "$service_log" "$org_key"
     redact_file_in_place "$service_log"
     if [ "$protocol" = "http" ]; then
         if grep -Fq "HTTP TLS authentication bypass active for DEBUG/test profile only." "$service_log" &&

--- a/TODO.md
+++ b/TODO.md
@@ -658,13 +658,13 @@
     - Batch 2: added static checks and sample-row preview execution for parser candidates.
     - Batch 3: added live verifier coverage for pending deny, reviewed allow, and preview-only execution.
 
-- [ ] #88 Add structured JSON audit logs for agent activity.
+- [x] #88 Add structured JSON audit logs for agent activity.
   - Source: transaction logging, parser audit lines, docs.
   - Goal: make agent actions, policy decisions, and parser execution reviewable by machines without scraping text logs.
-  - Plan:
-    - Batch 1: define JSON audit event schemas for auth, authorization, parser policy, parser execution, and cleanup.
-    - Batch 2: emit structured audit events alongside existing text diagnostics.
-    - Batch 3: add an agent-readable recent-audit sample and verifier checks for redaction.
+  - Done:
+    - Batch 1: defined JSON audit event schemas for auth, authorization, request, parser policy, parser upload/execution, and cleanup.
+    - Batch 2: emitted structured `CaumeDSE AuditJSON: ` events alongside existing text diagnostics without changing LogsDB storage.
+    - Batch 3: added an agent-readable recent-audit sample and live verifier checks for JSON parsing, required categories, and redaction.
 
 - [ ] #89 Promote the MCP prototype into a supported read-only tool surface.
   - Source: `samples/mcp-server/`, `AI_USAGE.md`, live verifier.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,9 +38,9 @@ paths:
       summary: Return a public machine-readable manifest for AI agents and MCP clients.
       description: |
         Describes safe automation guidance, supported auth modes, preferred
-        response formats, parser policy settings, documentation links, and core
-        data routes. This route is intentionally public and does not expose
-        organization data or secrets.
+        response formats, parser policy settings, structured audit metadata,
+        documentation links, and core data routes. This route is intentionally
+        public and does not expose organization data or secrets.
       responses:
         "200":
           description: JSON capability manifest.
@@ -65,6 +65,11 @@ paths:
                     type: object
                   parserPolicy:
                     type: object
+                  structuredAudit:
+                    type: object
+                    description: |
+                      Versioned JSON audit line metadata. Service logs prefix
+                      each structured event with `CaumeDSE AuditJSON: `.
                   routes:
                     type: array
                     items:
@@ -1713,6 +1718,9 @@ components:
               type: integer
         parserPolicy:
           type: object
+        structuredAudit:
+          type: object
+          description: Versioned JSON audit line metadata for service logs.
     DocumentUpload:
       type: object
       required: [file, userId, orgId, orgKey]

--- a/samples/ai-agent/README.md
+++ b/samples/ai-agent/README.md
@@ -72,6 +72,14 @@ The workflow:
 8. Runs the reviewed parser with `outputType=json`.
 9. Deletes temporary documents and user/role/filter resources.
 
+Structured audit lines are emitted in service logs with the
+`CaumeDSE AuditJSON: ` prefix. To summarize recent agent-safe events from a
+local verifier service log:
+
+```sh
+python3 samples/ai-agent/recent_audit_reader.py /tmp/cdse-debug-components-*/live_http_service.log --limit 10
+```
+
 Use `--keep-resources` only when debugging cleanup behavior:
 
 ```sh

--- a/samples/ai-agent/recent_audit_reader.py
+++ b/samples/ai-agent/recent_audit_reader.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Read recent CaumeDSE AuditJSON lines from a local service log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+
+PREFIX = "CaumeDSE AuditJSON: "
+SECRET_MARKERS = ("Authorization:", "Bearer ")
+
+
+def iter_audit_events(path: Path) -> Iterable[dict]:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if PREFIX not in line:
+                continue
+            payload = line.split(PREFIX, 1)[1].strip()
+            if not payload.startswith("{"):
+                continue
+            try:
+                event, _ = json.JSONDecoder().raw_decode(payload)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if event.get("auditSchemaVersion") == 1 and event.get("safeForAgent") is True:
+                yield event
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize recent CaumeDSE structured audit events.")
+    parser.add_argument("log", type=Path, help="CaumeDSE service log containing AuditJSON lines.")
+    parser.add_argument("--limit", type=int, default=20, help="Maximum events to return.")
+    args = parser.parse_args()
+
+    events = list(iter_audit_events(args.log))[-max(1, args.limit):]
+    combined = json.dumps(events, sort_keys=True)
+    if any(marker in combined for marker in SECRET_MARKERS):
+        raise SystemExit("refusing to print audit events that appear to contain credential markers")
+
+    categories = Counter(str(event.get("category", "unknown")) for event in events)
+    print(json.dumps(
+        {
+            "source": str(args.log),
+            "returnedEvents": len(events),
+            "categories": dict(sorted(categories.items())),
+            "events": events,
+        },
+        indent=2,
+        sort_keys=True,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -287,6 +287,109 @@ static void cmeWebServiceAppendJSONStringValue(char **dst, const char *src)
     cmeStrConstrAppend(dst,"\"");
 }
 
+static void cmeWebServiceAuditJSON(const char *category, const char *event, const char *outcome,
+                                   const char *reason, int result, const char *requestId,
+                                   const char *userId, const char *orgId, const char *storageId,
+                                   const char *documentId, const char *scriptId, const char *scriptType,
+                                   const char *method, const char *route, const char *authenticated,
+                                   const char *responseCode, int previewOnly)
+{
+#ifdef ERROR_LOG
+    char *jsonLine=NULL;
+
+    cmeStrConstrAppend(&jsonLine,"{\"auditSchemaVersion\":1,\"safeForAgent\":true,\"timestamp\":%lld",
+                       (long long)time(NULL));
+    cmeStrConstrAppend(&jsonLine,",\"category\":");
+    cmeWebServiceAppendJSONStringValue(&jsonLine,category?category:"unknown");
+    cmeStrConstrAppend(&jsonLine,",\"event\":");
+    cmeWebServiceAppendJSONStringValue(&jsonLine,event?event:"unknown");
+    cmeStrConstrAppend(&jsonLine,",\"outcome\":");
+    cmeWebServiceAppendJSONStringValue(&jsonLine,outcome?outcome:"unknown");
+    if (reason)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"reason\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,reason);
+    }
+    cmeStrConstrAppend(&jsonLine,",\"result\":%d",result);
+    if (requestId)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"requestId\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,requestId);
+    }
+    if (userId)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"userId\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,userId);
+    }
+    if (orgId)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"orgId\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,orgId);
+    }
+    if (storageId)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"storageId\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,storageId);
+    }
+    if (documentId)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"documentId\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,documentId);
+    }
+    if (scriptId)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"scriptId\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,scriptId);
+    }
+    if (scriptType)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"scriptType\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,scriptType);
+    }
+    if (method)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"method\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,method);
+    }
+    if (route)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"route\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,route);
+    }
+    if (authenticated)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"authenticated\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,authenticated);
+    }
+    if (responseCode)
+    {
+        cmeStrConstrAppend(&jsonLine,",\"responseCode\":");
+        cmeWebServiceAppendJSONStringValue(&jsonLine,responseCode);
+    }
+    cmeStrConstrAppend(&jsonLine,",\"previewOnly\":%s}",previewOnly?"true":"false");
+    fprintf(stderr,"\nCaumeDSE AuditJSON: %s\n",jsonLine?jsonLine:"{}");
+    cmeFree(jsonLine);
+#else
+    (void)category;
+    (void)event;
+    (void)outcome;
+    (void)reason;
+    (void)result;
+    (void)requestId;
+    (void)userId;
+    (void)orgId;
+    (void)storageId;
+    (void)documentId;
+    (void)scriptId;
+    (void)scriptType;
+    (void)method;
+    (void)route;
+    (void)authenticated;
+    (void)responseCode;
+    (void)previewOnly;
+#endif
+}
+
 static int cmeWebServiceLogAppendFieldValue(char **resultStr, const char *name, const char *value)
 {
     if (cmeWebServiceLogIsSensitiveField(name))
@@ -1430,6 +1533,8 @@ static int cmeWebServiceParserPolicyAllows(const char *metadata, const char *scr
         fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=type userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
                 userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
                 scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+        cmeWebServiceAuditJSON("parserPolicy","policy-deny","deny","type",1,NULL,userId,orgId,storageId,
+                               documentId,scriptId,scriptType,method,NULL,NULL,NULL,previewOnly);
 #endif
         return(1);
     }
@@ -1439,6 +1544,8 @@ static int cmeWebServiceParserPolicyAllows(const char *metadata, const char *scr
         fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=pending-review userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
                 userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
                 scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+        cmeWebServiceAuditJSON("parserPolicy","policy-deny","deny","pending-review",4,NULL,userId,orgId,storageId,
+                               documentId,scriptId,scriptType,method,NULL,NULL,NULL,previewOnly);
 #endif
         return(4);
     }
@@ -1448,6 +1555,8 @@ static int cmeWebServiceParserPolicyAllows(const char *metadata, const char *scr
         fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=unreviewed userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
                 userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
                 scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+        cmeWebServiceAuditJSON("parserPolicy","policy-deny","deny","unreviewed",2,NULL,userId,orgId,storageId,
+                               documentId,scriptId,scriptType,method,NULL,NULL,NULL,previewOnly);
 #endif
         return(2);
     }
@@ -1460,6 +1569,8 @@ static int cmeWebServiceParserPolicyAllows(const char *metadata, const char *scr
         fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-deny reason=profile userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s' isolationProfile='%s'\n",
                 userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
                 scriptId?scriptId:"",scriptType?scriptType:"",method?method:"",isolationProfile);
+        cmeWebServiceAuditJSON("parserPolicy","policy-deny","deny","profile",3,NULL,userId,orgId,storageId,
+                               documentId,scriptId,scriptType,method,NULL,NULL,NULL,previewOnly);
 #endif
         return(3);
     }
@@ -1467,6 +1578,8 @@ static int cmeWebServiceParserPolicyAllows(const char *metadata, const char *scr
     fprintf(stderr,"CaumeDSE Audit: parserExecution event=policy-allow userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s' reviewed='%d' isolationProfile='%s'\n",
             userId?userId:"",orgId?orgId:"",storageId?storageId:"",documentId?documentId:"",
             scriptId?scriptId:"",scriptType?scriptType:"",method?method:"",reviewed,isolationProfile);
+    cmeWebServiceAuditJSON("parserPolicy","policy-allow","allow",reviewed?"reviewed":"preview-or-policy",0,NULL,
+                           userId,orgId,storageId,documentId,scriptId,scriptType,method,NULL,NULL,NULL,previewOnly);
 #endif
     return(0);
 }
@@ -1573,9 +1686,30 @@ static void cmeWebServiceParserAuditResult(const char *event, int result, const 
                                            const char *documentId, const char *scriptId, const char *method)
 {
 #ifdef ERROR_LOG
+    const char *category="parserExecution";
+    const char *outcome="error";
+
+    if (event&&strstr(event,"upload"))
+    {
+        category="parserUpload";
+    }
+    else if (event&&strstr(event,"cleanup"))
+    {
+        category="cleanup";
+    }
+    if (event&&((strstr(event,"success"))||(!strcmp(event,"execute-success"))))
+    {
+        outcome="allow";
+    }
+    else if (event&&((strstr(event,"fail"))||(strstr(event,"reject"))||(strstr(event,"timeout"))||(strstr(event,"deny"))))
+    {
+        outcome="deny";
+    }
     fprintf(stderr,"CaumeDSE Audit: parserExecution event=%s result=%d userId='%s' orgId='%s' storageId='%s' documentId='%s' scriptId='%s' scriptType='%s' method='%s'\n",
             event?event:"unknown",result,userId?userId:"",orgId?orgId:"",storageId?storageId:"",
             documentId?documentId:"",scriptId?scriptId:"",scriptType?scriptType:"",method?method:"");
+    cmeWebServiceAuditJSON(category,event?event:"unknown",outcome,NULL,result,NULL,userId,orgId,storageId,
+                           documentId,scriptId,scriptType,method,NULL,NULL,NULL,0);
 #else
     (void)event;
     (void)result;
@@ -2181,6 +2315,15 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
                     "\"isolationProfile\":\"%s\","
                     "\"requireReviewed\":%s,"
                     "\"requirePolicyProfiles\":%s},"
+                "\"structuredAudit\":{\"schemaVersion\":1,"
+                    "\"logPrefix\":\"CaumeDSE AuditJSON: \","
+                    "\"events\":[\"auth\",\"authorization\",\"request\",\"parserPolicy\","
+                    "\"parserUpload\",\"parserExecution\",\"cleanup\"],"
+                    "\"safeFields\":[\"requestId\",\"category\",\"event\",\"outcome\","
+                    "\"reason\",\"result\",\"userId\",\"orgId\",\"storageId\",\"documentId\","
+                    "\"scriptId\",\"scriptType\",\"method\",\"route\",\"authenticated\","
+                    "\"responseCode\",\"previewOnly\"],"
+                    "\"secretsRedacted\":true},"
                 "\"routes\":["
                     "{\"name\":\"organizations\",\"path\":\"/organizations\",\"methods\":[\"GET\",\"POST\",\"PUT\",\"DELETE\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
                     "{\"name\":\"documents\",\"path\":\"/organizations/{org}/storage/{storage}/documentTypes/{type}/documents\",\"methods\":[\"GET\",\"POST\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
@@ -10258,6 +10401,10 @@ int cmeWebServiceProcessParserScriptResource (char **responseText, char ***respo
                             result=cmeWebServiceParserStaticCheck(tmpRAWFile,scriptType,&staticDeniedPattern);
                             if (result)
                             {
+                                cmeWebServiceAuditJSON("parserPolicy","static-deny","deny",
+                                                       staticDeniedPattern?staticDeniedPattern:"unknown",result,NULL,
+                                                       userId,orgId,urlElements[3],urlElements[7],urlElements[9],
+                                                       scriptType,method,NULL,NULL,NULL,parserPreviewOnly);
                                 cmeStrConstrAppend(responseText,"<b>403 FORBIDDEN parser static check denied preview.</b><br>"
                                                    "Denied pattern: '%s'. METHOD: '%s' URL: '%s'."
                                                    "%sLatest IDD version: <code>%s</code>",
@@ -14315,7 +14462,12 @@ static int cmeWebServiceConstructTableSchemaResponse(char **responseText, char *
                        CDSE_PARSER_SCRIPT_MAX_OUTPUT_BYTES,
                        CDSE_PARSER_SCRIPT_MAX_RESULT_CELLS);
     cmeWebServiceAppendJSONStringValue(responseText,isolationProfile);
-    cmeStrConstrAppend(responseText,",\"requireReviewed\":%s,\"requirePolicyProfiles\":%s}}",
+    cmeStrConstrAppend(responseText,",\"requireReviewed\":%s,\"requirePolicyProfiles\":%s},"
+                       "\"structuredAudit\":{\"schemaVersion\":1,"
+                       "\"logPrefix\":\"CaumeDSE AuditJSON: \","
+                       "\"events\":[\"auth\",\"authorization\",\"request\",\"parserPolicy\","
+                       "\"parserUpload\",\"parserExecution\",\"cleanup\"],"
+                       "\"secretsRedacted\":true}}",
                        cmeWebServiceParserEnvFlag("CDSE_PARSER_REQUIRE_REVIEWED",
                                                   CDSE_PARSER_REQUIRE_REVIEWED)?"true":"false",
                        cmeWebServiceParserEnvFlag("CDSE_PARSER_REQUIRE_POLICY_PROFILES",
@@ -15245,6 +15397,32 @@ int cmeWebServiceLogConnection (struct MHD_Connection *connection, void *con_cls
                                      startTimestamp, endTimestamp, requestDataSize, responseDataSize,
                                      orgResourceId, requestIPAddress, responseCode, responseHeaders,
                                      authenticated, orgKey);
+    if (!result)
+    {
+        const char *auditCategory="request";
+        const char *auditEvent="request-complete";
+        const char *auditOutcome="allow";
+
+        if (con_info->answerCode==401)
+        {
+            auditCategory="auth";
+            auditEvent="auth-deny";
+            auditOutcome="deny";
+        }
+        else if (con_info->answerCode==403)
+        {
+            auditCategory="authorization";
+            auditEvent="authorization-deny";
+            auditOutcome="deny";
+        }
+        else if (con_info->answerCode>=400)
+        {
+            auditOutcome="deny";
+        }
+        cmeWebServiceAuditJSON(auditCategory,auditEvent,auditOutcome,NULL,result,
+                               con_info->requestId,userId,orgId,orgResourceId,NULL,NULL,NULL,
+                               requestMethod,requestUrl,authenticated,responseCode,0);
+    }
     if (result) //Error
     {
 #ifdef ERROR_LOG


### PR DESCRIPTION
## Summary

- add versioned `CaumeDSE AuditJSON: ` events for auth, authorization, request completion, parser policy, parser upload/execution, and cleanup failures
- expose structured audit metadata in `/agentCapabilities`, schema responses, OpenAPI, and docs
- add `samples/ai-agent/recent_audit_reader.py` for bounded agent-readable audit summaries
- extend live verifier coverage to parse structured audit JSON, require key categories, and check redaction

## Validation

- `bash -n TEST/run_debug_components.sh`
- `python3 -m py_compile samples/ai-agent/guarded_agent_workflow.py samples/ai-agent/recent_audit_reader.py samples/mcp-server/caumedse_mcp_server.py`
- `TEST/validate_openapi_routes.sh`
- `CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke` -> `RESULT passed=119 failed=0 skipped=1`

## Security impact

- structured audit events are marked `safeForAgent` and omit org keys, authorization headers, script bodies, and CSV content
- verifier now fails if structured audit JSON leaks credential markers or misses auth/authorization/parser categories
- existing text diagnostics and LogsDB storage remain compatible