### PR TITLE
Add re-protect helpers and operational samples

### DIFF
--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -469,6 +469,27 @@ run_mcp_write_guard_self_test() {
     return 1
 }
 
+run_policy_authz_tester_self_test() {
+    local log="$LOG_ROOT/policy_authz_tester_self_test.log"
+    local start
+    local rc
+
+    note "RUN  policy_authz_tester_self_test"
+    start="$(date +%s)"
+    (
+        cd "$ROOT_DIR" || exit 1
+        python3 samples/policy-authz-tester/policy_authz_tester.py self-test
+    ) > "$log" 2>&1
+    rc=$?
+    redact_file_in_place "$log"
+    if [ "$rc" -eq 0 ] && grep -Fq "PASS policy authz tester self-test" "$log"; then
+        record_pass "policy_authz_tester_self_test ($(elapsed_seconds "$start"))"
+        return 0
+    fi
+    record_fail policy_authz_tester_self_test "exit=$rc elapsed=$(elapsed_seconds "$start") log=$log"
+    return 1
+}
+
 protocol_enabled() {
     local protocol="$1"
 
@@ -1778,12 +1799,14 @@ if command -v python3 >/dev/null 2>&1; then
     run_review_workspace_self_test
     run_audit_dashboard_self_test
     run_mcp_write_guard_self_test
+    run_policy_authz_tester_self_test
 else
     record_skip delegated_token_broker_self_test "python3 not available"
     record_skip agent_rag_connector_self_test "python3 not available"
     record_skip review_workspace_self_test "python3 not available"
     record_skip audit_dashboard_self_test "python3 not available"
     record_skip mcp_write_guard_self_test "python3 not available"
+    record_skip policy_authz_tester_self_test "python3 not available"
 fi
 run_webservice_preflight_self_test
 

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -585,6 +585,27 @@ check_herradurakex_independent_component() {
         'TESTS: testHerraduraIndependent(), PASS: HFSCX-256-DS known-answer vector matches.'
 }
 
+check_key_rotation_component() {
+    local source="$1"
+
+    check_component key_rotation_reprotect 'testCryptoReprotectDBValue|re-protect' "$source" \
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rotates key with AES profile.' \
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB value dry-run re-protect reports plaintext length without writing.' \
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rejects wrong source key.'
+}
+
+check_key_rotation_herradurakex_component() {
+    local source="$1"
+
+    if [ -z "$VERIFY_HERRADURAKEX_DIR" ]; then
+        record_skip key_rotation_herradurakex "HerraduraKEx provider not requested"
+        return 0
+    fi
+    check_component key_rotation_herradurakex 'testCryptoReprotectDBValue|Herradura.*re-protect' "$source" \
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect migrates AES to Herradura profile.' \
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rolls Herradura back to AES profile.'
+}
+
 check_live_herradurakex_storage_at_rest() {
     local protocol="$1"
     local storage_path="$2"
@@ -1722,6 +1743,8 @@ check_component crypto_streaming '---ctSize|---etSize|Decrypted text|Unprotected
 
 check_herradurakex_component "$FULL_LOG"
 check_herradurakex_independent_component "$FULL_LOG"
+check_key_rotation_component "$FULL_LOG"
+check_key_rotation_herradurakex_component "$FULL_LOG"
 
 check_component digest 'HASH parameters|HASH digest Size|HASH digest with integrated function|StrToB64|B64ToStr' "$FULL_LOG" \
     '--- HASH digest Size (bytes): 32' \

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -490,6 +490,27 @@ run_policy_authz_tester_self_test() {
     return 1
 }
 
+run_backup_restore_self_test() {
+    local log="$LOG_ROOT/backup_restore_self_test.log"
+    local start
+    local rc
+
+    note "RUN  backup_restore_self_test"
+    start="$(date +%s)"
+    (
+        cd "$ROOT_DIR" || exit 1
+        python3 samples/encrypted-backup-restore/cdse_backup_restore.py self-test
+    ) > "$log" 2>&1
+    rc=$?
+    redact_file_in_place "$log"
+    if [ "$rc" -eq 0 ] && grep -Fq "PASS encrypted backup restore self-test" "$log"; then
+        record_pass "backup_restore_self_test ($(elapsed_seconds "$start"))"
+        return 0
+    fi
+    record_fail backup_restore_self_test "exit=$rc elapsed=$(elapsed_seconds "$start") log=$log"
+    return 1
+}
+
 protocol_enabled() {
     local protocol="$1"
 
@@ -1800,6 +1821,7 @@ if command -v python3 >/dev/null 2>&1; then
     run_audit_dashboard_self_test
     run_mcp_write_guard_self_test
     run_policy_authz_tester_self_test
+    run_backup_restore_self_test
 else
     record_skip delegated_token_broker_self_test "python3 not available"
     record_skip agent_rag_connector_self_test "python3 not available"
@@ -1807,6 +1829,7 @@ else
     record_skip audit_dashboard_self_test "python3 not available"
     record_skip mcp_write_guard_self_test "python3 not available"
     record_skip policy_authz_tester_self_test "python3 not available"
+    record_skip backup_restore_self_test "python3 not available"
 fi
 run_webservice_preflight_self_test
 

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -591,7 +591,8 @@ check_key_rotation_component() {
     check_component key_rotation_reprotect 'testCryptoReprotectDBValue|re-protect' "$source" \
         'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rotates key with AES profile.' \
         'TESTS: testCryptoReprotectDBValue(), PASS: DB value dry-run re-protect reports plaintext length without writing.' \
-        'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rejects wrong source key.'
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rejects wrong source key.' \
+        'TESTS: testCryptoReprotectDBValue(), PASS: DB re-protect inventory reports AES protected row scope.'
 }
 
 check_key_rotation_herradurakex_component() {

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -448,6 +448,27 @@ run_audit_dashboard_self_test() {
     return 1
 }
 
+run_mcp_write_guard_self_test() {
+    local log="$LOG_ROOT/mcp_write_guard_self_test.log"
+    local start
+    local rc
+
+    note "RUN  mcp_write_guard_self_test"
+    start="$(date +%s)"
+    (
+        cd "$ROOT_DIR" || exit 1
+        python3 samples/mcp-server/caumedse_mcp_server.py self-test
+    ) > "$log" 2>&1
+    rc=$?
+    redact_file_in_place "$log"
+    if [ "$rc" -eq 0 ] && grep -Fq "PASS MCP write guard self-test" "$log"; then
+        record_pass "mcp_write_guard_self_test ($(elapsed_seconds "$start"))"
+        return 0
+    fi
+    record_fail mcp_write_guard_self_test "exit=$rc elapsed=$(elapsed_seconds "$start") log=$log"
+    return 1
+}
+
 protocol_enabled() {
     local protocol="$1"
 
@@ -1756,11 +1777,13 @@ if command -v python3 >/dev/null 2>&1; then
     run_agent_rag_connector_self_test
     run_review_workspace_self_test
     run_audit_dashboard_self_test
+    run_mcp_write_guard_self_test
 else
     record_skip delegated_token_broker_self_test "python3 not available"
     record_skip agent_rag_connector_self_test "python3 not available"
     record_skip review_workspace_self_test "python3 not available"
     record_skip audit_dashboard_self_test "python3 not available"
+    record_skip mcp_write_guard_self_test "python3 not available"
 fi
 run_webservice_preflight_self_test
 

--- a/TEST/run_debug_components.sh
+++ b/TEST/run_debug_components.sh
@@ -472,6 +472,76 @@ valid_tcp_port() {
     [ "$port" -gt 0 ] && [ "$port" -le 65535 ]
 }
 
+run_webservice_preflight_self_test() {
+    local log="$LOG_ROOT/webservice-preflight-self-test.log"
+
+    : > "$log"
+    if valid_tcp_port 1 && valid_tcp_port 65535 &&
+       ! valid_tcp_port 0 && ! valid_tcp_port 65536 && ! valid_tcp_port abc; then
+        printf 'PASS valid_tcp_port boundary checks\n' > "$log"
+        record_pass webservice_preflight_self_test
+    else
+        printf 'FAIL valid_tcp_port boundary checks\n' > "$log"
+        record_fail webservice_preflight_self_test "log=$log"
+    fi
+}
+
+write_webservice_startup_preflight() {
+    local log="$LOG_ROOT/webservice-startup-preflight.log"
+    local protocol
+    local port
+    local file
+    local size
+
+    {
+        printf 'CaumeDSE webservice startup preflight\n'
+        printf 'root=%s\n' "$ROOT_DIR"
+        printf 'prefix=%s\n' "$PREFIX"
+        printf 'web_protocol=%s skip_web=%s live_only=%s\n' "$WEB_PROTOCOL" "$SKIP_WEB" "$LIVE_ONLY"
+        printf 'http_port=%s https_port=%s run_timeout=%s\n' "$HTTP_PORT" "$HTTPS_PORT" "$RUN_TIMEOUT"
+        printf 'curl=%s\n' "$(command -v curl 2>/dev/null || printf '<missing>')"
+        if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists libmicrohttpd 2>/dev/null; then
+            printf 'libmicrohttpd=%s\n' "$(pkg-config --modversion libmicrohttpd 2>/dev/null)"
+        elif command -v microhttpd-config >/dev/null 2>&1; then
+            printf 'libmicrohttpd=%s\n' "$(microhttpd-config --version 2>/dev/null)"
+        else
+            printf 'libmicrohttpd=<version-unavailable>\n'
+        fi
+        for protocol in http https; do
+            if protocol_enabled "$protocol"; then
+                if [ "$protocol" = "http" ]; then
+                    port="$HTTP_PORT"
+                else
+                    port="$HTTPS_PORT"
+                fi
+                if valid_tcp_port "$port"; then
+                    printf '%s_port_valid=yes port=%s\n' "$protocol" "$port"
+                else
+                    printf '%s_port_valid=no port=%s\n' "$protocol" "$port"
+                fi
+                if command -v ss >/dev/null 2>&1; then
+                    printf '%s_port_listeners:\n' "$protocol"
+                    ss -ltnp 2>/dev/null | awk -v port="$port" '$4 ~ ":" port "$" { print $0 }'
+                else
+                    printf '%s_port_listeners=<ss-unavailable>\n' "$protocol"
+                fi
+            fi
+        done
+        if protocol_enabled https; then
+            for file in "$PREFIX/cdse/server.key" "$PREFIX/cdse/server.pem" "$PREFIX/cdse/ca.pem"; do
+                if [ -r "$file" ]; then
+                    size="$(wc -c < "$file" 2>/dev/null || printf '0')"
+                    printf 'certificate_file readable=yes bytes=%s path=%s\n' "$size" "$file"
+                else
+                    printf 'certificate_file readable=no bytes=0 path=%s\n' "$file"
+                fi
+            done
+        fi
+    } > "$log" 2>&1
+    redact_file_in_place "$log"
+    record_pass "webservice_startup_preflight log=$log"
+}
+
 check_required() {
     local log="$1"
     local marker="$2"
@@ -1651,6 +1721,7 @@ else
 fi
 
 if [ "$SKIP_WEB" -eq 0 ]; then
+    write_webservice_startup_preflight
     if protocol_enabled http && ! valid_tcp_port "$HTTP_PORT"; then
         record_fail webservice_ports "HTTP port '$HTTP_PORT' is not a valid TCP port"
         exit 1
@@ -1677,6 +1748,7 @@ if [ "$SKIP_WEB" -eq 0 ]; then
     fi
 else
     record_skip webservice_ports "requested --skip-web"
+    record_skip webservice_startup_preflight "requested --skip-web"
 fi
 
 if command -v python3 >/dev/null 2>&1; then
@@ -1690,6 +1762,7 @@ else
     record_skip review_workspace_self_test "python3 not available"
     record_skip audit_dashboard_self_test "python3 not available"
 fi
+run_webservice_preflight_self_test
 
 FULL_LOG="$LOG_ROOT/full-debug-run.log"
 if [ "$LIVE_ONLY" -eq 0 ]; then

--- a/TODO.md
+++ b/TODO.md
@@ -941,6 +941,7 @@
     - Emit a redacted report that maps each policy rule to observed HTTP status, request id, route, and relevant audit category.
     - Add negative cases for overbroad roles, missing filters, conflicting whitelist/blacklist rows, unsupported methods, and cleanup failures.
     - Add documentation for AI-generated policy review, including prompt-boundary rules and human approval before applying generated policies to real deployments.
+  - Batch 1: added `samples/policy-authz-tester/` with a JSON policy format, setup-plan rendering for roleTables/filterWhitelist/filterBlacklist intent, offline observed-status evaluation, redacted `safeForAgent` reports, documentation, and a verifier self-test for validation, mismatch detection, and secret redaction.
 
 - [ ] #106 Add an encrypted backup and restore utility.
   - Source: storage path layout, ResourcesDB/ColumnFile DB handling, `filehandling.c`, `crypto.c`, `samples/`, `README.md`, and verifier fixtures.

--- a/TODO.md
+++ b/TODO.md
@@ -930,6 +930,7 @@
     - Integrate with the delegated-token broker sample so MCP clients never receive raw `orgKey` or `newOrgKey`.
     - Add dry-run output, redacted audit correlation, and clear refusal messages for unsafe parser execution or broad data mutation.
     - Add sample README guidance and verifier self-tests that prove write tools are hidden by default and guarded when enabled.
+  - Batch 1: tightened the MCP sample so write tools require both `CDSE_MCP_ENABLE_WRITE_TOOLS=1` and `CDSE_MCP_DELEGATED_TOKEN`, added per-call guard fields for exact organization/storage/user/scope, expected status, idempotency key, confirmation, and dry-run mode, documented the write boundary, and added an offline verifier self-test for hidden/default write tools and broad-scope rejection.
 
 - [ ] #105 Add a policy-as-code authorization tester.
   - Source: roleTables, filterWhitelist/filterBlacklist handlers, `TEST/run_debug_components.sh`, `samples/`, `AI_USAGE.md`, and `API_EXAMPLES.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -943,7 +943,7 @@
     - Add documentation for AI-generated policy review, including prompt-boundary rules and human approval before applying generated policies to real deployments.
   - Batch 1: added `samples/policy-authz-tester/` with a JSON policy format, setup-plan rendering for roleTables/filterWhitelist/filterBlacklist intent, offline observed-status evaluation, redacted `safeForAgent` reports, documentation, and a verifier self-test for validation, mismatch detection, and secret redaction.
 
-- [ ] #106 Add an encrypted backup and restore utility.
+- [x] #106 Add an encrypted backup and restore utility.
   - Source: storage path layout, ResourcesDB/ColumnFile DB handling, `filehandling.c`, `crypto.c`, `samples/`, `README.md`, and verifier fixtures.
   - Goal: provide a portable, integrity-checked backup/restore workflow for CaumeDSE data directories and metadata, including mixed AES/Herradura protected data.
   - Plan:
@@ -953,6 +953,7 @@
     - Preserve mixed AES/Herradura data without rewriting protected values unless the operator separately invokes the re-protect workflow.
     - Add verifier coverage for backup creation, tamper detection, wrong-key rejection, restore readback, redaction, and cleanup of temporary archive material.
   - Batch 1: added `samples/encrypted-backup-restore/` with a portable manifest utility that inventories CaumeDSE data directories, records file sizes/SHA-256 hashes/classification, redacts identifier-like labels and paths, verifies tamper/missing-file status, renders dry-run restore plans, documents the workflow, and adds an offline verifier self-test.
+  - Batch 2: finished the sample workflow with encrypted backup packages, OpenSSL/PBKDF2 payload encryption with passphrases read from environment or key files, outer HMAC-SHA256 authentication for wrong-key/tamper rejection, restore execution into fresh prefixes with overwrite gates, expected-profile compatibility checks, byte-preserving restore of mixed AES/Herradura data, README operator examples, and expanded offline self-test coverage for backup creation, wrong-key rejection, tamper detection, restore readback, and temporary archive cleanup.
 
 - [ ] #107 Add an operational health and readiness service.
   - Source: `engine_admin.c`, `webservice_interface.c`, `config.c`, `runtime.c`, parser policy configuration, storage path checks, TLS/auth configuration, and `AI_USAGE.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -907,6 +907,7 @@
     - Add failure-safe journaling or resumable checkpoints so interrupted migrations do not leave ambiguous key/profile state.
     - Add DEBUG and live verifier coverage for key rotation, profile migration, wrong-key rejection, partial-scope migration, dry-run output, and rollback/readback behavior.
   - Batch 1: added `cmeReprotectDBSaltedValue()` as a strict per-value re-protect primitive for explicit workflows, including dry-run length reporting, source-key rejection, target profile selection, new salt generation, AES key rotation, and AES/Herradura migration/rollback DEBUG component markers when the provider is enabled.
+  - Batch 2: added `cmeInventoryMemSecureDBReprotect()` for read-only column-file dry-run inventory, reporting meta/data row counts, protect metadata rows, protected value scope, source/target profiles, and legacy AES versus Herradura-framed protected values without mutating the DB.
 
 - [ ] #103 Harden verifier web startup diagnostics and reliability.
   - Source: `engine_admin.c`, `debug_tests.c`, `TEST/run_debug_components.sh`, libmicrohttpd startup options, generated test certificates, and live verifier logs.

--- a/TODO.md
+++ b/TODO.md
@@ -918,6 +918,7 @@
     - Add fallback or configurable alternate port selection for verifier runs when the default ports are unavailable.
     - Capture startup diagnostics into dedicated verifier logs and include concise failure hints in `summary.txt`.
     - Add DEBUG component tests for expected startup failure redaction and verifier self-tests for port validation, timeout behavior, and skipped live-flow handling.
+  - Batch 1: added webservice preflight self-tests for TCP port validation, a dedicated `webservice-startup-preflight.log` with selected protocol/ports, curl/libmicrohttpd availability, listener diagnostics, and certificate readability/size checks, plus richer `cmeWebServiceSetup()` HTTP/HTTPS daemon-start failure diagnostics with daemon flags, thread limits, connection limits, and errno context.
 
 - [ ] #104 Add a guarded write-capable MCP service sample.
   - Source: `samples/mcp-server/`, `samples/delegated-token-broker/`, `AI_USAGE.md`, `openapi.yaml`, live verifier routes, and delegated-token patterns.

--- a/TODO.md
+++ b/TODO.md
@@ -895,3 +895,66 @@
     has a separate `herradurakex_independent` component that skips without a
     requested Herradura provider and fails Herradura-enabled runs on vector/API
     drift.
+
+- [ ] #102 Add an explicit key rotation and re-protect service.
+  - Source: `crypto.c`, `db.c`, `engine_interface.c`, `webservice_interface.c`, ResourcesDB/ColumnFile DB metadata, `README.md`, `TUTORIAL.md`, and `TEST/run_debug_components.sh`.
+  - Goal: let operators rotate organization keys or migrate selected protected values between storage profiles, including AES-to-Herradura transitions, without automatic background migration.
+  - Plan:
+    - Define an explicit re-protect command/API workflow that requires current key material, new key material, target storage profile, and an operator-confirmed scope.
+    - Support dry-run inventory reporting for affected organizations, storage resources, documents, tables, row counts, profile ids, and legacy unframed AES values.
+    - Re-encrypt values through existing protect/unprotect wrappers so profile metadata, salts, `CDSEHKX1` frames, and legacy AES fallback behavior stay consistent.
+    - Preserve rollback expectations by allowing staged migration and mixed AES/Herradura data until the operator commits the final scope.
+    - Add failure-safe journaling or resumable checkpoints so interrupted migrations do not leave ambiguous key/profile state.
+    - Add DEBUG and live verifier coverage for key rotation, profile migration, wrong-key rejection, partial-scope migration, dry-run output, and rollback/readback behavior.
+  - Batch 1: added `cmeReprotectDBSaltedValue()` as a strict per-value re-protect primitive for explicit workflows, including dry-run length reporting, source-key rejection, target profile selection, new salt generation, AES key rotation, and AES/Herradura migration/rollback DEBUG component markers when the provider is enabled.
+
+- [ ] #103 Harden verifier web startup diagnostics and reliability.
+  - Source: `engine_admin.c`, `debug_tests.c`, `TEST/run_debug_components.sh`, libmicrohttpd startup options, generated test certificates, and live verifier logs.
+  - Goal: make HTTP/HTTPS verifier startup failures actionable and reduce false failures when local ports, daemon flags, certificates, or environment limits prevent `MHD_start_daemon()` from starting.
+  - Plan:
+    - Add preflight diagnostics for selected HTTP/HTTPS ports, bind address, process ownership, certificate/key/CA readability, libmicrohttpd version, and relevant daemon flags.
+    - Improve `cmeWebServiceSetup()` error reporting with errno-adjacent context where available and distinct diagnostics for HTTP, HTTPS, certificate loading, signal-handler setup, and daemon startup.
+    - Add fallback or configurable alternate port selection for verifier runs when the default ports are unavailable.
+    - Capture startup diagnostics into dedicated verifier logs and include concise failure hints in `summary.txt`.
+    - Add DEBUG component tests for expected startup failure redaction and verifier self-tests for port validation, timeout behavior, and skipped live-flow handling.
+
+- [ ] #104 Add a guarded write-capable MCP service sample.
+  - Source: `samples/mcp-server/`, `samples/delegated-token-broker/`, `AI_USAGE.md`, `openapi.yaml`, live verifier routes, and delegated-token patterns.
+  - Goal: provide an MCP sample that can perform controlled writes while keeping organization keys out of model context and requiring explicit guardrails for mutations.
+  - Plan:
+    - Keep read-only MCP tools as the default and expose write tools only behind `CDSE_MCP_ENABLE_WRITE_TOOLS=1` plus delegated-token configuration.
+    - Add guarded tools for CSV upload, parser candidate upload, parser preview, reviewed metadata update, narrow document deletion, and cleanup of disposable resources.
+    - Require explicit tool arguments for organization, storage, document, user, scope, expected status, and idempotency key; reject broad or implicit writes.
+    - Integrate with the delegated-token broker sample so MCP clients never receive raw `orgKey` or `newOrgKey`.
+    - Add dry-run output, redacted audit correlation, and clear refusal messages for unsafe parser execution or broad data mutation.
+    - Add sample README guidance and verifier self-tests that prove write tools are hidden by default and guarded when enabled.
+
+- [ ] #105 Add a policy-as-code authorization tester.
+  - Source: roleTables, filterWhitelist/filterBlacklist handlers, `TEST/run_debug_components.sh`, `samples/`, `AI_USAGE.md`, and `API_EXAMPLES.md`.
+  - Goal: let operators and AI-assisted workflows declare intended access policy and verify that CaumeDSE role/filter resources enforce it before deployment.
+  - Plan:
+    - Define a simple JSON or YAML policy format for users, roles, allowed routes, denied routes, methods, storage/document scopes, and expected status codes.
+    - Build a CLI/sample runner that creates disposable organizations and resources, applies roleTables and whitelist/blacklist filters, and executes expected allow/deny probes.
+    - Emit a redacted report that maps each policy rule to observed HTTP status, request id, route, and relevant audit category.
+    - Add negative cases for overbroad roles, missing filters, conflicting whitelist/blacklist rows, unsupported methods, and cleanup failures.
+    - Add documentation for AI-generated policy review, including prompt-boundary rules and human approval before applying generated policies to real deployments.
+
+- [ ] #106 Add an encrypted backup and restore utility.
+  - Source: storage path layout, ResourcesDB/ColumnFile DB handling, `filehandling.c`, `crypto.c`, `samples/`, `README.md`, and verifier fixtures.
+  - Goal: provide a portable, integrity-checked backup/restore workflow for CaumeDSE data directories and metadata, including mixed AES/Herradura protected data.
+  - Plan:
+    - Define a backup manifest containing schema version, file list, sizes, hashes, storage profile metadata, creation time, and redacted organization/storage identifiers.
+    - Encrypt backup payloads with the configured storage crypto profile while keeping key handling outside model-visible logs and command lines.
+    - Support restore into a fresh prefix with dry-run validation, manifest verification, profile compatibility checks, and explicit overwrite controls.
+    - Preserve mixed AES/Herradura data without rewriting protected values unless the operator separately invokes the re-protect workflow.
+    - Add verifier coverage for backup creation, tamper detection, wrong-key rejection, restore readback, redaction, and cleanup of temporary archive material.
+
+- [ ] #107 Add an operational health and readiness service.
+  - Source: `engine_admin.c`, `webservice_interface.c`, `config.c`, `runtime.c`, parser policy configuration, storage path checks, TLS/auth configuration, and `AI_USAGE.md`.
+  - Goal: expose a safe readiness view for operators and automation without leaking secrets or protected data.
+  - Plan:
+    - Add a CLI command or authenticated endpoint that reports database accessibility, configured storage crypto profile, Herradura build availability, parser policy, temp-directory safety, TLS-auth state, build mode, storage path readability/writability, and verifier-relevant limits.
+    - Redact secret values and avoid returning organization keys, certificate private keys, access passwords, OAuth secrets, or document contents.
+    - Include machine-readable JSON output for monitoring and AI-agent preflight checks, plus concise human-readable output for operators.
+    - Return distinct status codes or readiness states for healthy, degraded, misconfigured, and unsafe DEBUG-only configurations.
+    - Add DEBUG and live verifier coverage for healthy readiness, missing storage path, unsafe parser temp directory, Herradura-disabled profile requests, and redacted output.

--- a/TODO.md
+++ b/TODO.md
@@ -952,6 +952,7 @@
     - Support restore into a fresh prefix with dry-run validation, manifest verification, profile compatibility checks, and explicit overwrite controls.
     - Preserve mixed AES/Herradura data without rewriting protected values unless the operator separately invokes the re-protect workflow.
     - Add verifier coverage for backup creation, tamper detection, wrong-key rejection, restore readback, redaction, and cleanup of temporary archive material.
+  - Batch 1: added `samples/encrypted-backup-restore/` with a portable manifest utility that inventories CaumeDSE data directories, records file sizes/SHA-256 hashes/classification, redacts identifier-like labels and paths, verifies tamper/missing-file status, renders dry-run restore plans, documents the workflow, and adds an offline verifier self-test.
 
 - [ ] #107 Add an operational health and readiness service.
   - Source: `engine_admin.c`, `webservice_interface.c`, `config.c`, `runtime.c`, parser policy configuration, storage path checks, TLS/auth configuration, and `AI_USAGE.md`.

--- a/db.c
+++ b/db.c
@@ -2614,6 +2614,118 @@ int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const c
     return (0);
 }
 
+int cmeReprotectDBSaltedValue (const char *protectedValue, char **reprotectedValue,
+                               const char *sourceEncAlg, const char *targetEncAlg,
+                               char **sourceSalt, char **targetSalt,
+                               const char *sourceOrgKey, const char *targetOrgKey,
+                               int *reprotectedValueLen, int dryRun)
+{
+    int result;
+    int saltedValueLen=0;
+    int valueLen=0;
+    char *saltedValue=NULL;
+    char *value=NULL;
+    cmeCryptoProfile sourceProfile;
+    cmeCryptoProfile targetProfile;
+    #define cmeReprotectDBSaltedValueFree() \
+        do { \
+            if (saltedValue) \
+            { \
+                OPENSSL_cleanse(saltedValue,saltedValueLen>0 ? saltedValueLen : 1); \
+            } \
+            if (value) \
+            { \
+                OPENSSL_cleanse(value,valueLen>0 ? valueLen : 1); \
+            } \
+            cmeFree(saltedValue); \
+            cmeFree(value); \
+        } while (0); //Local free() macro
+
+    if (reprotectedValueLen)
+    {
+        *reprotectedValueLen=0;
+    }
+    if (reprotectedValue)
+    {
+        *reprotectedValue=NULL;
+    }
+    if ((!protectedValue)||(!sourceEncAlg)||(!targetEncAlg)||(!sourceSalt)||
+        (!sourceOrgKey)||(!targetOrgKey)||(!reprotectedValueLen)||
+        ((!dryRun)&&((!reprotectedValue)||(!targetSalt))))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeReprotectDBSaltedValue(), Error, NULL parameter.\n");
+#endif
+        return(1);
+    }
+    result=cmeGetCryptoProfile(&sourceProfile,sourceEncAlg);
+    if (result||(!sourceProfile.implemented))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeReprotectDBSaltedValue(), Error, source algorithm %s is not implemented.\n",
+                sourceEncAlg);
+#endif
+        return(2);
+    }
+    result=cmeGetCryptoProfile(&targetProfile,targetEncAlg);
+    if (result||(!targetProfile.implemented))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeReprotectDBSaltedValue(), Error, target algorithm %s is not implemented.\n",
+                targetEncAlg);
+#endif
+        return(3);
+    }
+    result=cmeUnprotectByteString(protectedValue,&saltedValue,sourceEncAlg,sourceSalt,sourceOrgKey,
+                                  &saltedValueLen,strlen(protectedValue));
+    if (result)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeReprotectDBSaltedValue(), Error, source value could not be unprotected.\n");
+#endif
+        cmeReprotectDBSaltedValueFree();
+        return(4);
+    }
+    if (saltedValueLen<=cmeDefaultValueSaltCharLen)
+    {
+#ifdef DEBUG
+        fprintf(stderr,"CaumeDSE Debug: cmeReprotectDBSaltedValue(), Warning, source value decrypted to an ambiguous salted length.\n");
+#endif
+        cmeReprotectDBSaltedValueFree();
+        return(5);
+    }
+    if (saltedValueLen>cmeDefaultValueSaltCharLen)
+    {
+        cmeStrConstrAppend(&value,"%s",&(saltedValue[cmeDefaultValueSaltCharLen]));
+        valueLen=saltedValueLen-cmeDefaultValueSaltCharLen;
+    }
+    if (dryRun)
+    {
+        *reprotectedValueLen=valueLen;
+#ifdef DEBUG
+        fprintf(stdout,"CaumeDSE Debug: cmeReprotectDBSaltedValue(), dry-run verified valueLen=%d from %s to %s.\n",
+                valueLen,sourceEncAlg,targetEncAlg);
+#endif
+        cmeReprotectDBSaltedValueFree();
+        return(0);
+    }
+    result=cmeProtectDBSaltedValue(value,reprotectedValue,targetEncAlg,targetSalt,targetOrgKey,reprotectedValueLen);
+    if (result)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeReprotectDBSaltedValue(), Error, target value could not be protected.\n");
+#endif
+        cmeReprotectDBSaltedValueFree();
+        return(6);
+    }
+#ifdef DEBUG
+    fprintf(stdout,"CaumeDSE Debug: cmeReprotectDBSaltedValue(), re-protected valueLen=%d from %s to %s.\n",
+            valueLen,sourceEncAlg,targetEncAlg);
+#endif
+    cmeReprotectDBSaltedValueFree();
+    return (0);
+}
+
 int cmeGetProtectDBLookupValue (const char *columnName, const char *value, const char *orgKey,
                                 char **lookupValue)
 {

--- a/db.c
+++ b/db.c
@@ -2726,6 +2726,174 @@ int cmeReprotectDBSaltedValue (const char *protectedValue, char **reprotectedVal
     return (0);
 }
 
+static int cmeDBProtectedValueHasHerraduraFrame(const char *protectedValue)
+{
+    int written=0;
+    unsigned char *decodedValue=NULL;
+    int hasFrame=0;
+
+    if (!protectedValue)
+    {
+        return(0);
+    }
+    if (!cmeB64ToStr((unsigned char *)protectedValue,&decodedValue,strlen(protectedValue),&written))
+    {
+        if (written>=cmeHerraduraKExFrameHeaderLen &&
+            !memcmp(decodedValue,cmeHerraduraKExFrameMagic,cmeHerraduraKExFrameMagicLen))
+        {
+            hasFrame=1;
+        }
+    }
+    cmeFree(decodedValue);
+    return(hasFrame);
+}
+
+int cmeInventoryMemSecureDBReprotect (sqlite3 *memSecureDB, const char *orgKey,
+                                      const char *targetEncAlg,
+                                      cmeReprotectDBInventory *inventory)
+{
+    int cont,result,written=0;
+    int numColsData=0;
+    int numRowsData=0;
+    int numColsMeta=0;
+    int numRowsMeta=0;
+    char **memData=NULL;
+    char **memMeta=NULL;
+    char *currentMetaAttribute=NULL;
+    char *currentMetaAttributeData=NULL;
+    char *currentMetaSalt=NULL;
+    cmeCryptoProfile targetProfile;
+    #define cmeInventoryMemSecureDBReprotectFree() \
+        do { \
+            cmeFree(currentMetaAttribute); \
+            cmeFree(currentMetaAttributeData); \
+            cmeFree(currentMetaSalt); \
+            if (memData) \
+            { \
+                cmeMemTableFinal(memData); \
+                memData=NULL; \
+            } \
+            if (memMeta) \
+            { \
+                cmeMemTableFinal(memMeta); \
+                memMeta=NULL; \
+            } \
+        } while (0); //Local free() macro
+
+    if ((!memSecureDB)||(!orgKey)||(!targetEncAlg)||(!inventory))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeInventoryMemSecureDBReprotect(), Error, NULL parameter.\n");
+#endif
+        return(1);
+    }
+    memset(inventory,0,sizeof(*inventory));
+    snprintf(inventory->targetProfile,sizeof(inventory->targetProfile),"%s",targetEncAlg);
+    result=cmeGetCryptoProfile(&targetProfile,targetEncAlg);
+    if (result||(!targetProfile.implemented))
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeInventoryMemSecureDBReprotect(), Error, target algorithm %s is not implemented.\n",
+                targetEncAlg);
+#endif
+        return(2);
+    }
+    result=cmeMemTable(memSecureDB,"SELECT * FROM data;",&memData,&numRowsData,&numColsData);
+    if (result)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeInventoryMemSecureDBReprotect(), cmeMemTable() Error"
+                " can't execute 'SELECT * FROM data;'!\n");
+#endif
+        cmeInventoryMemSecureDBReprotectFree();
+        return(3);
+    }
+    if (numColsData<cmeIDDColumnFileDataNumCols)
+    {
+        cmeInventoryMemSecureDBReprotectFree();
+        return(4);
+    }
+    inventory->dataRows=numRowsData;
+    for (cont=1;cont<=numRowsData;cont++)
+    {
+        if (cmeDBProtectedValueHasHerraduraFrame(memData[cont*numColsData+cmeIDDColumnFileData_value]))
+        {
+            inventory->herraduraValueRows++;
+        }
+        else if (memData[cont*numColsData+cmeIDDColumnFileData_value] &&
+                 memData[cont*numColsData+cmeIDDColumnFileData_value][0])
+        {
+            inventory->legacyAESValueRows++;
+        }
+        else
+        {
+            inventory->unknownValueRows++;
+        }
+    }
+    result=cmeMemTable(memSecureDB,"SELECT * FROM meta;",&memMeta,&numRowsMeta,&numColsMeta);
+    if (result)
+    {
+#ifdef ERROR_LOG
+        fprintf(stderr,"CaumeDSE Error: cmeInventoryMemSecureDBReprotect(), cmeMemTable() Error"
+                " can't execute 'SELECT * FROM meta;'!\n");
+#endif
+        cmeInventoryMemSecureDBReprotectFree();
+        return(5);
+    }
+    if (numColsMeta<cmeIDDColumnFileMetaNumCols)
+    {
+        cmeInventoryMemSecureDBReprotectFree();
+        return(6);
+    }
+    inventory->metaRows=numRowsMeta;
+    for (cont=1;cont<=numRowsMeta;cont++)
+    {
+        cmeStrConstrAppend(&currentMetaSalt,"%s",memMeta[cont*numColsMeta+cmeIDDanydb_salt]);
+        result=cmeUnprotectDBSaltedValue(memMeta[cont*numColsMeta+cmeIDDColumnFileMeta_attribute],
+                                         &currentMetaAttribute,cmeDefaultEncAlg,&currentMetaSalt,orgKey,&written);
+        if (result)
+        {
+            cmeInventoryMemSecureDBReprotectFree();
+            return(7);
+        }
+        result=cmeUnprotectDBSaltedValue(memMeta[cont*numColsMeta+cmeIDDColumnFileMeta_attributeData],
+                                         &currentMetaAttributeData,cmeDefaultEncAlg,&currentMetaSalt,orgKey,&written);
+        if (result)
+        {
+            cmeInventoryMemSecureDBReprotectFree();
+            return(8);
+        }
+        if (!strcmp(currentMetaAttribute,cmeIDDColumnFileMeta_attribute_2))
+        {
+            inventory->protectMetaRows++;
+            inventory->protectedValueRows+=numRowsData;
+            if (!inventory->sourceProfile[0])
+            {
+                snprintf(inventory->sourceProfile,sizeof(inventory->sourceProfile),"%s",currentMetaAttributeData);
+            }
+            if (!strcmp(currentMetaAttributeData,targetEncAlg))
+            {
+                inventory->targetProfileRows++;
+            }
+            else
+            {
+                inventory->sourceProfileRows++;
+            }
+        }
+        cmeFree(currentMetaAttribute);
+        cmeFree(currentMetaAttributeData);
+        cmeFree(currentMetaSalt);
+    }
+#ifdef DEBUG
+    fprintf(stdout,"CaumeDSE Debug: cmeInventoryMemSecureDBReprotect(), rows=%d protectedValues=%d source=%s target=%s legacyAES=%d herradura=%d unknown=%d.\n",
+            inventory->dataRows,inventory->protectedValueRows,inventory->sourceProfile,
+            inventory->targetProfile,inventory->legacyAESValueRows,inventory->herraduraValueRows,
+            inventory->unknownValueRows);
+#endif
+    cmeInventoryMemSecureDBReprotectFree();
+    return(0);
+}
+
 int cmeGetProtectDBLookupValue (const char *columnName, const char *value, const char *orgKey,
                                 char **lookupValue)
 {

--- a/db.h
+++ b/db.h
@@ -92,12 +92,31 @@ int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const cha
 // Function to unprotect+unsalt (decodify B64, unencrypt and remove salt from value) a salt+protected text string.
 int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const char *encAlg, char **salt,
                                const char *orgKey, int *valueLen);
