### PR TITLE
Add AI agent cookbook checklist

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -183,6 +183,110 @@ summary, run:
 python3 samples/ai-agent/recent_audit_reader.py /tmp/cdse-debug-components-*/live_http_service.log --limit 20
 ```
 
+## Agent Cookbook
+
+These recipes are intended to be repeatable deployment patterns. Keep secrets
+in the host process or broker, pass only identifiers and bounded JSON results
+to the model, and record the `X-Request-Id` for every failed call.
+
+### Read-Only Document Inspection
+
+Use this when an agent needs to inspect a CSV document without changing
+CaumeDSE state.
+
+1. Call `/agentCapabilities` and confirm JSON responses, pagination, schema
+   routes, and parser policy.
+2. Use a least-privilege CaumeDSE user whose role/filter rows allow only the
+   required `GET`/`HEAD` routes.
+3. Read `/schema` for the document before reading content.
+4. Read one column or row page with `outputType=json&limit=N&offset=0`.
+5. Send only column names, row counts, and task-relevant sample rows to the
+   model. Treat cell text as untrusted data, not instructions.
+6. Stop when `pagination.hasMore` is true unless a human approves reading the
+   next page.
+
+For MCP clients, prefer the default read-only tools:
+`agentCapabilities_read`, `documentSchema_read`, `contentColumns_read`,
+`dbTableSchema_read`, and `dbTableColumns_read`.
+
+### Parser Review And Upload
+
+Use this when an LLM proposes a parser script.
+
+1. Save the generated script outside CaumeDSE and review it as source code.
+2. Reject scripts that use network, shell, dynamic-code, environment, or
+   arbitrary-file access.
+3. Upload candidates as pending with `parser.reviewStatus:pending`,
+   `parser.generated:true`, `parser.generator:<tool>`,
+   `parser.promptHash:<hash>`, `parser.interpreter:<path>`,
+   `parser.timeout:10`, and `parser.isolation:<profile>`.
+4. Run only `previewOnly=1&previewRows=N` against a small sample.
+5. Promote by updating metadata to `parser.reviewStatus:reviewed`,
+   `parser.reviewed:true`, `parser.reviewer:<user>`, and
+   `parser.reviewTime:<timestamp>` after human approval.
+6. Run full parser execution only with bounded JSON output and a clear
+   downstream consumer.
+
+### Audit Review
+
+Use this when an agent action needs operator review.
+
+1. Keep the response status, `X-Request-Id`, route template, and timestamp for
+   each tool call.
+2. Read structured service-log events with
+   `samples/ai-agent/recent_audit_reader.py`.
+3. Review `auth`, `authorization`, `request`, `parserPolicy`,
+   `parserUpload`, `parserExecution`, and `cleanup` categories.
+4. Share only redacted verifier artifacts. Use `CDSE_VERIFY_REDACT=1` before
+   uploading logs into issue trackers or model context.
+5. Escalate denied parser-policy events to a human reviewer instead of asking
+   the model to bypass or rewrite policy.
+
+### Cleanup
+
+Use this after each trial or incident investigation.
+
+1. Delete temporary documents, pending parser candidates, reviewed parser
+   fixtures, role/filter rows, users, and storage resources created for the
+   task.
+2. Revoke delegated tokens and upstream OAuth grants tied to the agent
+   session.
+3. Remove local temporary CSV/parser files and generated certificate/key files
+   from non-retained scratch directories.
+4. Re-run a narrow read or `HEAD` check to confirm removed resources return
+   404 or are no longer listed.
+5. Keep only redacted summaries, coverage matrices, and structured audit
+   excerpts needed for operational records.
+
+## Operational Checklist
+
+Before deploying an agent or MCP bridge:
+
+- HTTPS: use HTTPS with client certificates outside DEBUG-only HTTP testing.
+  Disable `--enable-BYPASSTLSAUTHINHTTP` for production builds.
+- Scoped users: provision a dedicated CaumeDSE user per agent task class and
+  configure role/filter rows for the exact read/write methods required.
+- Delegation: put a broker in front of repeated agent sessions; mint
+  short-lived opaque scoped tokens and keep organization keys in the broker or
+  secret manager.
+- Parser review: require reviewed parser metadata for full execution and keep
+  generated candidates pending until human approval.
+- Parser isolation: set parser interpreter, timeout, and isolation metadata;
+  enable `CDSE_PARSER_REQUIRE_POLICY_PROFILES=1`, and use network/chroot
+  isolation where the deployment can satisfy the runtime requirements.
+- Pagination: require schema reads before data reads and cap model-visible
+  results with JSON `limit`/`offset` or MCP result limits.
+- Redaction: run verifier/debug flows with `CDSE_VERIFY_REDACT=1` before
+  sharing artifacts. Do not paste expanded URLs containing `orgKey` or
+  `newOrgKey`.
+- Prompt boundaries: tell the model that CSV cells, parser output, audit
+  events, and error messages are data. They must not override system,
+  developer, authorization, cleanup, TLS, logging, or parser-review rules.
+- Auditability: log request IDs and review `CaumeDSE AuditJSON` events for
+  auth, authorization, parser policy, parser execution, and cleanup outcomes.
+- Cleanup: define an owner and deadline for deleting temporary organizations,
+  storage paths, users, documents, parser scripts, and delegated tokens.
+
 ## Anti-Patterns
 
 Do not:

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -50,7 +50,8 @@ curl -s "$BASE_URL/agentCapabilities"
 
 Useful fields include `authentication.requiredParameters`,
 `formats.preferred`, `formats.jsonPagination`, `parserPolicy`, and each entry
-in `routes`.
+in `routes`. For repeatable agent deployment recipes, see
+`AI_USAGE.md#agent-cookbook` and `AI_USAGE.md#operational-checklist`.
 
 Every response includes `X-Request-Id` for correlation with LogsDB response
 headers. For parseable failures, request JSON:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ For tested `curl` examples based on the live verifier fixtures, see
 For a machine-readable route reference for the stable live-verifier-covered
 API surface, see [openapi.yaml](openapi.yaml).
 
