### PR TITLE
Promote MCP read-only tool surface

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -222,6 +222,9 @@ See `samples/delegated-token-broker/` for an external-manager sample that
 mints short-lived scoped tokens and maps them to broker-held delegated CaumeDSE
 credentials.
 
-See `samples/mcp-server/` for a prototype MCP stdio server that exposes a
-small allow-listed tool surface for the same REST API operations while keeping
-organization keys in environment variables.
+See `samples/mcp-server/` for the supported read-only MCP stdio surface. It
+exposes route-aligned tools such as `agentCapabilities_read`,
+`documentSchema_read`, `contentColumns_read`, `parserScripts_run`,
+`parserScripts_preview`, and `dbTableSchema_read` while keeping organization
+keys in environment variables. Local DEBUG setup/upload/cleanup helpers are
+hidden unless `CDSE_MCP_ENABLE_WRITE_TOOLS=1` is set.

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -6,8 +6,8 @@ integration testing. They show the request shape for common resources without
 expanding the main README API reference. For AI-agent and automation guardrails
 around these examples, see `AI_USAGE.md`. For a machine-readable reference for
 the stable documented routes, see `openapi.yaml`. For a guarded end-to-end
-Python automation sample, see `samples/ai-agent/`. For an MCP wrapper prototype
-over safe REST operations, see `samples/mcp-server/`.
+Python automation sample, see `samples/ai-agent/`. For the supported
+read-only MCP stdio surface over safe REST reads, see `samples/mcp-server/`.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a delegated scoped-token broker sample that keeps CaumeDSE organization
 keys out of agent prompts, see
 [samples/delegated-token-broker/](samples/delegated-token-broker/).
 
-For a prototype MCP stdio server that wraps a safe REST tool surface, see
+For the supported read-only MCP stdio tool surface over safe REST reads, see
 [samples/mcp-server/](samples/mcp-server/).
 
 AI agents and MCP clients can discover safe automation capabilities with