+typedef struct
+{
+    int metaRows;
+    int dataRows;
+    int protectMetaRows;
+    int protectedValueRows;
+    int sourceProfileRows;
+    int targetProfileRows;
+    int legacyAESValueRows;
+    int herraduraValueRows;
+    int unknownValueRows;
+    char sourceProfile[64];
+    char targetProfile[64];
+} cmeReprotectDBInventory;
+
 // Function to strictly unprotect+reprotect one salted DB value for explicit key/profile rotation workflows.
 int cmeReprotectDBSaltedValue (const char *protectedValue, char **reprotectedValue,
                                const char *sourceEncAlg, const char *targetEncAlg,
                                char **sourceSalt, char **targetSalt,
                                const char *sourceOrgKey, const char *targetOrgKey,
                                int *reprotectedValueLen, int dryRun);
+// Function to inventory a protected in-memory column-file DB before explicit key/profile rotation.
+int cmeInventoryMemSecureDBReprotect (sqlite3 *memSecureDB, const char *orgKey,
+                                      const char *targetEncAlg,
+                                      cmeReprotectDBInventory *inventory);
 // Function to compute deterministic keyed lookup values for selected protected exact-match columns.
 int cmeGetProtectDBLookupValue (const char *columnName, const char *value, const char *orgKey,
                                 char **lookupValue);