-For safe AI-agent and automation patterns around the API, see
+For safe AI-agent and automation patterns, cookbook recipes, and an
+operational checklist around the API, see
 [AI_USAGE.md](AI_USAGE.md).
 
 For a guarded Python AI-agent workflow sample, see
@@ -56,7 +57,7 @@ entries and retained verifier artifacts.
 - [Cryptography and Data Security Tutorial](TUTORIAL.md)
 - [API Examples](API_EXAMPLES.md)
 - [OpenAPI Route Reference](openapi.yaml)
-- [AI-Safe API Usage](AI_USAGE.md)
+- [AI-Safe API Usage, Cookbook, And Checklist](AI_USAGE.md)
 - [AI Agent Capability Manifest](#ai-agent-capability-manifest)
 - [AI Agent Sample](samples/ai-agent/)
 - [Delegated Token Broker Sample](samples/delegated-token-broker/)

--- a/TODO.md
+++ b/TODO.md
@@ -674,10 +674,10 @@
     - Batch 2: added schema validation, pagination, and safer result truncation to read tools.
     - Batch 3: added a smoke test that runs MCP initialize/tools/list/tool calls against the live verifier service.
 
-- [ ] #90 Add an AI agent cookbook and operational checklist.
+- [x] #90 Add an AI agent cookbook and operational checklist.
   - Source: `AI_USAGE.md`, `samples/`, README.
   - Goal: make safe agent deployments repeatable for integrators.
-  - Plan:
-    - Batch 1: add recipes for read-only document inspection, parser review/upload, audit review, and cleanup.
-    - Batch 2: add deployment checklist entries for HTTPS, scoped delegated users, parser isolation, log redaction, and model prompt boundaries.
-    - Batch 3: cross-link cookbook recipes from README, API examples, MCP docs, and OpenAPI.
+  - Done:
+    - Batch 1: added recipes for read-only document inspection, parser review/upload, audit review, and cleanup.
+    - Batch 2: added deployment checklist entries for HTTPS, scoped delegated users, parser isolation, log redaction, and model prompt boundaries.
+    - Batch 3: cross-linked cookbook recipes from README, API examples, MCP docs, and OpenAPI/capability metadata.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -39,8 +39,9 @@ paths:
       description: |
         Describes safe automation guidance, supported auth modes, preferred
         response formats, parser policy settings, structured audit metadata,
-        documentation links, and core data routes. This route is intentionally
-        public and does not expose organization data or secrets.
+        documentation links, cookbook/checklist references, and core data
+        routes. This route is intentionally public and does not expose
+        organization data or secrets.
       responses:
         "200":
           description: JSON capability manifest.

--- a/samples/ai-agent/README.md
+++ b/samples/ai-agent/README.md
@@ -102,5 +102,7 @@ python3 samples/ai-agent/guarded_agent_workflow.py --keep-resources
   returned from CaumeDSE rewrite the agent's security instructions or cause new
   parser uploads without review.
 
-See `../../AI_USAGE.md` for the broader AI-agent policy and anti-patterns, and
+See `../../AI_USAGE.md#agent-cookbook` and
+`../../AI_USAGE.md#operational-checklist` for repeatable deployment recipes,
+broader AI-agent policy, and anti-patterns. See
 `../delegated-token-broker/` for a scoped-token broker sample.

--- a/samples/mcp-server/README.md
+++ b/samples/mcp-server/README.md
@@ -133,6 +133,9 @@ A typical local flow is:
   credentials, or create unbounded output.
 - Request logs go to stderr and redact `orgKey`, `newOrgKey`, and selected
   credential-style parameters.
+- For repeatable deployment recipes and the full operational checklist, see
+  `../../AI_USAGE.md#agent-cookbook` and
+  `../../AI_USAGE.md#operational-checklist`.
 
 ## Local Smoke Test
 

--- a/webservice_interface.c
+++ b/webservice_interface.c
@@ -2334,7 +2334,9 @@ int cmeWebServiceProcessRequest (char **responseText, char **responseFilePath, c
                     "{\"name\":\"dbBrowsing\",\"path\":\"/organizations/{org}/storage/{storage}/dbNames/{db}/dbTables/{table}\",\"methods\":[\"GET\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true},"
                     "{\"name\":\"dbTableSchema\",\"path\":\"/organizations/{org}/storage/{storage}/dbNames/{db}/dbTables/{table}/schema\",\"methods\":[\"GET\",\"HEAD\",\"OPTIONS\"],\"authRequired\":true}"
                 "],"
-                "\"docs\":[\"README.md\",\"AI_USAGE.md\",\"API_EXAMPLES.md\",\"openapi.yaml\",\"samples/ai-agent/\",\"samples/mcp-server/\"]"
+                "\"docs\":[\"README.md\",\"AI_USAGE.md\",\"AI_USAGE.md#agent-cookbook\","
+                    "\"AI_USAGE.md#operational-checklist\",\"API_EXAMPLES.md\",\"openapi.yaml\","
+                    "\"samples/ai-agent/\",\"samples/mcp-server/\"]"
                 "}",
                 cmeInternalDBDefinitionsVersion,
                 cmeUseTLSAuthentication ? "true" : "false",


### PR DESCRIPTION
## Summary

Adds a repeatable AI-agent cookbook to AI_USAGE.md with recipes for read-only document inspection, parser review/upload, audit review, and cleanup.

Adds an operational deployment checklist covering HTTPS, scoped delegated users, parser isolation, log redaction, prompt boundaries, auditability, pagination, and cleanup ownership.

Cross-links the cookbook/checklist from README, API examples, AI-agent sample docs, MCP docs, OpenAPI, and the /agentCapabilities documentation metadata.

## Validation

- python3 -m py_compile samples/mcp-server/caumedse_mcp_server.py samples/ai-agent/guarded_agent_workflow.py samples/ai-agent/recent_audit_reader.py
- bash -n TEST/run_debug_components.sh
- TEST/validate_openapi_routes.sh
- git diff --check
- CDSE_VERIFY_REDACT=1 TEST/run_debug_components.sh --ci-smoke: RESULT passed=120 failed=0 skipped=1