@@ -60,7 +60,7 @@ entries and retained verifier artifacts.
 - [AI Agent Capability Manifest](#ai-agent-capability-manifest)
 - [AI Agent Sample](samples/ai-agent/)
 - [Delegated Token Broker Sample](samples/delegated-token-broker/)
-- [MCP Server Prototype](samples/mcp-server/)
+- [MCP Read-Only Server](samples/mcp-server/)
 - [License](#license)
 - [Architecture and Functionality](#architecture-and-functionality)
 - [REST Resource API Reference](#rest-resource-api-reference)

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -697,6 +697,118 @@ PY
     rm -f "$audit_log"
 }
 
+check_live_mcp_readonly_smoke() {
+    local protocol="$1"
+    local base_url="$2"
+    local org_name="$3"
+    local storage_name="$4"
+    local user_id="$5"
+    local org_key="$6"
+    local csv_name="$7"
+    local parser_name="$8"
+    local pending_parser_name="$9"
+    local client_chain="${10:-}"
+    local client_key="${11:-}"
+    local mcp_log="$LOG_ROOT/live_${protocol}_mcp_readonly_smoke.log"
+
+    : > "$mcp_log"
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        record_skip "live_${protocol}_mcp_readonly_smoke" "python3 is required for MCP stdio smoke"
+        return
+    fi
+
+    if ! env \
+        CDSE_MCP_BASE_URL="$base_url" \
+        CDSE_MCP_ORG="$org_name" \
+        CDSE_MCP_USER="$user_id" \
+        CDSE_MCP_STORAGE="$storage_name" \
+        CDSE_MCP_ORG_KEY="$org_key" \
+        CDSE_MCP_CSV_DOC="$csv_name" \
+        CDSE_MCP_PARSER_DOC="$parser_name" \
+        CDSE_MCP_PENDING_PARSER_DOC="$pending_parser_name" \
+        CDSE_MCP_CA_CERT="$PREFIX/cdse/ca.pem" \
+        CDSE_MCP_CLIENT_CERT="$client_chain" \
+        CDSE_MCP_CLIENT_KEY="$client_key" \
+        python3 - "$ROOT_DIR/samples/mcp-server/caumedse_mcp_server.py" > "$mcp_log" 2>&1 <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+server = sys.argv[1]
+requests = [
+    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "agentCapabilities_read", "arguments": {}}},
+    {"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {"name": "documentSchema_read", "arguments": {}}},
+    {"jsonrpc": "2.0", "id": 5, "method": "tools/call", "params": {"name": "contentColumns_read", "arguments": {"column": "name", "limit": 1}}},
+    {"jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {"name": "parserScripts_run", "arguments": {"limit": 1}}},
+    {"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {"name": "parserScripts_preview", "arguments": {"limit": 1, "preview_rows": 1}}},
+    {"jsonrpc": "2.0", "id": 8, "method": "tools/call", "params": {"name": "dbTableSchema_read", "arguments": {}}},
+    {"jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": {"name": "dbTableColumns_read", "arguments": {"column": "name", "limit": 1}}},
+]
+payload = "\n".join(json.dumps(item) for item in requests) + "\n"
+proc = subprocess.run(
+    [sys.executable, server],
+    input=payload,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    env=os.environ.copy(),
+    timeout=90,
+)
+print(proc.stdout)
+if proc.stderr:
+    print(proc.stderr, file=sys.stderr)
+if proc.returncode != 0:
+    raise SystemExit(f"MCP server exited {proc.returncode}")
+responses = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+by_id = {response.get("id"): response for response in responses}
+if set(by_id) != set(range(1, 10)):
+    raise SystemExit(f"unexpected MCP response ids: {sorted(by_id)}")
+tool_names = {tool["name"] for tool in by_id[2]["result"]["tools"]}
+required = {
+    "agentCapabilities_read",
+    "documentTypes_list",
+    "documentSchema_read",
+    "contentColumns_read",
+    "parserScripts_run",
+    "parserScripts_preview",
+    "dbTableSchema_read",
+    "dbTableColumns_read",
+}
+for name in required:
+    if name not in tool_names:
+        raise SystemExit(f"missing read-only MCP tool: {name}")
+for name in ("create_workspace", "upload_csv", "upload_parser", "cleanup_workspace"):
+    if name in tool_names:
+        raise SystemExit(f"write helper exposed without CDSE_MCP_ENABLE_WRITE_TOOLS: {name}")
+for request_id in range(3, 10):
+    result = by_id[request_id].get("result", {})
+    if result.get("isError"):
+        raise SystemExit(f"MCP tool call {request_id} failed: {result}")
+    content = result.get("content") or []
+    if not content:
+        raise SystemExit(f"MCP tool call {request_id} returned no content")
+    text = content[0].get("text", "")
+    if any(marker in text for marker in (os.environ["CDSE_MCP_ORG_KEY"], "Authorization:", "Bearer ")):
+        raise SystemExit("MCP tool result leaked a credential marker")
+    parsed = json.loads(text)
+    if request_id in (4, 8) and parsed.get("safeForAgent") is not True:
+        raise SystemExit("schema read did not return safeForAgent metadata")
+print("MCP read-only smoke passed")
+PY
+    then
+        redact_file_in_place "$mcp_log"
+        record_fail "live_${protocol}_mcp_readonly_smoke" "MCP read-only smoke failed log=$mcp_log"
+        return
+    fi
+
+    record_pass "live_${protocol}_mcp_readonly_smoke"
+    rm -f "$mcp_log"
+}
+
 stop_live_service() {
     local pid="$1"
 
@@ -1026,6 +1138,7 @@ run_live_web_flow() {
         -F "*resourceInfo=live $protocol pending generated Python script $python_pending_policy_meta"
     live_api_check "$protocol" python_parser_pending_full_denied 403 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_pending_script_name?$auth&newOrgKey=$org_key&outputType=json" '"code":"forbidden"' "${curl_tls_args[@]}"
     live_api_check "$protocol" python_parser_pending_preview 200 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/file.csv/documents/$csv_name/parserScripts/$python_pending_script_name?$auth&newOrgKey=$org_key&outputType=json&previewOnly=1&previewRows=1&limit=1" '"returnedRows":1' "${curl_tls_args[@]}"
+    check_live_mcp_readonly_smoke "$protocol" "$base_url" "$org_name" "$storage_name" "$user_id" "$org_key" "$csv_name" "$python_script_name" "$python_pending_script_name" "${client_chain:-}" "${client_key:-}"
     live_api_check "$protocol" upload_python_pending_static_bad_script 201 "$base_url/organizations/$org_name/storage/$storage_name/documentTypes/script.python/documents/$python_pending_static_bad_script_name" "" "${curl_tls_args[@]}" \
         -F "file=@$ROOT_DIR/TEST/testfiles/test_network_access.py" \
         -F "userId=$user_id" \

--- a/TODO.md
+++ b/TODO.md
@@ -666,13 +666,13 @@
     - Batch 2: emitted structured `CaumeDSE AuditJSON: ` events alongside existing text diagnostics without changing LogsDB storage.
     - Batch 3: added an agent-readable recent-audit sample and live verifier checks for JSON parsing, required categories, and redaction.
 
-- [ ] #89 Promote the MCP prototype into a supported read-only tool surface.
+- [x] #89 Promote the MCP prototype into a supported read-only tool surface.
   - Source: `samples/mcp-server/`, `AI_USAGE.md`, live verifier.
   - Goal: provide a stable MCP interface for agents to inspect CaumeDSE data with narrow permissions.
-  - Plan:
-    - Batch 1: align MCP tools with `/agentCapabilities` and OpenAPI route names.
-    - Batch 2: add schema validation, pagination, and safer result truncation to read tools.
-    - Batch 3: add a smoke test that runs MCP initialize/tools/list/tool calls against the live verifier service.
+  - Done:
+    - Batch 1: aligned supported MCP tools with `/agentCapabilities` and OpenAPI route names.
+    - Batch 2: added schema validation, pagination, and safer result truncation to read tools.
+    - Batch 3: added a smoke test that runs MCP initialize/tools/list/tool calls against the live verifier service.
 
 - [ ] #90 Add an AI agent cookbook and operational checklist.
   - Source: `AI_USAGE.md`, `samples/`, README.

--- a/samples/mcp-server/README.md
+++ b/samples/mcp-server/README.md
@@ -1,30 +1,39 @@
-# CaumeDSE MCP Server Prototype
+# CaumeDSE MCP Read-Only Server
 
 This sample exposes a small, fixed Model Context Protocol tool surface over
-stdio for AI assistants that need guarded access to CaumeDSE REST operations.
-It is a prototype for local DEBUG/test workflows, not a production gateway.
+stdio for AI assistants that need guarded read-only access to CaumeDSE REST
+operations. It is suitable as the supported reference surface for local
+DEBUG/test integration; production bridges should still add their own
+authentication, authorization, and deployment controls.
 
 The server uses only Python's standard library. Credentials are read from
 environment variables and are never part of MCP tool arguments or tool results.
 
 ## Tools
 
-- `get_agent_capabilities`: reads the public `/agentCapabilities` manifest.
+- `agentCapabilities_read`: reads the public `/agentCapabilities` manifest.
+- `documentTypes_list`: lists document types in the configured storage.
+- `documentSchema_read`: reads column, row-count, pagination, and parser-policy
+  metadata for a CSV document.
+- `contentColumns_read`: validates one CSV column against schema and returns a
+  bounded row preview.
+- `parserScripts_run`: reads schema before running an uploaded reviewed parser
+  and returns a bounded row preview.
+- `parserScripts_preview`: runs a pending parser candidate in preview-only mode
+  against capped sample rows.
+- `dbTableSchema_read`: reads schema metadata for one exposed secure CSV table.
+- `dbTableColumns_read`: validates one exposed table column against schema and
+  returns a bounded row preview.
+
+Local DEBUG setup helpers are hidden unless
+`CDSE_MCP_ENABLE_WRITE_TOOLS=1` is set in the server environment:
+
 - `create_workspace`: creates the configured disposable organization, storage,
   and user.
-- `list_document_types`: lists document types in the configured storage.
 - `upload_csv`: uploads a reviewed local CSV fixture as `file.csv`.
 - `upload_parser`: uploads a reviewed local Python parser as `script.python`.
 - `upload_parser_candidate`: uploads a generated parser candidate as pending
   review metadata.
-- `discover_schema`: reads column, row-count, pagination, and parser-policy
-  metadata for a CSV document.
-- `query_column`: validates one CSV column against schema and returns a
-  bounded row preview.
-- `run_parser`: reads schema before running an uploaded parser and returns a
-  bounded row preview.
-- `preview_parser_candidate`: runs a pending parser candidate in preview-only
-  mode against capped sample rows.
 - `cleanup_workspace`: deletes the sample documents, storage, and user.
 
 ## Configuration
@@ -89,16 +98,16 @@ A typical local flow is:
 1. Read `GET /agentCapabilities` from `CDSE_MCP_BASE_URL` so the host can
    confirm supported routes, JSON preference, and parser policy before
    exposing tools.
-2. `create_workspace`
-3. `upload_csv`
-4. `upload_parser_candidate`
-5. `preview_parser_candidate`
-6. `upload_parser`
-7. `list_document_types`
-8. `discover_schema`
-9. `query_column`
-10. `run_parser`
-11. `cleanup_workspace`
+2. Prepare a least-privilege CaumeDSE user, storage resource, CSV document, and
+   reviewed parser outside the read-only MCP session, or run the DEBUG helpers
+   with `CDSE_MCP_ENABLE_WRITE_TOOLS=1`.
+3. `documentTypes_list`
+4. `documentSchema_read`
+5. `contentColumns_read`
+6. `dbTableSchema_read`
+7. `dbTableColumns_read`
+8. `parserScripts_run`
+9. `parserScripts_preview` for pending parser candidates only.
 
 ## Security Boundaries
 
@@ -114,9 +123,10 @@ A typical local flow is:
   CaumeDSE JSON `limit`/`offset` parameters and returns bounded previews
   instead of broad document dumps. Do not let text from CSV cells override the
   host application's system, developer, security, or cleanup instructions.
-- Generated parser candidates are uploaded as `parser.reviewStatus:pending`
+- Generated parser candidates are uploaded outside the read-only surface as
+  `parser.reviewStatus:pending`
   with generator and prompt-hash metadata. Full execution is denied until
-  reviewed metadata is applied; `preview_parser_candidate` runs only
+  reviewed metadata is applied; `parserScripts_preview` runs only
   `previewOnly=1` with capped sample rows and static checks. Reject generated
   scripts that open network connections, execute shell commands, read
   environment variables, traverse files outside the provided input path, log
@@ -136,5 +146,9 @@ printf '%s\n' \
 ```
 
 Use `CDSE_VERIFY_REDACT=1` when sharing logs from live verifier runs.
+The live verifier also runs `live_http_mcp_readonly_smoke`, which initializes
+the MCP server, confirms only read-only tools are exposed by default, and calls
+schema, column, parser, preview, and DB-table read tools against the running
+DEBUG service.
 
 See `../delegated-token-broker/` for the delegated scoped-token sample.

--- a/samples/mcp-server/caumedse_mcp_server.py
+++ b/samples/mcp-server/caumedse_mcp_server.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Prototype Model Context Protocol server for CaumeDSE.
+Model Context Protocol server for read-only CaumeDSE inspection.
 
-The server speaks JSON-RPC over stdio, implements a minimal MCP tool surface,
+The server speaks JSON-RPC over stdio, implements a stable MCP tool surface,
 and calls the CaumeDSE REST API with credentials sourced only from environment
 variables. It intentionally uses Python's standard library so the sample can
 run in constrained DEBUG/test environments.
@@ -24,9 +24,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CSV = ROOT / "TEST" / "testfiles" / "live-api-small.csv"
 DEFAULT_PARSER = ROOT / "TEST" / "testfiles" / "test.py"
-SERVER_NAME = "caumedse-mcp-prototype"
-SERVER_VERSION = "0.1.0"
+SERVER_NAME = "caumedse-mcp-readonly"
+SERVER_VERSION = "0.2.0"
 PROTOCOL_VERSION = "2024-11-05"
+MAX_LIMIT = 10
+MAX_TEXT_BYTES = 12000
 
 
 class ToolError(Exception):
@@ -48,6 +50,7 @@ class Config:
         self.ca_cert = os.environ.get("CDSE_MCP_CA_CERT")
         self.client_cert = os.environ.get("CDSE_MCP_CLIENT_CERT")
         self.client_key = os.environ.get("CDSE_MCP_CLIENT_KEY")
+        self.enable_write_tools = os.environ.get("CDSE_MCP_ENABLE_WRITE_TOOLS", "").lower() in {"1", "true", "yes", "on"}
 
     def require_key(self):
         if not self.org_key:
@@ -163,7 +166,7 @@ def get_agent_capabilities(cfg, _args):
     return json.loads(payload.decode("utf-8"))
 
 
-def clamp_limit(value, default=3, maximum=10):
+def clamp_limit(value, default=3, maximum=MAX_LIMIT):
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -172,13 +175,21 @@ def clamp_limit(value, default=3, maximum=10):
 
 
 def summarize_table(result, limit):
+    if not isinstance(result, dict):
+        raise ToolError("CaumeDSE returned a non-object JSON response.")
+    if "error" in result:
+        raise ToolError(json.dumps(result["error"], sort_keys=True))
     rows = result.get("rows", [])
+    columns = result.get("columns", [])
+    pagination = result.get("pagination", {})
+    if not isinstance(rows, list) or not isinstance(columns, list) or not isinstance(pagination, dict):
+        raise ToolError("CaumeDSE JSON table response is missing rows, columns, or pagination.")
     return {
-        "columns": result.get("columns", []),
-        "rowCount": result.get("pagination", {}).get("totalRows", len(rows)),
-        "pagination": result.get("pagination", {}),
+        "columns": columns[:MAX_LIMIT],
+        "rowCount": pagination.get("totalRows", len(rows)),
+        "pagination": pagination,
         "rows": rows[:limit],
-        "truncated": bool(result.get("pagination", {}).get("hasMore", len(rows) > limit)),
+        "truncated": bool(pagination.get("hasMore", len(rows) > limit) or len(columns) > MAX_LIMIT),
     }
 
 
@@ -299,7 +310,23 @@ def upload_parser_candidate(cfg, args):
 def discover_schema(cfg, args):
     doc_name = args.get("document") or cfg.csv_doc
     path = f"{base_document_path(cfg, 'file.csv', doc_name)}/schema"
-    return json_request(cfg, path, cfg.auth_params(include_new_key=True), limit=1)
+    schema = json_request(cfg, path, cfg.auth_params(include_new_key=True), limit=1)
+    validate_schema(schema, "document")
+    return schema
+
+
+def validate_schema(schema, expected_resource=None):
+    if not isinstance(schema, dict):
+        raise ToolError("CaumeDSE schema response is not a JSON object.")
+    if schema.get("safeForAgent") is not True:
+        raise ToolError("CaumeDSE schema response is not marked safeForAgent.")
+    if expected_resource and schema.get("resource") != expected_resource:
+        raise ToolError(f"Unexpected schema resource: {schema.get('resource')}")
+    if not isinstance(schema.get("columns"), list):
+        raise ToolError("CaumeDSE schema response is missing columns.")
+    if not isinstance(schema.get("pagination"), dict):
+        raise ToolError("CaumeDSE schema response is missing pagination metadata.")
+    return schema
 
 
 def query_column(cfg, args):
@@ -310,6 +337,41 @@ def query_column(cfg, args):
     if column not in {entry.get("name") for entry in schema.get("columns", [])}:
         raise ToolError(f"Column not found in document schema: {column}")
     path = f"{base_document_path(cfg, 'file.csv', doc_name)}/contentColumns/{quote_path(column)}"
+    summary = summarize_table(json_request(cfg, path, cfg.auth_params(include_new_key=True), limit=limit), limit)
+    summary["schema"] = {"rowCount": schema.get("rowCount"), "columnCount": schema.get("columnCount")}
+    return summary
+
+
+def discover_db_table_schema(cfg, args):
+    db_name = args.get("db_name") or cfg.csv_doc
+    table = args.get("table") or "data"
+    path = (
+        f"/organizations/{quote_path(cfg.org)}"
+        f"/storage/{quote_path(cfg.storage)}"
+        f"/dbNames/{quote_path(db_name)}"
+        f"/dbTables/{quote_path(table)}"
+        f"/schema"
+    )
+    schema = json_request(cfg, path, cfg.auth_params(include_new_key=True), limit=1)
+    validate_schema(schema, "dbTable")
+    return schema
+
+
+def query_db_table_column(cfg, args):
+    db_name = args.get("db_name") or cfg.csv_doc
+    table = args.get("table") or "data"
+    column = args.get("column") or "name"
+    limit = clamp_limit(args.get("limit"))
+    schema = discover_db_table_schema(cfg, {"db_name": db_name, "table": table})
+    if column not in {entry.get("name") for entry in schema.get("columns", [])}:
+        raise ToolError(f"Column not found in table schema: {column}")
+    path = (
+        f"/organizations/{quote_path(cfg.org)}"
+        f"/storage/{quote_path(cfg.storage)}"
+        f"/dbNames/{quote_path(db_name)}"
+        f"/dbTables/{quote_path(table)}"
+        f"/tableColumns/{quote_path(column)}"
+    )
     summary = summarize_table(json_request(cfg, path, cfg.auth_params(include_new_key=True), limit=limit), limit)
     summary["schema"] = {"rowCount": schema.get("rowCount"), "columnCount": schema.get("columnCount")}
     return summary
@@ -358,40 +420,124 @@ def cleanup_workspace(cfg, args):
     return {"cleanup": deleted}
 
 
-TOOLS = {
-    "get_agent_capabilities": get_agent_capabilities,
+READ_ONLY_TOOLS = {
+    "agentCapabilities_read": get_agent_capabilities,
+    "documentTypes_list": list_document_types,
+    "documentSchema_read": discover_schema,
+    "contentColumns_read": query_column,
+    "parserScripts_run": run_parser,
+    "parserScripts_preview": preview_parser_candidate,
+    "dbTableSchema_read": discover_db_table_schema,
+    "dbTableColumns_read": query_db_table_column,
+}
+
+WRITE_TOOLS = {
     "create_workspace": create_workspace,
-    "list_document_types": list_document_types,
     "upload_csv": upload_csv,
     "upload_parser": upload_parser,
     "upload_parser_candidate": upload_parser_candidate,
-    "discover_schema": discover_schema,
-    "query_column": query_column,
-    "run_parser": run_parser,
-    "preview_parser_candidate": preview_parser_candidate,
     "cleanup_workspace": cleanup_workspace,
 }
 
-
-TOOL_SCHEMAS = [
+READ_ONLY_TOOL_SCHEMAS = [
     {
-        "name": "get_agent_capabilities",
+        "name": "agentCapabilities_read",
         "description": "Read the public CaumeDSE AI-agent capability manifest without credentials.",
         "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
     {
-        "name": "create_workspace",
-        "description": "Create the configured disposable organization, storage, and user.",
-        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
-    },
-    {
-        "name": "list_document_types",
+        "name": "documentTypes_list",
         "description": "List document types in the configured storage as a bounded JSON summary.",
         "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
     },
     {
+        "name": "documentSchema_read",
+        "description": "Read document schema metadata before row, column, or parser reads.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "document": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "contentColumns_read",
+        "description": "Validate one CSV column against schema and return a bounded row preview.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "document": {"type": "string"},
+                "column": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_LIMIT},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "parserScripts_run",
+        "description": "Run an already uploaded reviewed parser and return a bounded row preview.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "document": {"type": "string"},
+                "parser": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_LIMIT},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "parserScripts_preview",
+        "description": "Run a pending parser candidate in preview-only mode against capped sample rows.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "document": {"type": "string"},
+                "parser": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_LIMIT},
+                "preview_rows": {"type": "integer", "minimum": 1, "maximum": MAX_LIMIT},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "dbTableSchema_read",
+        "description": "Read schema metadata for one exposed secure CSV table.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "db_name": {"type": "string"},
+                "table": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "dbTableColumns_read",
+        "description": "Validate one exposed table column against schema and return a bounded row preview.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "db_name": {"type": "string"},
+                "table": {"type": "string"},
+                "column": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": MAX_LIMIT},
+            },
+            "additionalProperties": False,
+        },
+    },
+]
+
+WRITE_TOOL_SCHEMAS = [
+    {
+        "name": "create_workspace",
+        "description": "Local DEBUG helper: create the configured disposable organization, storage, and user.",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    {
         "name": "upload_csv",
-        "description": "Upload a reviewed local CSV fixture to the configured storage.",
+        "description": "Local DEBUG helper: upload a reviewed local CSV fixture to the configured storage.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -404,7 +550,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "upload_parser",
-        "description": "Upload a reviewed local Python parser fixture with review metadata.",
+        "description": "Local DEBUG helper: upload a reviewed local Python parser fixture with review metadata.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -417,7 +563,7 @@ TOOL_SCHEMAS = [
     },
     {
         "name": "upload_parser_candidate",
-        "description": "Upload a generated parser candidate as pending review metadata.",
+        "description": "Local DEBUG helper: upload a generated parser candidate as pending review metadata.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -429,59 +575,8 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "discover_schema",
-        "description": "Read document schema metadata before row, column, or parser reads.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "document": {"type": "string"},
-            },
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "query_column",
-        "description": "Read document schema, validate one CSV column, and return a bounded row preview.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "document": {"type": "string"},
-                "column": {"type": "string"},
-                "limit": {"type": "integer", "minimum": 1, "maximum": 10},
-            },
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "run_parser",
-        "description": "Run an already uploaded reviewed parser and return a bounded row preview.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "document": {"type": "string"},
-                "parser": {"type": "string"},
-                "limit": {"type": "integer", "minimum": 1, "maximum": 10},
-            },
-            "additionalProperties": False,
-        },
-    },
-    {
-        "name": "preview_parser_candidate",
-        "description": "Run a pending parser candidate in preview-only mode against capped sample rows.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "document": {"type": "string"},
-                "parser": {"type": "string"},
-                "limit": {"type": "integer", "minimum": 1, "maximum": 10},
-                "preview_rows": {"type": "integer", "minimum": 1, "maximum": 10},
-            },
-            "additionalProperties": False,
-        },
-    },
-    {
         "name": "cleanup_workspace",
-        "description": "Delete the configured sample documents, storage, and user.",
+        "description": "Local DEBUG helper: delete the configured sample documents, storage, and user.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -494,10 +589,32 @@ TOOL_SCHEMAS = [
 ]
 
 
+def available_tools(cfg):
+    tools = dict(READ_ONLY_TOOLS)
+    if cfg.enable_write_tools:
+        tools.update(WRITE_TOOLS)
+    return tools
+
+
+def available_tool_schemas(cfg):
+    schemas = list(READ_ONLY_TOOL_SCHEMAS)
+    if cfg.enable_write_tools:
+        schemas.extend(WRITE_TOOL_SCHEMAS)
+    return schemas
+
+
 def tool_result(data, is_error=False):
+    text = json.dumps(data, indent=2, sort_keys=True)
+    truncated = False
+    encoded = text.encode("utf-8")
+    if len(encoded) > MAX_TEXT_BYTES:
+        text = encoded[:MAX_TEXT_BYTES].decode("utf-8", errors="ignore")
+        text += "\n...<truncated>"
+        truncated = True
     return {
-        "content": [{"type": "text", "text": json.dumps(data, indent=2, sort_keys=True)}],
+        "content": [{"type": "text", "text": text}],
         "isError": is_error,
+        "structuredContent": {"truncated": truncated},
     }
 
 
@@ -511,16 +628,17 @@ def handle_request(cfg, request_obj):
             "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
         }
     if method == "tools/list":
-        return {"tools": TOOL_SCHEMAS}
+        return {"tools": available_tool_schemas(cfg)}
     if method == "tools/call":
         name = params.get("name")
         arguments = params.get("arguments") or {}
-        if name not in TOOLS:
+        tools = available_tools(cfg)
+        if name not in tools:
             raise ToolError(f"Unknown tool: {name}")
         if not isinstance(arguments, dict):
             raise ToolError("Tool arguments must be an object.")
         try:
-            return tool_result(TOOLS[name](cfg, arguments))
+            return tool_result(tools[name](cfg, arguments))
         except ToolError as exc:
             return tool_result({"error": str(exc)}, is_error=True)
     if method and method.startswith("notifications/"):


### PR DESCRIPTION
## Summary

- promote `samples/mcp-server` from prototype wording to the supported read-only MCP stdio reference surface
- expose route-aligned read tools by default, including `agentCapabilities_read`, `documentSchema_read`, `contentColumns_read`, `parserScripts_run`, `parserScripts_preview`, and DB table schema/column reads
- hide local setup/upload/cleanup helpers unless `CDSE_MCP_ENABLE_WRITE_TOOLS=1` is explicitly set
- add schema validation, pagination limits, and capped MCP result text for safer agent consumption
- add a live verifier MCP smoke test that initializes the server, checks `tools/list`, and calls read tools against the DEBUG service

## Validation

- `python3 -m py_compile samples/mcp-server/caumedse_mcp_server.py samples/ai-agent/guarded_agent_workflow.py samples/ai-agent/recent_audit_reader.py`
- `bash -n TEST/run_debug_components.sh`
- `TEST/validate_openapi_routes.sh`
- MCP stdio initialize/tools-list smoke
- `CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke` -> `RESULT passed=120 failed=0 skipped=1`

## Security impact

- write-capable MCP helper tools are no longer advertised by default
- MCP tool results are bounded and checked for credential marker leakage in the live smoke
- read tools validate CaumeDSE schema metadata before column/parser/table reads