--- a/db.h
+++ b/db.h
@@ -92,6 +92,12 @@ int cmeProtectDBSaltedValue (const char *value, char **protectedValue, const cha
 // Function to unprotect+unsalt (decodify B64, unencrypt and remove salt from value) a salt+protected text string.
 int cmeUnprotectDBSaltedValue (const char *protectedValue, char **value, const char *encAlg, char **salt,
                                const char *orgKey, int *valueLen);
+// Function to strictly unprotect+reprotect one salted DB value for explicit key/profile rotation workflows.
+int cmeReprotectDBSaltedValue (const char *protectedValue, char **reprotectedValue,
+                               const char *sourceEncAlg, const char *targetEncAlg,
+                               char **sourceSalt, char **targetSalt,
+                               const char *sourceOrgKey, const char *targetOrgKey,
+                               int *reprotectedValueLen, int dryRun);
 // Function to compute deterministic keyed lookup values for selected protected exact-match columns.
 int cmeGetProtectDBLookupValue (const char *columnName, const char *value, const char *orgKey,
                                 char **lookupValue);

--- a/debug_tests.c
+++ b/debug_tests.c
@@ -106,6 +106,7 @@ int main(int argc, char *argv[], char *env[])
     testCryptoSymmetricGCM_ByteString();
     testEngMgmnt();
     testCryptoSymmetric(bufIn,bufOut);
+    testCryptoReprotectDBValue();
     testHerraduraIndependent();
     testCryptoDigest_Str(bufIn);
     testCryptoHMAC();

--- a/engine_admin.c
+++ b/engine_admin.c
@@ -1053,7 +1053,10 @@ int cmeWebServiceSetup (unsigned short port, int useSSL, const char *sslKeyFile,
                         unsigned int numThreads)
 {
     int result;
+    int daemonErrno=0;
     int stopHandlersInstalled=0;
+    unsigned int nThreads = numThreads ? numThreads : (unsigned int)cmeDefaultMaxThreads;
+    unsigned int connectionLimit = nThreads*4;
     struct sigaction oldIntAction;
     struct sigaction oldTermAction;
     struct MHD_Daemon *webServiceDaemon=NULL;
@@ -1093,26 +1096,28 @@ int cmeWebServiceSetup (unsigned short port, int useSSL, const char *sslKeyFile,
             cmeWebServiceSetupFree();
             return (1);
         }
-        {
-            unsigned int nThreads = numThreads ? numThreads : (unsigned int)cmeDefaultMaxThreads;
-            webServiceDaemon = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD | MHD_USE_SSL,
-                                                port,NULL,NULL,
-                                                (MHD_AccessHandlerCallback)&cmeWebServiceAnswerConnection,NULL,
-                                                MHD_OPTION_NOTIFY_COMPLETED,&cmeWebServiceRequestCompleted,NULL,
-                                                MHD_OPTION_THREAD_POOL_SIZE,(unsigned int)nThreads,
-                                                MHD_OPTION_CONNECTION_LIMIT,(unsigned int)(nThreads*4),
-                                                MHD_OPTION_HTTPS_MEM_KEY,key_pem,
-                                                MHD_OPTION_HTTPS_MEM_CERT,cert_pem,
-                                                MHD_OPTION_HTTPS_MEM_TRUST,ca_pem,    //root CA certificate = engine certificate; CA certifies organization, and organization certifies user.
-                                                MHD_OPTION_END);
-        }
+        errno=0;
+        webServiceDaemon = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD | MHD_USE_SSL,
+                                            port,NULL,NULL,
+                                            (MHD_AccessHandlerCallback)&cmeWebServiceAnswerConnection,NULL,
+                                            MHD_OPTION_NOTIFY_COMPLETED,&cmeWebServiceRequestCompleted,NULL,
+                                            MHD_OPTION_THREAD_POOL_SIZE,nThreads,
+                                            MHD_OPTION_CONNECTION_LIMIT,connectionLimit,
+                                            MHD_OPTION_HTTPS_MEM_KEY,key_pem,
+                                            MHD_OPTION_HTTPS_MEM_CERT,cert_pem,
+                                            MHD_OPTION_HTTPS_MEM_TRUST,ca_pem,    //root CA certificate = engine certificate; CA certifies organization, and organization certifies user.
+                                            MHD_OPTION_END);
+        daemonErrno=errno;
 
         if (NULL == webServiceDaemon) //Error
         {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeWebServiceSetup(), Error, can't "
                 "start HTTPS server on port %d. Cert path: %s. Key path: %s. "
-                "CA path: %s.\n",port,sslCertFile,sslKeyFile,caCertFile);
+                "CA path: %s. Flags: MHD_USE_INTERNAL_POLLING_THREAD|MHD_USE_SSL. "
+                "threads=%u connectionLimit=%u errno=%d (%s).\n",
+                port,sslCertFile,sslKeyFile,caCertFile,nThreads,connectionLimit,
+                daemonErrno,strerror(daemonErrno));
 #endif
             cmeWebServiceSetupFree();
             return (2);
@@ -1120,21 +1125,22 @@ int cmeWebServiceSetup (unsigned short port, int useSSL, const char *sslKeyFile,
     }
     else  //HTTP
     {
-        {
-            unsigned int nThreads = numThreads ? numThreads : (unsigned int)cmeDefaultMaxThreads;
-            webServiceDaemon = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD,
-                                                port, NULL, NULL,
-                                                (MHD_AccessHandlerCallback)&cmeWebServiceAnswerConnection,NULL,
-                                                MHD_OPTION_NOTIFY_COMPLETED,&cmeWebServiceRequestCompleted,NULL,
-                                                MHD_OPTION_THREAD_POOL_SIZE,(unsigned int)nThreads,
-                                                MHD_OPTION_CONNECTION_LIMIT,(unsigned int)(nThreads*4),
-                                                MHD_OPTION_END);
-        }
+        errno=0;
+        webServiceDaemon = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD,
+                                            port, NULL, NULL,
+                                            (MHD_AccessHandlerCallback)&cmeWebServiceAnswerConnection,NULL,
+                                            MHD_OPTION_NOTIFY_COMPLETED,&cmeWebServiceRequestCompleted,NULL,
+                                            MHD_OPTION_THREAD_POOL_SIZE,nThreads,
+                                            MHD_OPTION_CONNECTION_LIMIT,connectionLimit,
+                                            MHD_OPTION_END);
+        daemonErrno=errno;
         if (NULL == webServiceDaemon)
         {
 #ifdef ERROR_LOG
         fprintf(stderr,"CaumeDSE Error: cmeWebServiceSetup(), Error, can't "
-                "start HTTP server on port %d!\n",port);
+                "start HTTP server on port %d. Flags: MHD_USE_INTERNAL_POLLING_THREAD. "
+                "threads=%u connectionLimit=%u errno=%d (%s).\n",
+                port,nThreads,connectionLimit,daemonErrno,strerror(daemonErrno));
 #endif
             cmeWebServiceSetupFree();
             return (3);

--- a/function_tests.c
+++ b/function_tests.c
@@ -894,6 +894,128 @@ void testCryptoSymmetric(unsigned char *bufIn, unsigned char *bufOut)
     cmeFree(expectedKeyIv);
 }
 
+void testCryptoReprotectDBValue(void)
+{
+    const char *value="CaumeDSE explicit re-protect test value.";
+    const char *oldKey="OldRotationPassword";
+    const char *newKey="NewRotationPassword";
+    char *sourceSalt=NULL;
+    char *rotatedSalt=NULL;
+    char *dryRunSalt=NULL;
+    char *protectedValue=NULL;
+    char *rotatedValue=NULL;
+    char *readbackValue=NULL;
+    char *wrongKeyValue=NULL;
+    int protectedValueLen=0;
+    int rotatedValueLen=0;
+    int readbackValueLen=0;
+    int dryRunValueLen=0;
+
+    if (!cmeProtectDBSaltedValue(value,&protectedValue,cmeOpenSSLLegacyStorageProfile,
+                                 &sourceSalt,oldKey,&protectedValueLen) &&
+        !cmeReprotectDBSaltedValue(protectedValue,&rotatedValue,cmeOpenSSLLegacyStorageProfile,
+                                   cmeOpenSSLLegacyStorageProfile,&sourceSalt,&rotatedSalt,
+                                   oldKey,newKey,&rotatedValueLen,0) &&
+        rotatedSalt && strcmp(sourceSalt,rotatedSalt) &&
+        !cmeUnprotectDBSaltedValue(rotatedValue,&readbackValue,cmeOpenSSLLegacyStorageProfile,
+                                   &rotatedSalt,newKey,&readbackValueLen) &&
+        readbackValueLen==(int)strlen(value) && !strcmp(value,readbackValue))
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rotates key with AES profile.\n");
+    }
+    else
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), FAIL: DB value AES key rotation failed.\n");
+    }
+    cmeFree(readbackValue);
+    readbackValue=NULL;
+    readbackValueLen=0;
+
+    if (!cmeReprotectDBSaltedValue(protectedValue,NULL,cmeOpenSSLLegacyStorageProfile,
+                                   cmeOpenSSLLegacyStorageProfile,&sourceSalt,&dryRunSalt,
+                                   oldKey,newKey,&dryRunValueLen,1) &&
+        dryRunValueLen==(int)strlen(value) && dryRunSalt==NULL)
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), PASS: DB value dry-run re-protect reports plaintext length without writing.\n");
+    }
+    else
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), FAIL: DB value dry-run re-protect failed.\n");
+    }
+
+    if (cmeReprotectDBSaltedValue(protectedValue,&wrongKeyValue,cmeOpenSSLLegacyStorageProfile,
+                                  cmeOpenSSLLegacyStorageProfile,&sourceSalt,&dryRunSalt,
+                                  "WrongRotationPassword",newKey,&rotatedValueLen,0))
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rejects wrong source key.\n");
+    }
+    else
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), FAIL: DB value re-protect accepted wrong source key.\n");
+    }
+    cmeFree(wrongKeyValue);
+    wrongKeyValue=NULL;
+
+    if (cmeUseHerraduraKEx)
+    {
+        char *hkxSalt=NULL;
+        char *hkxValue=NULL;
+        char *hkxReadback=NULL;
+        char *rollbackSalt=NULL;
+        char *rollbackValue=NULL;
+        char *rollbackReadback=NULL;
+        int hkxValueLen=0;
+        int hkxReadbackLen=0;
+        int rollbackValueLen=0;
+        int rollbackReadbackLen=0;
+
+        if (!cmeReprotectDBSaltedValue(protectedValue,&hkxValue,cmeOpenSSLLegacyStorageProfile,
+                                       cmeHerraduraKExProfileHSKENLA1AEAD256,&sourceSalt,&hkxSalt,
+                                       oldKey,newKey,&hkxValueLen,0) &&
+            !cmeUnprotectDBSaltedValue(hkxValue,&hkxReadback,cmeHerraduraKExProfileHSKENLA1AEAD256,
+                                       &hkxSalt,newKey,&hkxReadbackLen) &&
+            hkxReadbackLen==(int)strlen(value) && !strcmp(value,hkxReadback))
+        {
+            printf("TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect migrates AES to Herradura profile.\n");
+        }
+        else
+        {
+            printf("TESTS: testCryptoReprotectDBValue(), FAIL: DB value AES to Herradura re-protect failed.\n");
+        }
+        if (hkxValue &&
+            !cmeReprotectDBSaltedValue(hkxValue,&rollbackValue,cmeHerraduraKExProfileHSKENLA1AEAD256,
+                                       cmeOpenSSLLegacyStorageProfile,&hkxSalt,&rollbackSalt,
+                                       newKey,oldKey,&rollbackValueLen,0) &&
+            !cmeUnprotectDBSaltedValue(rollbackValue,&rollbackReadback,cmeOpenSSLLegacyStorageProfile,
+                                       &rollbackSalt,oldKey,&rollbackReadbackLen) &&
+            rollbackReadbackLen==(int)strlen(value) && !strcmp(value,rollbackReadback))
+        {
+            printf("TESTS: testCryptoReprotectDBValue(), PASS: DB value re-protect rolls Herradura back to AES profile.\n");
+        }
+        else
+        {
+            printf("TESTS: testCryptoReprotectDBValue(), FAIL: DB value Herradura rollback re-protect failed.\n");
+        }
+        cmeFree(hkxSalt);
+        cmeFree(hkxValue);
+        cmeFree(hkxReadback);
+        cmeFree(rollbackSalt);
+        cmeFree(rollbackValue);
+        cmeFree(rollbackReadback);
+    }
+    else
+    {
+        printf("TESTS: testCryptoReprotectDBValue(), SKIP: HerraduraKEx provider is not compiled in.\n");
+    }
+
+    cmeFree(sourceSalt);
+    cmeFree(rotatedSalt);
+    cmeFree(dryRunSalt);
+    cmeFree(protectedValue);
+    cmeFree(rotatedValue);
+    cmeFree(readbackValue);
+}
+
 void testCryptoSymmetricGCM()
 {
     const unsigned char cleartext[] = "This is cleartext for GCM.";

--- a/function_tests.c
+++ b/function_tests.c
@@ -1014,6 +1014,44 @@ void testCryptoReprotectDBValue(void)
     cmeFree(protectedValue);
     cmeFree(rotatedValue);
     cmeFree(readbackValue);
+
+    {
+        sqlite3 *memDB=NULL;
+        cmeReprotectDBInventory inventory;
+        int inventoryOK=0;
+
+        memset(&inventory,0,sizeof(inventory));
+        if (!sqlite3_open(":memory:",&memDB) &&
+            !cmeSQLRows(memDB,
+                        "BEGIN TRANSACTION;"
+                        "CREATE TABLE data (id INTEGER PRIMARY KEY,userId TEXT,orgId TEXT,salt TEXT,value TEXT,rowOrder TEXT,MAC TEXT,sign TEXT,MACProtected TEXT,signProtected TEXT,otphDKey TEXT);"
+                        "CREATE TABLE meta (id INTEGER PRIMARY KEY,userId TEXT,orgId TEXT,salt TEXT,attribute TEXT,attributeData TEXT);"
+                        "INSERT INTO data VALUES (1,'userA','orgA','','alpha','1','','','','','');"
+                        "INSERT INTO data VALUES (2,'userA','orgA','','beta','2','','','','','');"
+                        "INSERT INTO meta VALUES (1,'userA','orgA','','protect','aes-256-gcm');"
+                        "COMMIT;",NULL,NULL) &&
+            !cmeMemSecureDBProtect(memDB,oldKey) &&
+            !cmeInventoryMemSecureDBReprotect(memDB,oldKey,cmeOpenSSLLegacyStorageProfile,&inventory) &&
+            inventory.dataRows==2 && inventory.metaRows==1 && inventory.protectMetaRows==1 &&
+            inventory.protectedValueRows==2 && inventory.targetProfileRows==1 &&
+            inventory.legacyAESValueRows==2 && inventory.herraduraValueRows==0 &&
+            !strcmp(inventory.sourceProfile,cmeOpenSSLLegacyStorageProfile))
+        {
+            inventoryOK=1;
+        }
+        if (inventoryOK)
+        {
+            printf("TESTS: testCryptoReprotectDBValue(), PASS: DB re-protect inventory reports AES protected row scope.\n");
+        }
+        else
+        {
+            printf("TESTS: testCryptoReprotectDBValue(), FAIL: DB re-protect inventory failed AES protected row scope.\n");
+        }
+        if (memDB)
+        {
+            sqlite3_close(memDB);
+        }
+    }
 }
 
 void testCryptoSymmetricGCM()

--- a/function_tests.h
+++ b/function_tests.h
@@ -47,6 +47,7 @@ Copyright 2010-2026 by Omar Alejandro Herrera Reyna
 
 //Test functions for the rest of the engine functions
 void testCryptoSymmetric(unsigned char *bufIn, unsigned char *bufOut);
+void testCryptoReprotectDBValue(void);
 void testHerraduraIndependent(void);
 void testCryptoSymmetricGCM();
 void testCryptoSymmetricGCM_ByteString();

--- a/samples/encrypted-backup-restore/README.md
+++ b/samples/encrypted-backup-restore/README.md
@@ -1,15 +1,17 @@
 # CaumeDSE Encrypted Backup And Restore Utility
 
-This sample starts the backup/restore workflow with a portable integrity
-manifest. It records file paths, sizes, SHA-256 hashes, storage-file
-classification, creation time, and redacted source identifiers for a CaumeDSE
-data directory.
+This sample provides a portable encrypted backup/restore workflow for a
+CaumeDSE data directory. It records file paths, sizes, SHA-256 hashes,
+storage-file classification, creation time, and redacted source identifiers,
+then stores a tar payload inside an authenticated encrypted backup package.
 
-Batch 1 deliberately preserves existing protected values exactly as stored. It
-does not re-encrypt AES or Herradura-protected database values and does not
-change storage profiles. Encryption wrapping for the archive payload is the next
-batch; this manifest is the integrity contract that encrypted backups will
-carry.
+The utility deliberately preserves existing protected values exactly as stored.
+It does not re-encrypt AES or Herradura-protected database values and does not
+change storage profiles. Use the separate re-protect workflow when an operator
+explicitly wants to migrate protected values between AES and Herradura profiles.
+
+The backup key is read from `CDSE_BACKUP_KEY` by default, or from a key file via
+`--key-file`. Do not pass backup keys on command lines.
 
 ## Commands
 
@@ -44,12 +46,54 @@ Run offline checks:
 python3 samples/encrypted-backup-restore/cdse_backup_restore.py self-test
 ```
 
+Create an encrypted backup package:
+
+```sh
+CDSE_BACKUP_KEY="$(openssl rand -base64 32)" \
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py create-backup \
+  --source /tmp/cdse-verify/cdse \
+  --label test-storage \
+  --profile mixed-existing \
+  --output backup.cdsebackup.json
+```
+
+Authenticate a backup package without restoring it:
+
+```sh
+CDSE_BACKUP_KEY="$CDSE_BACKUP_KEY" \
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py verify-backup \
+  --backup backup.cdsebackup.json
+```
+
+Dry-run a restore into a fresh prefix:
+
+```sh
+CDSE_BACKUP_KEY="$CDSE_BACKUP_KEY" \
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py restore \
+  --backup backup.cdsebackup.json \
+  --target /tmp/cdse-restore \
+  --expected-profile mixed-existing \
+  --dry-run
+```
+
+Restore after reviewing the plan:
+
+```sh
+CDSE_BACKUP_KEY="$CDSE_BACKUP_KEY" \
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py restore \
+  --backup backup.cdsebackup.json \
+  --target /tmp/cdse-restore \
+  --expected-profile mixed-existing
+```
+
 ## Security Notes
 
 - Do not put organization keys, TLS private keys, delegated tokens, or OAuth
   secrets in manifest labels, paths, or logs.
 - Treat manifests as sensitive operational metadata even though identifiers are
   redacted.
+- The encrypted package uses OpenSSL `enc` with AES-256-CBC/PBKDF2 and an outer
+  HMAC-SHA256 over the ciphertext for wrong-key and tamper rejection.
 - Preserve mixed AES/Herradura data as-is unless a separate explicit re-protect
   workflow is run.
 - Verify manifests before restoring, and restore into a fresh prefix unless an

--- a/samples/encrypted-backup-restore/README.md
+++ b/samples/encrypted-backup-restore/README.md
@@ -1,0 +1,56 @@
+# CaumeDSE Encrypted Backup And Restore Utility
+
+This sample starts the backup/restore workflow with a portable integrity
+manifest. It records file paths, sizes, SHA-256 hashes, storage-file
+classification, creation time, and redacted source identifiers for a CaumeDSE
+data directory.
+
+Batch 1 deliberately preserves existing protected values exactly as stored. It
+does not re-encrypt AES or Herradura-protected database values and does not
+change storage profiles. Encryption wrapping for the archive payload is the next
+batch; this manifest is the integrity contract that encrypted backups will
+carry.
+
+## Commands
+
+Create a manifest:
+
+```sh
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py manifest \
+  --source /tmp/cdse-verify/cdse \
+  --label test-storage \
+  --output backup-manifest.json
+```
+
+Verify a manifest against a source directory:
+
+```sh
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py verify \
+  --manifest backup-manifest.json \
+  --source /tmp/cdse-verify/cdse
+```
+
+Render a restore plan without writing files:
+
+```sh
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py plan-restore \
+  --manifest backup-manifest.json \
+  --target /tmp/cdse-restore
+```
+
+Run offline checks:
+
+```sh
+python3 samples/encrypted-backup-restore/cdse_backup_restore.py self-test
+```
+
+## Security Notes
+
+- Do not put organization keys, TLS private keys, delegated tokens, or OAuth
+  secrets in manifest labels, paths, or logs.
+- Treat manifests as sensitive operational metadata even though identifiers are
+  redacted.
+- Preserve mixed AES/Herradura data as-is unless a separate explicit re-protect
+  workflow is run.
+- Verify manifests before restoring, and restore into a fresh prefix unless an
+  operator explicitly approves overwrite behavior.

--- a/samples/encrypted-backup-restore/cdse_backup_restore.py
+++ b/samples/encrypted-backup-restore/cdse_backup_restore.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+CaumeDSE backup/restore manifest utility sample.
+
+Builds a portable integrity manifest for a CaumeDSE data directory, verifies
+manifest/file consistency, and renders restore plans without exposing secrets.
+Uses only Python's standard library; encryption wrapping is intentionally a
+separate follow-up around this manifest contract.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+SAMPLE_DIR = Path(__file__).resolve().parent
+MANIFEST_SCHEMA_VERSION = 1
+SENSITIVE_NAME_RE = re.compile(r"(?i)(orgKey|newOrgKey|accessPassword|oauthConsumerSecret|privateKey|secret)")
+HEXISH_RE = re.compile(r"\b[A-Fa-f0-9]{16,}\b")
+
+
+class BackupError(Exception):
+    pass
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def redact_text(value):
+    text = str(value)
+    text = SENSITIVE_NAME_RE.sub("<redacted>", text)
+    text = HEXISH_RE.sub("<redacted-hex>", text)
+    return text
+
+
+def relative_files(root):
+    root = Path(root)
+    if not root.is_dir():
+        raise BackupError(f"Source directory does not exist: {root}")
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel.startswith("."):
+            continue
+        files.append((rel, path))
+    return files
+
+
+def classify_file(rel_path):
+    name = Path(rel_path).name
+    if name == "ResourcesDB":
+        return "resourcesDB"
+    if name == "RolesDB":
+        return "rolesDB"
+    if name == "LogsDB":
+        return "logsDB"
+    if name.endswith(".sqlite") or name.endswith(".db") or "column" in name.lower():
+        return "columnFileOrSQLite"
+    return "storageFile"
+
+
+def build_manifest(source_dir, label=None, profile="mixed-existing"):
+    source = Path(source_dir).resolve()
+    entries = []
+    total_size = 0
+    for rel, path in relative_files(source):
+        size = path.stat().st_size
+        total_size += size
+        entries.append({
+            "path": rel,
+            "redactedPath": redact_text(rel),
+            "size": size,
+            "sha256": sha256_file(path),
+            "kind": classify_file(rel),
+        })
+    manifest = {
+        "manifestSchemaVersion": MANIFEST_SCHEMA_VERSION,
+        "safeForAgent": True,
+        "createdAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "source": {
+            "label": redact_text(label or source.name),
+            "rootName": redact_text(source.name),
+        },
+        "storageCrypto": {
+            "profile": profile,
+            "note": "Manifest preserves existing protected AES/Herradura data without rewriting values.",
+        },
+        "summary": {
+            "fileCount": len(entries),
+            "totalBytes": total_size,
+        },
+        "files": entries,
+    }
+    return manifest
+
+
+def verify_manifest(manifest, source_dir):
+    if not isinstance(manifest, dict) or manifest.get("manifestSchemaVersion") != MANIFEST_SCHEMA_VERSION:
+        raise BackupError("Unsupported or invalid manifest schema.")
+    source = Path(source_dir)
+    results = []
+    for entry in manifest.get("files", []):
+        rel = entry.get("path")
+        if not isinstance(rel, str) or rel.startswith("/") or ".." in Path(rel).parts:
+            raise BackupError(f"Unsafe manifest path: {rel}")
+        path = source / rel
+        if not path.is_file():
+            results.append({"path": redact_text(rel), "status": "missing", "passed": False})
+            continue
+        size = path.stat().st_size
+        digest = sha256_file(path)
+        passed = size == entry.get("size") and digest == entry.get("sha256")
+        results.append({
+            "path": redact_text(rel),
+            "status": "ok" if passed else "mismatch",
+            "passed": passed,
+            "expectedSize": entry.get("size"),
+            "actualSize": size,
+        })
+    passed_count = sum(1 for item in results if item["passed"])
+    return {
+        "safeForAgent": True,
+        "summary": {
+            "passed": passed_count,
+            "failed": len(results) - passed_count,
+        },
+        "results": results,
+    }
+
+
+def restore_plan(manifest, target_dir, overwrite=False):
+    target = Path(target_dir)
+    planned = []
+    for entry in manifest.get("files", []):
+        rel = entry["path"]
+        destination = target / rel
+        planned.append({
+            "path": redact_text(rel),
+            "destination": redact_text(destination),
+            "size": entry["size"],
+            "action": "overwrite" if overwrite and destination.exists() else "create",
+        })
+    return {
+        "safeForAgent": True,
+        "target": redact_text(target),
+        "overwrite": overwrite,
+        "plannedFiles": planned,
+    }
+
+
+def load_json(path):
+    try:
+        with Path(path).open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except OSError as exc:
+        raise BackupError(f"Cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise BackupError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def write_json(data, path=None):
+    text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    if path:
+        Path(path).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+
+def manifest_command(args):
+    manifest = build_manifest(args.source, args.label, args.profile)
+    write_json(manifest, args.output)
+
+
+def verify_command(args):
+    report = verify_manifest(load_json(args.manifest), args.source)
+    write_json(report, args.output)
+    return 0 if report["summary"]["failed"] == 0 else 1
+
+
+def plan_restore_command(args):
+    plan = restore_plan(load_json(args.manifest), args.target, args.overwrite)
+    write_json(plan, args.output)
+
+
+def self_test():
+    with tempfile.TemporaryDirectory(prefix="cdse-backup-self-test-") as tmp:
+        root = Path(tmp) / "source"
+        root.mkdir()
+        (root / "ResourcesDB").write_text("resources fixture\n", encoding="utf-8")
+        (root / "column-0001.db").write_bytes(b"column data")
+        nested = root / "storage"
+        nested.mkdir()
+        (nested / "document.csv").write_text("name,salary\nAda,10\n", encoding="utf-8")
+        manifest = build_manifest(root, label="OrgKeyABCDEF1234567890abcdef", profile="mixed-aes-herradura")
+        if manifest["summary"]["fileCount"] != 3:
+            raise BackupError("self-test manifest file count mismatch.")
+        if "ABCDEF1234567890abcdef" in json.dumps(manifest):
+            raise BackupError("self-test manifest leaked an identifier-like value.")
+        ok = verify_manifest(manifest, root)
+        if ok["summary"]["failed"] != 0:
+            raise BackupError("self-test verification failed for unchanged source.")
+        (nested / "document.csv").write_text("name,salary\nAda,999\n", encoding="utf-8")
+        tampered = verify_manifest(manifest, root)
+        if tampered["summary"]["failed"] != 1:
+            raise BackupError("self-test did not detect tampered file.")
+        plan = restore_plan(manifest, Path(tmp) / "restore")
+        if len(plan["plannedFiles"]) != 3 or plan["safeForAgent"] is not True:
+            raise BackupError("self-test restore plan mismatch.")
+    print("PASS encrypted backup restore self-test")
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Create and verify CaumeDSE backup manifests.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    manifest = sub.add_parser("manifest", help="Create an integrity manifest for a data directory.")
+    manifest.add_argument("--source", required=True)
+    manifest.add_argument("--label")
+    manifest.add_argument("--profile", default="mixed-existing")
+    manifest.add_argument("--output")
+    verify = sub.add_parser("verify", help="Verify a manifest against a data directory.")
+    verify.add_argument("--manifest", required=True)
+    verify.add_argument("--source", required=True)
+    verify.add_argument("--output")
+    plan = sub.add_parser("plan-restore", help="Render a safe restore plan without writing files.")
+    plan.add_argument("--manifest", required=True)
+    plan.add_argument("--target", required=True)
+    plan.add_argument("--overwrite", action="store_true")
+    plan.add_argument("--output")
+    sub.add_parser("self-test", help="Run offline manifest, tamper, and restore-plan checks.")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        if args.command == "manifest":
+            manifest_command(args)
+        elif args.command == "verify":
+            return verify_command(args)
+        elif args.command == "plan-restore":
+            plan_restore_command(args)
+        elif args.command == "self-test":
+            self_test()
+    except BackupError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/samples/encrypted-backup-restore/cdse_backup_restore.py
+++ b/samples/encrypted-backup-restore/cdse_backup_restore.py
@@ -2,17 +2,22 @@
 """
 CaumeDSE backup/restore manifest utility sample.
 
-Builds a portable integrity manifest for a CaumeDSE data directory, verifies
-manifest/file consistency, and renders restore plans without exposing secrets.
-Uses only Python's standard library; encryption wrapping is intentionally a
-separate follow-up around this manifest contract.
+Builds a portable encrypted backup package for a CaumeDSE data directory,
+verifies manifest/file consistency, and restores payloads without exposing
+secrets on command lines or in model-visible logs.
 """
 
 import argparse
+import base64
 import hashlib
+import hmac
 import json
+import os
 import re
+import shutil
+import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 from pathlib import Path
@@ -20,6 +25,9 @@ from pathlib import Path
 
 SAMPLE_DIR = Path(__file__).resolve().parent
 MANIFEST_SCHEMA_VERSION = 1
+BACKUP_PACKAGE_VERSION = 1
+PBKDF2_ITERATIONS = 250000
+MAC_KEY_LABEL = b"CaumeDSE backup package MAC v1"
 SENSITIVE_NAME_RE = re.compile(r"(?i)(orgKey|newOrgKey|accessPassword|oauthConsumerSecret|privateKey|secret)")
 HEXISH_RE = re.compile(r"\b[A-Fa-f0-9]{16,}\b")
 
@@ -36,11 +44,34 @@ def sha256_file(path):
     return digest.hexdigest()
 
 
+def sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
 def redact_text(value):
     text = str(value)
     text = SENSITIVE_NAME_RE.sub("<redacted>", text)
     text = HEXISH_RE.sub("<redacted-hex>", text)
     return text
+
+
+def read_backup_key(key_env=None, key_file=None):
+    if key_env and key_file:
+        raise BackupError("Use either --key-env or --key-file, not both.")
+    if key_file:
+        try:
+            key = Path(key_file).read_bytes().strip()
+        except OSError as exc:
+            raise BackupError(f"Cannot read backup key file: {exc}") from exc
+    else:
+        env_name = key_env or "CDSE_BACKUP_KEY"
+        key_value = os.environ.get(env_name)
+        if not key_value:
+            raise BackupError(f"Backup key is required in ${env_name} or via --key-file.")
+        key = key_value.encode("utf-8")
+    if len(key) < 16:
+        raise BackupError("Backup key must be at least 16 bytes.")
+    return key
 
 
 def relative_files(root):
@@ -106,6 +137,10 @@ def build_manifest(source_dir, label=None, profile="mixed-existing"):
     return manifest
 
 
+def load_manifest_from_path(path):
+    return load_json(path)
+
+
 def verify_manifest(manifest, source_dir):
     if not isinstance(manifest, dict) or manifest.get("manifestSchemaVersion") != MANIFEST_SCHEMA_VERSION:
         raise BackupError("Unsupported or invalid manifest schema.")
@@ -140,7 +175,17 @@ def verify_manifest(manifest, source_dir):
     }
 
 
+def ensure_manifest_compatible(manifest, expected_profile=None):
+    if not isinstance(manifest, dict) or manifest.get("manifestSchemaVersion") != MANIFEST_SCHEMA_VERSION:
+        raise BackupError("Unsupported or invalid manifest schema.")
+    profile = manifest.get("storageCrypto", {}).get("profile")
+    if expected_profile and profile != expected_profile:
+        raise BackupError(f"Backup profile {profile!r} does not match expected profile {expected_profile!r}.")
+    return profile
+
+
 def restore_plan(manifest, target_dir, overwrite=False):
+    ensure_manifest_compatible(manifest)
     target = Path(target_dir)
     planned = []
     for entry in manifest.get("files", []):
@@ -157,6 +202,207 @@ def restore_plan(manifest, target_dir, overwrite=False):
         "target": redact_text(target),
         "overwrite": overwrite,
         "plannedFiles": planned,
+    }
+
+
+def safe_destination(root, rel_path):
+    rel = Path(rel_path)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise BackupError(f"Unsafe manifest path: {rel_path}")
+    destination = root / rel
+    try:
+        destination.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise BackupError(f"Unsafe restore path: {rel_path}") from exc
+    return destination
+
+
+def write_tar_payload(source_dir, manifest, output_path):
+    source = Path(source_dir)
+    with tarfile.open(output_path, "w") as archive:
+        manifest_bytes = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+        manifest_info = tarfile.TarInfo("manifest.json")
+        manifest_info.size = len(manifest_bytes)
+        manifest_info.mode = 0o600
+        manifest_info.mtime = 0
+        archive.addfile(manifest_info, fileobj=BytesReader(manifest_bytes))
+        for entry in manifest["files"]:
+            rel = entry["path"]
+            archive.add(source / rel, arcname=f"data/{rel}", recursive=False)
+
+
+class BytesReader:
+    def __init__(self, data):
+        self.data = data
+        self.offset = 0
+
+    def read(self, size=-1):
+        if size is None or size < 0:
+            size = len(self.data) - self.offset
+        chunk = self.data[self.offset:self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+
+def run_openssl_enc(input_bytes, key_bytes, decrypt=False):
+    openssl = shutil.which("openssl")
+    if not openssl:
+        raise BackupError("openssl CLI is required for encrypted backup packages.")
+    read_fd, write_fd = os.pipe()
+    mode = "-d" if decrypt else "-e"
+    cmd = [
+        openssl,
+        "enc",
+        "-aes-256-cbc",
+        mode,
+        "-pbkdf2",
+        "-iter",
+        str(PBKDF2_ITERATIONS),
+        "-salt",
+        "-pass",
+        f"fd:{read_fd}",
+    ]
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            pass_fds=(read_fd,),
+        )
+        os.close(read_fd)
+        with os.fdopen(write_fd, "wb") as handle:
+            handle.write(key_bytes)
+            handle.write(b"\n")
+        output, stderr = process.communicate(input_bytes)
+    finally:
+        for fd in (read_fd, write_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+    if process.returncode != 0:
+        detail = stderr.decode("utf-8", "replace").strip().splitlines()[-1:] or ["openssl failed"]
+        raise BackupError(redact_text(detail[0]))
+    return output
+
+
+def derive_mac_key(key_bytes, salt):
+    return hashlib.pbkdf2_hmac("sha256", key_bytes + MAC_KEY_LABEL, salt, PBKDF2_ITERATIONS, dklen=32)
+
+
+def package_hmac(key_bytes, salt, ciphertext):
+    mac_key = derive_mac_key(key_bytes, salt)
+    return hmac.new(mac_key, ciphertext, hashlib.sha256).hexdigest()
+
+
+def create_backup_package(source_dir, output_path, key_bytes, label=None, profile="mixed-existing"):
+    manifest = build_manifest(source_dir, label=label, profile=profile)
+    with tempfile.TemporaryDirectory(prefix="cdse-backup-package-") as tmp:
+        tar_path = Path(tmp) / "payload.tar"
+        write_tar_payload(source_dir, manifest, tar_path)
+        tar_bytes = tar_path.read_bytes()
+    ciphertext = run_openssl_enc(tar_bytes, key_bytes)
+    mac_salt = os.urandom(16)
+    package = {
+        "backupPackageVersion": BACKUP_PACKAGE_VERSION,
+        "safeForAgent": True,
+        "createdAt": manifest["createdAt"],
+        "manifest": manifest,
+        "payload": {
+            "cipher": "openssl-enc-aes-256-cbc-pbkdf2",
+            "kdf": "PBKDF2-HMAC-SHA256",
+            "iterations": PBKDF2_ITERATIONS,
+            "hash": "SHA-256",
+            "ciphertextSha256": sha256_bytes(ciphertext),
+            "hmacSaltB64": base64.b64encode(mac_salt).decode("ascii"),
+            "hmacSha256": package_hmac(key_bytes, mac_salt, ciphertext),
+            "ciphertextB64": base64.b64encode(ciphertext).decode("ascii"),
+        },
+    }
+    write_json(package, output_path)
+    return package
+
+
+def load_backup_package(path):
+    package = load_json(path)
+    if not isinstance(package, dict) or package.get("backupPackageVersion") != BACKUP_PACKAGE_VERSION:
+        raise BackupError("Unsupported or invalid backup package.")
+    ensure_manifest_compatible(package.get("manifest"))
+    payload = package.get("payload", {})
+    for field in ("ciphertextB64", "hmacSaltB64", "hmacSha256"):
+        if not payload.get(field):
+            raise BackupError(f"Backup package payload is missing {field}.")
+    return package
+
+
+def decrypt_backup_payload(package, key_bytes):
+    payload = package["payload"]
+    try:
+        ciphertext = base64.b64decode(payload["ciphertextB64"], validate=True)
+        mac_salt = base64.b64decode(payload["hmacSaltB64"], validate=True)
+    except ValueError as exc:
+        raise BackupError("Backup package payload is not valid base64.") from exc
+    if sha256_bytes(ciphertext) != payload.get("ciphertextSha256"):
+        raise BackupError("Backup package ciphertext hash mismatch.")
+    expected = package_hmac(key_bytes, mac_salt, ciphertext)
+    if not hmac.compare_digest(expected, payload.get("hmacSha256", "")):
+        raise BackupError("Backup package authentication failed.")
+    return run_openssl_enc(ciphertext, key_bytes, decrypt=True)
+
+
+def extract_tar_payload(tar_bytes, target_dir):
+    target = Path(target_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    tar_path = target / "payload.tar"
+    tar_path.write_bytes(tar_bytes)
+    try:
+        with tarfile.open(tar_path, "r") as archive:
+            for member in archive.getmembers():
+                if member.name.startswith("/") or ".." in Path(member.name).parts:
+                    raise BackupError(f"Unsafe archive member: {member.name}")
+            archive.extractall(target)
+    finally:
+        try:
+            tar_path.unlink()
+        except OSError:
+            pass
+
+
+def restore_backup_package(package_path, target_dir, key_bytes, overwrite=False, dry_run=False, expected_profile=None):
+    package = load_backup_package(package_path)
+    manifest = package["manifest"]
+    ensure_manifest_compatible(manifest, expected_profile=expected_profile)
+    plan = restore_plan(manifest, target_dir, overwrite=overwrite)
+    target = Path(target_dir)
+    for entry in manifest["files"]:
+        destination = safe_destination(target, entry["path"])
+        if destination.exists() and not overwrite:
+            raise BackupError(f"Restore target already exists: {redact_text(destination)}")
+    if dry_run:
+        return {"safeForAgent": True, "dryRun": True, "plan": plan}
+    with tempfile.TemporaryDirectory(prefix="cdse-restore-payload-") as tmp:
+        tmp_root = Path(tmp)
+        extract_tar_payload(decrypt_backup_payload(package, key_bytes), tmp_root)
+        extracted_manifest = load_manifest_from_path(tmp_root / "manifest.json")
+        if json.dumps(extracted_manifest, sort_keys=True) != json.dumps(manifest, sort_keys=True):
+            raise BackupError("Embedded manifest does not match backup package manifest.")
+        extracted_data = tmp_root / "data"
+        report = verify_manifest(manifest, extracted_data)
+        if report["summary"]["failed"]:
+            raise BackupError("Decrypted payload failed manifest verification.")
+        for entry in manifest["files"]:
+            destination = safe_destination(target, entry["path"])
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(extracted_data / entry["path"], destination)
+    post_restore = verify_manifest(manifest, target)
+    if post_restore["summary"]["failed"]:
+        raise BackupError("Restored files failed manifest verification.")
+    return {
+        "safeForAgent": True,
+        "dryRun": False,
+        "summary": post_restore["summary"],
+        "plan": plan,
     }
 
 
@@ -194,6 +440,50 @@ def plan_restore_command(args):
     write_json(plan, args.output)
 
 
+def create_backup_command(args):
+    key = read_backup_key(args.key_env, args.key_file)
+    package = create_backup_package(args.source, args.output, key, label=args.label, profile=args.profile)
+    summary = {
+        "safeForAgent": True,
+        "output": redact_text(args.output),
+        "fileCount": package["manifest"]["summary"]["fileCount"],
+        "totalBytes": package["manifest"]["summary"]["totalBytes"],
+        "profile": package["manifest"]["storageCrypto"]["profile"],
+        "ciphertextSha256": package["payload"]["ciphertextSha256"],
+    }
+    write_json(summary, args.summary_output)
+
+
+def restore_command(args):
+    key = read_backup_key(args.key_env, args.key_file)
+    report = restore_backup_package(
+        args.backup,
+        args.target,
+        key,
+        overwrite=args.overwrite,
+        dry_run=args.dry_run,
+        expected_profile=args.expected_profile,
+    )
+    write_json(report, args.output)
+
+
+def verify_backup_command(args):
+    key = read_backup_key(args.key_env, args.key_file)
+    package = load_backup_package(args.backup)
+    decrypt_backup_payload(package, key)
+    report = {
+        "safeForAgent": True,
+        "summary": {
+            "fileCount": package["manifest"]["summary"]["fileCount"],
+            "totalBytes": package["manifest"]["summary"]["totalBytes"],
+            "authenticated": True,
+        },
+        "profile": package["manifest"]["storageCrypto"]["profile"],
+        "ciphertextSha256": package["payload"]["ciphertextSha256"],
+    }
+    write_json(report, args.output)
+
+
 def self_test():
     with tempfile.TemporaryDirectory(prefix="cdse-backup-self-test-") as tmp:
         root = Path(tmp) / "source"
@@ -218,11 +508,41 @@ def self_test():
         plan = restore_plan(manifest, Path(tmp) / "restore")
         if len(plan["plannedFiles"]) != 3 or plan["safeForAgent"] is not True:
             raise BackupError("self-test restore plan mismatch.")
+        backup_path = Path(tmp) / "backup.cdsebackup.json"
+        key = b"correct horse battery staple"
+        create_backup_package(root, backup_path, key, label="OrgKeyABCDEF1234567890abcdef", profile="mixed-aes-herradura")
+        package_text = backup_path.read_text(encoding="utf-8")
+        if "ABCDEF1234567890abcdef" in package_text:
+            raise BackupError("self-test backup package leaked an identifier-like value.")
+        try:
+            restore_backup_package(backup_path, Path(tmp) / "wrong-key-restore", b"wrong backup passphrase")
+        except BackupError as exc:
+            if "authentication failed" not in str(exc):
+                raise
+        else:
+            raise BackupError("self-test did not reject wrong backup key.")
+        restored = Path(tmp) / "restore"
+        restore_report = restore_backup_package(backup_path, restored, key, expected_profile="mixed-aes-herradura")
+        if restore_report["summary"]["failed"] != 0:
+            raise BackupError("self-test restore verification failed.")
+        if (restored / "storage" / "document.csv").read_text(encoding="utf-8") != "name,salary\nAda,999\n":
+            raise BackupError("self-test restore readback mismatch.")
+        package = load_backup_package(backup_path)
+        package["payload"]["ciphertextB64"] = package["payload"]["ciphertextB64"][:-4] + "AAAA"
+        tampered_path = Path(tmp) / "tampered.cdsebackup.json"
+        write_json(package, tampered_path)
+        try:
+            restore_backup_package(tampered_path, Path(tmp) / "tampered-restore", key)
+        except BackupError as exc:
+            if "hash mismatch" not in str(exc) and "authentication failed" not in str(exc):
+                raise
+        else:
+            raise BackupError("self-test did not reject tampered backup package.")
     print("PASS encrypted backup restore self-test")
 
 
 def parse_args(argv):
-    parser = argparse.ArgumentParser(description="Create and verify CaumeDSE backup manifests.")
+    parser = argparse.ArgumentParser(description="Create, verify, and restore CaumeDSE backup packages.")
     sub = parser.add_subparsers(dest="command", required=True)
     manifest = sub.add_parser("manifest", help="Create an integrity manifest for a data directory.")
     manifest.add_argument("--source", required=True)
@@ -238,6 +558,28 @@ def parse_args(argv):
     plan.add_argument("--target", required=True)
     plan.add_argument("--overwrite", action="store_true")
     plan.add_argument("--output")
+    create = sub.add_parser("create-backup", help="Create an encrypted backup package.")
+    create.add_argument("--source", required=True)
+    create.add_argument("--output", required=True)
+    create.add_argument("--label")
+    create.add_argument("--profile", default="mixed-existing")
+    create.add_argument("--key-env", default="CDSE_BACKUP_KEY")
+    create.add_argument("--key-file")
+    create.add_argument("--summary-output")
+    verify_backup = sub.add_parser("verify-backup", help="Authenticate and inspect an encrypted backup package.")
+    verify_backup.add_argument("--backup", required=True)
+    verify_backup.add_argument("--key-env", default="CDSE_BACKUP_KEY")
+    verify_backup.add_argument("--key-file")
+    verify_backup.add_argument("--output")
+    restore = sub.add_parser("restore", help="Restore an encrypted backup package.")
+    restore.add_argument("--backup", required=True)
+    restore.add_argument("--target", required=True)
+    restore.add_argument("--key-env", default="CDSE_BACKUP_KEY")
+    restore.add_argument("--key-file")
+    restore.add_argument("--expected-profile")
+    restore.add_argument("--overwrite", action="store_true")
+    restore.add_argument("--dry-run", action="store_true")
+    restore.add_argument("--output")
     sub.add_parser("self-test", help="Run offline manifest, tamper, and restore-plan checks.")
     return parser.parse_args(argv)
 
@@ -251,6 +593,12 @@ def main(argv=None):
             return verify_command(args)
         elif args.command == "plan-restore":
             plan_restore_command(args)
+        elif args.command == "create-backup":
+            create_backup_command(args)
+        elif args.command == "verify-backup":
+            return verify_backup_command(args)
+        elif args.command == "restore":
+            restore_command(args)
         elif args.command == "self-test":
             self_test()
     except BackupError as exc:

--- a/samples/mcp-server/README.md
+++ b/samples/mcp-server/README.md
@@ -26,7 +26,8 @@ environment variables and are never part of MCP tool arguments or tool results.
   returns a bounded row preview.
 
 Local DEBUG setup helpers are hidden unless
-`CDSE_MCP_ENABLE_WRITE_TOOLS=1` is set in the server environment:
+`CDSE_MCP_ENABLE_WRITE_TOOLS=1` and `CDSE_MCP_DELEGATED_TOKEN` are set in the
+server environment:
 
 - `create_workspace`: creates the configured disposable organization, storage,
   and user.
@@ -35,6 +36,17 @@ Local DEBUG setup helpers are hidden unless
 - `upload_parser_candidate`: uploads a generated parser candidate as pending
   review metadata.
 - `cleanup_workspace`: deletes the sample documents, storage, and user.
+
+Every write call also requires explicit guard arguments:
+
+- `organization`, `storage`, and `user` must match the server environment.
+- `scope` must match the exact resource scope reported by the tool schema or
+  dry-run output, never `*`, `all`, or a broad organization/storage scope.
+- `expected_status` must be one of the status codes accepted by that helper.
+- `idempotency_key` must be a caller-generated non-space value of at least 12
+  characters.
+- `confirm` must be `confirm-caumedse-mcp-write`.
+- `dry_run=true` returns the guarded mutation plan without contacting CaumeDSE.
 
 ## Configuration
 
@@ -48,6 +60,7 @@ export CDSE_MCP_USER="McpTrialUser"
 export CDSE_MCP_STORAGE="McpTrialStorage"
 export CDSE_MCP_STORAGE_PATH="/tmp/caumedse-mcp-storage"
 export CDSE_MCP_ORG_KEY="$(openssl rand -hex 32)"
+export CDSE_MCP_DELEGATED_TOKEN="broker-minted-token-for-this-agent-session"
 ```
 
 For HTTPS, add the CA and client certificate paths used by the test service:
@@ -100,7 +113,8 @@ A typical local flow is:
    exposing tools.
 2. Prepare a least-privilege CaumeDSE user, storage resource, CSV document, and
    reviewed parser outside the read-only MCP session, or run the DEBUG helpers
-   with `CDSE_MCP_ENABLE_WRITE_TOOLS=1`.
+   with `CDSE_MCP_ENABLE_WRITE_TOOLS=1` and `CDSE_MCP_DELEGATED_TOKEN` only for
+   local guarded DEBUG workflows.
 3. `documentTypes_list`
 4. `documentSchema_read`
 5. `contentColumns_read`
@@ -116,6 +130,9 @@ A typical local flow is:
 - For repeated agent sessions, put a delegated-token broker in front of the MCP
   server so each tool call is authorized by a short-lived scoped token before
   the server forwards broker-held CaumeDSE credentials.
+- Write tools stay hidden unless both write-tool opt-in and delegated-token
+  configuration are present. Even then, each call must include the exact guard
+  fields, and `dry_run=true` should be used before every mutation.
 - Do not expose this prototype directly to untrusted clients. Put any
   production MCP bridge behind authentication, authorization, audit logging,
   rate limits, and route-level allow lists.
@@ -146,6 +163,13 @@ printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
   | python3 samples/mcp-server/caumedse_mcp_server.py
+```
+
+This checks guarded write-tool exposure and dry-run refusal behavior without
+contacting a CaumeDSE service:
+
+```sh
+python3 samples/mcp-server/caumedse_mcp_server.py self-test
 ```
 
 Use `CDSE_VERIFY_REDACT=1` when sharing logs from live verifier runs.

--- a/samples/mcp-server/caumedse_mcp_server.py
+++ b/samples/mcp-server/caumedse_mcp_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Model Context Protocol server for read-only CaumeDSE inspection.
+Model Context Protocol server for guarded CaumeDSE inspection.
 
 The server speaks JSON-RPC over stdio, implements a stable MCP tool surface,
 and calls the CaumeDSE REST API with credentials sourced only from environment
@@ -29,6 +29,7 @@ SERVER_VERSION = "0.2.0"
 PROTOCOL_VERSION = "2024-11-05"
 MAX_LIMIT = 10
 MAX_TEXT_BYTES = 12000
+WRITE_CONFIRMATION = "confirm-caumedse-mcp-write"
 
 
 class ToolError(Exception):
@@ -50,7 +51,9 @@ class Config:
         self.ca_cert = os.environ.get("CDSE_MCP_CA_CERT")
         self.client_cert = os.environ.get("CDSE_MCP_CLIENT_CERT")
         self.client_key = os.environ.get("CDSE_MCP_CLIENT_KEY")
-        self.enable_write_tools = os.environ.get("CDSE_MCP_ENABLE_WRITE_TOOLS", "").lower() in {"1", "true", "yes", "on"}
+        self.delegated_token = os.environ.get("CDSE_MCP_DELEGATED_TOKEN")
+        self.write_tools_requested = os.environ.get("CDSE_MCP_ENABLE_WRITE_TOOLS", "").lower() in {"1", "true", "yes", "on"}
+        self.enable_write_tools = self.write_tools_requested and bool(self.delegated_token)
 
     def require_key(self):
         if not self.org_key:
@@ -161,6 +164,49 @@ def resolve_file(path_value, default_path):
     return path
 
 
+def write_scope(action, cfg, document=None):
+    scopes = {
+        "create_workspace": f"workspace:{cfg.org}:{cfg.storage}:{cfg.user}",
+        "upload_csv": f"document:file.csv:{document}",
+        "upload_parser": f"document:script.python:{document}",
+        "upload_parser_candidate": f"document:script.python.pending:{document}",
+        "cleanup_workspace": f"cleanup:{cfg.org}:{cfg.storage}:{cfg.user}",
+    }
+    return scopes[action]
+
+
+def require_write_guard(cfg, args, action, allowed_statuses, document=None):
+    required = ("organization", "storage", "user", "scope", "expected_status", "idempotency_key", "confirm")
+    missing = [name for name in required if args.get(name) in (None, "")]
+    if missing:
+        raise ToolError(f"Write tool guard rejected {action}: missing required arguments: {', '.join(missing)}")
+    if args["organization"] != cfg.org or args["storage"] != cfg.storage or args["user"] != cfg.user:
+        raise ToolError("Write tool guard rejected request: organization, storage, and user must match server configuration.")
+    expected_scope = write_scope(action, cfg, document)
+    scope = str(args["scope"])
+    if scope != expected_scope or scope.lower() in {"*", "all", "organization", "storage"}:
+        raise ToolError(f"Write tool guard rejected request: scope must be exactly {expected_scope}.")
+    try:
+        expected_status = int(args["expected_status"])
+    except (TypeError, ValueError) as exc:
+        raise ToolError("Write tool guard rejected request: expected_status must be an integer.") from exc
+    if expected_status not in allowed_statuses:
+        raise ToolError(f"Write tool guard rejected request: expected_status must be one of {sorted(allowed_statuses)}.")
+    idempotency_key = str(args["idempotency_key"])
+    if len(idempotency_key) < 12 or any(ch.isspace() for ch in idempotency_key):
+        raise ToolError("Write tool guard rejected request: idempotency_key must be at least 12 non-space characters.")
+    if args["confirm"] != WRITE_CONFIRMATION:
+        raise ToolError(f"Write tool guard rejected request: confirm must be {WRITE_CONFIRMATION}.")
+    return {
+        "action": action,
+        "scope": scope,
+        "expectedStatus": expected_status,
+        "idempotencyKey": idempotency_key,
+        "dryRun": bool(args.get("dry_run")),
+        "delegatedTokenConfigured": True,
+    }
+
+
 def get_agent_capabilities(cfg, _args):
     _, _, payload = request(cfg, "GET", "/agentCapabilities")
     return json.loads(payload.decode("utf-8"))
@@ -203,6 +249,9 @@ def base_document_path(cfg, doc_type, doc_name):
 
 
 def create_workspace(cfg, _args):
+    guard = require_write_guard(cfg, _args, "create_workspace", {201, 409})
+    if guard["dryRun"]:
+        return {"guard": guard, "wouldCreate": {"organization": cfg.org, "storage": cfg.storage, "user": cfg.user}}
     auth = cfg.auth_params(include_new_key=True)
     Path(cfg.storage_path).mkdir(parents=True, exist_ok=True)
     request(
@@ -247,7 +296,7 @@ def create_workspace(cfg, _args):
         },
         expected=(201, 409),
     )
-    return {"organization": cfg.org, "storage": cfg.storage, "user": cfg.user, "createdOrAlreadyPresent": True}
+    return {"guard": guard, "organization": cfg.org, "storage": cfg.storage, "user": cfg.user, "createdOrAlreadyPresent": True}
 
 
 def list_document_types(cfg, _args):
@@ -280,31 +329,46 @@ def upload_document(cfg, doc_type, doc_name, file_path, resource_info):
 
 def upload_csv(cfg, args):
     doc_name = args.get("document") or cfg.csv_doc
+    guard = require_write_guard(cfg, args, "upload_csv", {201, 409}, doc_name)
+    if guard["dryRun"]:
+        return {"guard": guard, "wouldUpload": {"documentType": "file.csv", "document": doc_name}}
     file_path = resolve_file(args.get("csv_path"), DEFAULT_CSV)
     resource_info = args.get("resource_info") or "reviewed MCP CSV fixture"
-    return upload_document(cfg, "file.csv", doc_name, file_path, resource_info)
+    result = upload_document(cfg, "file.csv", doc_name, file_path, resource_info)
+    result["guard"] = guard
+    return result
 
 
 def upload_parser(cfg, args):
     doc_name = args.get("document") or cfg.parser_doc
+    guard = require_write_guard(cfg, args, "upload_parser", {201, 409}, doc_name)
+    if guard["dryRun"]:
+        return {"guard": guard, "wouldUpload": {"documentType": "script.python", "document": doc_name}}
     file_path = resolve_file(args.get("parser_path"), DEFAULT_PARSER)
     resource_info = args.get("resource_info") or (
         "reviewed MCP parser fixture parser.reviewStatus:reviewed parser.reviewed:true "
         "parser.reviewer:human-reviewer parser.reviewTime:2026-07-30T00:00:00Z "
         "parser.interpreter:/usr/bin/python3 parser.timeout:10 parser.isolation:none"
     )
-    return upload_document(cfg, "script.python", doc_name, file_path, resource_info)
+    result = upload_document(cfg, "script.python", doc_name, file_path, resource_info)
+    result["guard"] = guard
+    return result
 
 
 def upload_parser_candidate(cfg, args):
     doc_name = args.get("document") or cfg.pending_parser_doc
+    guard = require_write_guard(cfg, args, "upload_parser_candidate", {201, 409}, doc_name)
+    if guard["dryRun"]:
+        return {"guard": guard, "wouldUpload": {"documentType": "script.python", "document": doc_name, "reviewStatus": "pending"}}
     file_path = resolve_file(args.get("parser_path"), DEFAULT_PARSER)
     resource_info = args.get("resource_info") or (
         "generated MCP parser candidate parser.reviewStatus:pending parser.generated:true "
         "parser.generator:mcp-client parser.promptHash:sha256-demo "
         "parser.interpreter:/usr/bin/python3 parser.timeout:10 parser.isolation:none"
     )
-    return upload_document(cfg, "script.python", doc_name, file_path, resource_info)
+    result = upload_document(cfg, "script.python", doc_name, file_path, resource_info)
+    result["guard"] = guard
+    return result
 
 
 def discover_schema(cfg, args):
@@ -403,6 +467,9 @@ def preview_parser_candidate(cfg, args):
 
 
 def cleanup_workspace(cfg, args):
+    guard = require_write_guard(cfg, args, "cleanup_workspace", {200, 404})
+    if guard["dryRun"]:
+        return {"guard": guard, "wouldDelete": ["csv", "pending_parser", "parser", "storage", "user"]}
     auth = cfg.auth_params(include_new_key=True)
     csv_doc = args.get("csv_document") or cfg.csv_doc
     parser_doc = args.get("parser_document") or cfg.parser_doc
@@ -417,7 +484,7 @@ def cleanup_workspace(cfg, args):
     for label, method, path in resources:
         status, _, _ = request(cfg, method, path, params=auth, expected=(200, 404))
         deleted.append({"resource": label, "status": status})
-    return {"cleanup": deleted}
+    return {"guard": guard, "cleanup": deleted}
 
 
 READ_ONLY_TOOLS = {
@@ -438,6 +505,38 @@ WRITE_TOOLS = {
     "upload_parser_candidate": upload_parser_candidate,
     "cleanup_workspace": cleanup_workspace,
 }
+
+COMMON_WRITE_GUARD_PROPERTIES = {
+    "organization": {"type": "string"},
+    "storage": {"type": "string"},
+    "user": {"type": "string"},
+    "scope": {"type": "string"},
+    "expected_status": {"type": "integer"},
+    "idempotency_key": {"type": "string", "minLength": 12},
+    "confirm": {"type": "string", "const": WRITE_CONFIRMATION},
+    "dry_run": {"type": "boolean"},
+}
+COMMON_WRITE_GUARD_REQUIRED = [
+    "organization",
+    "storage",
+    "user",
+    "scope",
+    "expected_status",
+    "idempotency_key",
+    "confirm",
+]
+
+
+def write_schema(properties, required=None):
+    merged = dict(COMMON_WRITE_GUARD_PROPERTIES)
+    merged.update(properties)
+    return {
+        "type": "object",
+        "properties": merged,
+        "required": COMMON_WRITE_GUARD_REQUIRED + list(required or []),
+        "additionalProperties": False,
+    }
+
 
 READ_ONLY_TOOL_SCHEMAS = [
     {
@@ -533,57 +632,49 @@ WRITE_TOOL_SCHEMAS = [
     {
         "name": "create_workspace",
         "description": "Local DEBUG helper: create the configured disposable organization, storage, and user.",
-        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+        "inputSchema": write_schema({}),
     },
     {
         "name": "upload_csv",
         "description": "Local DEBUG helper: upload a reviewed local CSV fixture to the configured storage.",
         "inputSchema": {
-            "type": "object",
-            "properties": {
+            **write_schema({
                 "document": {"type": "string"},
                 "csv_path": {"type": "string"},
                 "resource_info": {"type": "string"},
-            },
-            "additionalProperties": False,
+            }),
         },
     },
     {
         "name": "upload_parser",
         "description": "Local DEBUG helper: upload a reviewed local Python parser fixture with review metadata.",
         "inputSchema": {
-            "type": "object",
-            "properties": {
+            **write_schema({
                 "document": {"type": "string"},
                 "parser_path": {"type": "string"},
                 "resource_info": {"type": "string"},
-            },
-            "additionalProperties": False,
+            }),
         },
     },
     {
         "name": "upload_parser_candidate",
         "description": "Local DEBUG helper: upload a generated parser candidate as pending review metadata.",
         "inputSchema": {
-            "type": "object",
-            "properties": {
+            **write_schema({
                 "document": {"type": "string"},
                 "parser_path": {"type": "string"},
                 "resource_info": {"type": "string"},
-            },
-            "additionalProperties": False,
+            }),
         },
     },
     {
         "name": "cleanup_workspace",
         "description": "Local DEBUG helper: delete the configured sample documents, storage, and user.",
         "inputSchema": {
-            "type": "object",
-            "properties": {
+            **write_schema({
                 "csv_document": {"type": "string"},
                 "parser_document": {"type": "string"},
-            },
-            "additionalProperties": False,
+            }),
         },
     },
 ]
@@ -655,6 +746,75 @@ def write_response(response):
     sys.stdout.flush()
 
 
+def scoped_guard_args(cfg, action, document=None, expected_status=201):
+    return {
+        "organization": cfg.org,
+        "storage": cfg.storage,
+        "user": cfg.user,
+        "scope": write_scope(action, cfg, document),
+        "expected_status": expected_status,
+        "idempotency_key": f"selftest-{action}-0001",
+        "confirm": WRITE_CONFIRMATION,
+        "dry_run": True,
+    }
+
+
+def self_test():
+    saved_env = {key: os.environ.get(key) for key in (
+        "CDSE_MCP_ENABLE_WRITE_TOOLS",
+        "CDSE_MCP_DELEGATED_TOKEN",
+        "CDSE_MCP_ORG",
+        "CDSE_MCP_STORAGE",
+        "CDSE_MCP_USER",
+    )}
+    try:
+        os.environ.pop("CDSE_MCP_ENABLE_WRITE_TOOLS", None)
+        os.environ.pop("CDSE_MCP_DELEGATED_TOKEN", None)
+        cfg = Config()
+        if any(name in available_tools(cfg) for name in WRITE_TOOLS):
+            raise AssertionError("write tools exposed by default")
+
+        os.environ["CDSE_MCP_ENABLE_WRITE_TOOLS"] = "1"
+        cfg = Config()
+        if any(name in available_tools(cfg) for name in WRITE_TOOLS):
+            raise AssertionError("write tools exposed without delegated-token configuration")
+
+        os.environ["CDSE_MCP_DELEGATED_TOKEN"] = "self-test-delegated-token"
+        os.environ["CDSE_MCP_ORG"] = "SelfTestOrg"
+        os.environ["CDSE_MCP_STORAGE"] = "SelfTestStorage"
+        os.environ["CDSE_MCP_USER"] = "SelfTestUser"
+        cfg = Config()
+        tools = available_tools(cfg)
+        for name in WRITE_TOOLS:
+            if name not in tools:
+                raise AssertionError(f"guarded write tool missing when explicitly enabled: {name}")
+
+        args = scoped_guard_args(cfg, "create_workspace")
+        result = create_workspace(cfg, args)
+        if not result.get("guard", {}).get("dryRun"):
+            raise AssertionError("guarded dry-run create_workspace did not return dryRun guard metadata")
+
+        bad_args = dict(args)
+        bad_args["scope"] = "*"
+        try:
+            create_workspace(cfg, bad_args)
+            raise AssertionError("broad write scope was accepted")
+        except ToolError:
+            pass
+
+        upload_args = scoped_guard_args(cfg, "upload_csv", cfg.csv_doc, expected_status=201)
+        upload_result = upload_csv(cfg, upload_args)
+        if upload_result.get("wouldUpload", {}).get("documentType") != "file.csv":
+            raise AssertionError("guarded dry-run upload_csv did not report target document")
+    finally:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    print("PASS MCP write guard self-test")
+
+
 def serve():
     cfg = Config()
     for line in sys.stdin:
@@ -683,11 +843,15 @@ def serve():
 def parse_args(argv):
     parser = argparse.ArgumentParser(description="Run the CaumeDSE MCP stdio prototype server.")
     parser.add_argument("--version", action="version", version=f"{SERVER_NAME} {SERVER_VERSION}")
+    parser.add_argument("command", nargs="?", choices=["serve", "self-test"], default="serve")
     return parser.parse_args(argv)
 
 
 def main(argv=None):
-    parse_args(argv or sys.argv[1:])
+    args = parse_args(argv or sys.argv[1:])
+    if args.command == "self-test":
+        self_test()
+        return
     serve()
 
 

--- a/samples/policy-authz-tester/README.md
+++ b/samples/policy-authz-tester/README.md
@@ -1,0 +1,63 @@
+# CaumeDSE Policy Authorization Tester
+
+This sample defines a small JSON policy format for intended role/filter
+authorization behavior and checks observed probe results against that policy.
+It is dependency-free and keeps credentials out of policy files and reports.
+
+Batch 1 is offline-oriented: it validates policy shape, renders the intended
+`roleTables`, `filterWhitelist`, and `filterBlacklist` setup plan, and compares
+recorded probe statuses to expected allow/deny outcomes. A later live workflow
+can use the same policy file to provision disposable resources and execute HTTP
+probes.
+
+## Policy Shape
+
+`policy.example.json` contains:
+
+- `subject`: the organization and user under test.
+- `resources`: storage, document, and document type names.
+- `roles`: intended roleTables resources and allowed methods.
+- `filterWhitelist`: positive method/resource patterns.
+- `filterBlacklist`: deny method/resource patterns.
+- `rules`: named HTTP probes with method, route, decision, and expected status.
+
+Do not include `orgKey`, `newOrgKey`, TLS private keys, delegated tokens, or
+authorization headers in policy files.
+
+## Commands
+
+Validate the committed example and render setup intent:
+
+```sh
+python3 samples/policy-authz-tester/policy_authz_tester.py validate
+```
+
+Compare observed probe results:
+
+```sh
+python3 samples/policy-authz-tester/policy_authz_tester.py report \
+  --policy samples/policy-authz-tester/policy.example.json \
+  --observations observed-policy-results.json
+```
+
+Run offline validation, evaluation, and redaction checks:
+
+```sh
+python3 samples/policy-authz-tester/policy_authz_tester.py self-test
+```
+
+Observation files are JSON arrays:
+
+```json
+[
+  {
+    "rule": "allow_document_schema",
+    "status": 200,
+    "requestId": "live-http-1",
+    "auditCategory": "request"
+  }
+]
+```
+
+Reports are marked `safeForAgent:true`, include pass/fail counts, and redact
+credential-style values from routes and structured fields.

--- a/samples/policy-authz-tester/policy.example.json
+++ b/samples/policy-authz-tester/policy.example.json
@@ -1,0 +1,56 @@
+{
+  "policySchemaVersion": 1,
+  "name": "agent-readonly-csv-policy",
+  "subject": {
+    "organization": "PolicyTrialOrg",
+    "user": "PolicyTrialUser"
+  },
+  "resources": {
+    "storage": "PolicyTrialStorage",
+    "document": "policy-small.csv",
+    "documentType": "file.csv"
+  },
+  "roles": [
+    {
+      "resource": "documents",
+      "allowMethods": ["GET", "HEAD", "OPTIONS"]
+    }
+  ],
+  "filterWhitelist": [
+    {
+      "user": "PolicyTrialUser",
+      "resourcePattern": "policy-small\\.csv",
+      "allowMethods": ["GET", "HEAD", "OPTIONS"]
+    }
+  ],
+  "filterBlacklist": [
+    {
+      "user": "PolicyTrialUser",
+      "resourcePattern": "policy-small\\.csv",
+      "denyMethods": ["POST", "PUT", "DELETE"]
+    }
+  ],
+  "rules": [
+    {
+      "name": "allow_document_schema",
+      "method": "GET",
+      "route": "/organizations/PolicyTrialOrg/storage/PolicyTrialStorage/documentTypes/file.csv/documents/policy-small.csv/schema",
+      "decision": "allow",
+      "expectedStatus": 200
+    },
+    {
+      "name": "deny_document_delete",
+      "method": "DELETE",
+      "route": "/organizations/PolicyTrialOrg/storage/PolicyTrialStorage/documentTypes/file.csv/documents/policy-small.csv",
+      "decision": "deny",
+      "expectedStatus": 403
+    },
+    {
+      "name": "deny_blacklisted_post",
+      "method": "POST",
+      "route": "/organizations/PolicyTrialOrg/storage/PolicyTrialStorage/documentTypes/file.csv/documents/policy-small.csv",
+      "decision": "deny",
+      "expectedStatus": 403
+    }
+  ]
+}

--- a/samples/policy-authz-tester/policy_authz_tester.py
+++ b/samples/policy-authz-tester/policy_authz_tester.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+CaumeDSE policy-as-code authorization tester sample.
+
+Validates a small JSON policy format, renders the intended role/filter setup
+plan, and compares observed HTTP probe results against expected allow/deny
+outcomes. Uses only Python's standard library.
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+SAMPLE_DIR = Path(__file__).resolve().parent
+DEFAULT_POLICY = SAMPLE_DIR / "policy.example.json"
+SENSITIVE_KEYS = {
+    "orgKey",
+    "newOrgKey",
+    "authorization",
+    "accessPassword",
+    "oauthConsumerSecret",
+    "certificate",
+    "privateKey",
+}
+SECRET_PATTERNS = [
+    (re.compile(r"(?i)(orgKey|newOrgKey|accessPassword|oauthConsumerSecret)=([^&\s\"]+)"), r"\1=<redacted>"),
+    (re.compile(r"(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._~-]+"), "Authorization: Bearer <redacted>"),
+]
+SUPPORTED_METHODS = {"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"}
+SUPPORTED_DECISIONS = {"allow", "deny"}
+METHOD_FIELDS = {
+    "GET": "*_get",
+    "POST": "*_post",
+    "PUT": "*_put",
+    "DELETE": "*_delete",
+    "HEAD": "*_head",
+    "OPTIONS": "*_options",
+}
+
+
+class PolicyError(Exception):
+    pass
+
+
+def load_json(path):
+    try:
+        with Path(path).open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except OSError as exc:
+        raise PolicyError(f"Cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def redact_value(value):
+    if isinstance(value, dict):
+        return {key: ("<redacted>" if key in SENSITIVE_KEYS else redact_value(val)) for key, val in value.items()}
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if not isinstance(value, str):
+        return value
+    text = value
+    for pattern, replacement in SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def require_string(container, name, context):
+    value = container.get(name)
+    if not isinstance(value, str) or not value:
+        raise PolicyError(f"{context} must define non-empty string field: {name}")
+    return value
+
+
+def require_int(container, name, context):
+    value = container.get(name)
+    if not isinstance(value, int):
+        raise PolicyError(f"{context} must define integer field: {name}")
+    return value
+
+
+def validate_policy(policy):
+    if not isinstance(policy, dict):
+        raise PolicyError("Policy must be a JSON object.")
+    if policy.get("policySchemaVersion") != 1:
+        raise PolicyError("policySchemaVersion must be 1.")
+    subject = policy.get("subject")
+    if not isinstance(subject, dict):
+        raise PolicyError("Policy must define subject object.")
+    for field in ("organization", "user"):
+        require_string(subject, field, "subject")
+    resources = policy.get("resources", {})
+    if not isinstance(resources, dict):
+        raise PolicyError("resources must be an object.")
+    for field in ("storage", "document"):
+        require_string(resources, field, "resources")
+    rules = policy.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise PolicyError("Policy must define at least one rule.")
+    seen = set()
+    for index, rule in enumerate(rules):
+        context = f"rules[{index}]"
+        if not isinstance(rule, dict):
+            raise PolicyError(f"{context} must be an object.")
+        name = require_string(rule, "name", context)
+        if name in seen:
+            raise PolicyError(f"Duplicate rule name: {name}")
+        seen.add(name)
+        method = require_string(rule, "method", context).upper()
+        if method not in SUPPORTED_METHODS:
+            raise PolicyError(f"{context}.method is unsupported: {method}")
+        decision = require_string(rule, "decision", context).lower()
+        if decision not in SUPPORTED_DECISIONS:
+            raise PolicyError(f"{context}.decision must be allow or deny.")
+        status = require_int(rule, "expectedStatus", context)
+        if decision == "allow" and status >= 400:
+            raise PolicyError(f"{context} allow rule must expect a non-error status.")
+        if decision == "deny" and status < 400:
+            raise PolicyError(f"{context} deny rule must expect an error status.")
+        require_string(rule, "route", context)
+    return policy
+
+
+def method_map(allowed_methods):
+    allowed = {str(method).upper() for method in allowed_methods}
+    unknown = allowed - SUPPORTED_METHODS
+    if unknown:
+        raise PolicyError(f"Unsupported methods in setup plan: {', '.join(sorted(unknown))}")
+    return {field: ("1" if method in allowed else "0") for method, field in METHOD_FIELDS.items()}
+
+
+def setup_plan(policy):
+    subject = policy["subject"]
+    resources = policy["resources"]
+    org = subject["organization"]
+    user = subject["user"]
+    route_base = f"/organizations/{org}/users/{user}"
+    roles = policy.get("roles", [])
+    whitelist = policy.get("filterWhitelist", [])
+    blacklist = policy.get("filterBlacklist", [])
+    plan = []
+    for role in roles:
+        table = require_string(role, "resource", "roles[]")
+        plan.append({
+            "kind": "roleTable",
+            "method": "POST",
+            "path": f"{route_base}/roleTables/{table}",
+            "fields": method_map(role.get("allowMethods", [])),
+        })
+    for entry in whitelist:
+        filter_user = entry.get("user", user)
+        plan.append({
+            "kind": "filterWhitelist",
+            "method": "POST",
+            "path": f"{route_base}/filterWhitelist/{filter_user}",
+            "fields": method_map(entry.get("allowMethods", [])),
+            "resourcePattern": entry.get("resourcePattern", resources["document"]),
+        })
+    for entry in blacklist:
+        filter_user = entry.get("user", user)
+        plan.append({
+            "kind": "filterBlacklist",
+            "method": "POST",
+            "path": f"{route_base}/filterBlacklist/{filter_user}",
+            "fields": method_map(entry.get("denyMethods", [])),
+            "resourcePattern": entry.get("resourcePattern", resources["document"]),
+        })
+    return plan
+
+
+def observation_map(observations):
+    if not isinstance(observations, list):
+        raise PolicyError("observations must be a JSON array.")
+    mapped = {}
+    for item in observations:
+        if not isinstance(item, dict):
+            raise PolicyError("each observation must be an object.")
+        name = require_string(item, "rule", "observation")
+        if name in mapped:
+            raise PolicyError(f"duplicate observation for rule: {name}")
+        mapped[name] = item
+    return mapped
+
+
+def evaluate(policy, observations):
+    observed = observation_map(observations)
+    results = []
+    for rule in policy["rules"]:
+        item = observed.get(rule["name"])
+        actual = item.get("status") if item else None
+        passed = actual == rule["expectedStatus"]
+        results.append({
+            "rule": rule["name"],
+            "decision": rule["decision"],
+            "method": rule["method"].upper(),
+            "route": rule["route"],
+            "expectedStatus": rule["expectedStatus"],
+            "actualStatus": actual,
+            "requestId": item.get("requestId") if item else None,
+            "auditCategory": item.get("auditCategory") if item else None,
+            "passed": passed,
+        })
+    counts = Counter("passed" if item["passed"] else "failed" for item in results)
+    return {
+        "safeForAgent": True,
+        "policy": {
+            "name": policy.get("name", "unnamed"),
+            "subject": policy["subject"],
+            "resources": policy["resources"],
+            "ruleCount": len(policy["rules"]),
+        },
+        "setupPlan": setup_plan(policy),
+        "summary": {"passed": counts["passed"], "failed": counts["failed"]},
+        "results": results,
+    }
+
+
+def validate_command(args):
+    policy = validate_policy(load_json(args.policy))
+    print(json.dumps(redact_value({"safeForAgent": True, "policy": policy, "setupPlan": setup_plan(policy)}), indent=2, sort_keys=True))
+
+
+def report_command(args):
+    policy = validate_policy(load_json(args.policy))
+    observations = load_json(args.observations)
+    print(json.dumps(redact_value(evaluate(policy, observations)), indent=2, sort_keys=True))
+
+
+def self_test():
+    policy = validate_policy(load_json(DEFAULT_POLICY))
+    observations = [
+        {"rule": "allow_document_schema", "status": 200, "requestId": "authz-fixture-1", "auditCategory": "request"},
+        {"rule": "deny_document_delete", "status": 403, "requestId": "authz-fixture-2", "auditCategory": "authorization"},
+        {"rule": "deny_blacklisted_post", "status": 403, "requestId": "authz-fixture-3", "auditCategory": "authorization"},
+    ]
+    report = redact_value(evaluate(policy, observations))
+    if report["summary"] != {"passed": 3, "failed": 0}:
+        raise PolicyError("self-test expected all fixture observations to pass.")
+    failed = evaluate(policy, [{"rule": "allow_document_schema", "status": 403}])
+    if failed["summary"]["failed"] == 0:
+        raise PolicyError("self-test failed to detect a mismatched observation.")
+    secret_report = redact_value({"route": "/x?orgKey=abc&newOrgKey=def", "authorization": "Bearer secret"})
+    if "abc" in json.dumps(secret_report) or "secret" in json.dumps(secret_report):
+        raise PolicyError("self-test report redaction leaked a secret marker.")
+    print("PASS policy authz tester self-test")
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="Validate CaumeDSE authorization policy-as-code files.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    validate = sub.add_parser("validate", help="Validate a policy JSON file and render setup intent.")
+    validate.add_argument("--policy", default=str(DEFAULT_POLICY))
+    report = sub.add_parser("report", help="Compare observed probe results to policy expectations.")
+    report.add_argument("--policy", default=str(DEFAULT_POLICY))
+    report.add_argument("--observations", required=True)
+    sub.add_parser("self-test", help="Run offline validation, evaluation, and redaction checks.")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        if args.command == "validate":
+            validate_command(args)
+        elif args.command == "report":
+            report_command(args)
+        elif args.command == "self-test":
+            self_test()
+    except PolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add explicit key re-protect primitives and dry-run inventory helpers for protected DB values.
- Harden verifier web startup diagnostics and add guarded MCP write-helper behavior.
- Add policy-as-code authorization tester and encrypted backup/restore sample workflows.

## Security / Operator Impact

- Re-protect helpers preserve explicit operator control for key/profile migration and support mixed AES/Herradura storage states.
- MCP write helpers remain hidden by default and require delegated-token/write-tool opt-in guardrails.
- Backup/restore packages keep backup keys out of command-line arguments, authenticate ciphertext before restore, reject wrong keys/tampering, and preserve existing protected values byte-for-byte.

## Validation

- python3 -m py_compile samples/encrypted-backup-restore/cdse_backup_restore.py
- python3 samples/encrypted-backup-restore/cdse_backup_restore.py self-test
- end-to-end backup CLI create/verify/dry-run/restore validation
- bash -n TEST/run_debug_components.sh
- git diff --check
- make
- make check
- TEST/run_debug_components.sh --skip-web with passed=41 failed=0 skipped=9
