### PR TITLE
Add pull request CI workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -111,11 +111,17 @@ jobs:
             pkg-config \
             python3
 
+      - name: Refresh generated autotools files
+        run: autoreconf -fi
+
       - name: Configure DEBUG test build
         run: ./configure --prefix=/tmp/cdse-verify --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP
 
+      - name: Clean generated build outputs
+        run: make clean
+
       - name: Build
-        run: make
+        run: make V=1
 
       - name: Run make check
         run: make check

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -148,13 +148,14 @@ jobs:
 
       - name: Try CI web smoke verifier
         id: web_smoke
+        timeout-minutes: 8
         shell: bash
         run: |
           set -euo pipefail
           rm -rf /tmp/cdse-ci-web-smoke
           export CDSE_VERIFY_LOG_DIR=/tmp/cdse-ci-web-smoke
           set +e
-          TEST/run_debug_components.sh --ci-smoke
+          TEST/run_debug_components.sh --skip-build --ci-smoke
           rc=$?
           set -e
           if [ "$rc" -eq 0 ]; then

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -148,14 +148,14 @@ jobs:
 
       - name: Try CI web smoke verifier
         id: web_smoke
-        timeout-minutes: 8
+        timeout-minutes: 6
         shell: bash
         run: |
           set -euo pipefail
           rm -rf /tmp/cdse-ci-web-smoke
           export CDSE_VERIFY_LOG_DIR=/tmp/cdse-ci-web-smoke
           set +e
-          TEST/run_debug_components.sh --skip-build --ci-smoke
+          TEST/run_debug_components.sh --live-only --web-protocol=http
           rc=$?
           set -e
           if [ "$rc" -eq 0 ]; then

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,175 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Classify Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+            git diff --name-only "$base" "$head" > changed-files.txt
+          else
+            git ls-files > changed-files.txt
+          fi
+
+          docs_only=1
+          if [ ! -s changed-files.txt ]; then
+            docs_only=0
+          fi
+          while IFS= read -r path; do
+            case "$path" in
+              *.md|docs/*|README*|CHANGELOG.md|TODO.md|TUTORIAL.md|API_EXAMPLES.md|AI_USAGE.md)
+                ;;
+              *)
+                docs_only=0
+                ;;
+            esac
+          done < changed-files.txt
+
+          printf 'docs_only=%s\n' "$docs_only" >> "$GITHUB_OUTPUT"
+          printf 'Changed files:\n'
+          sed 's/^/  - /' changed-files.txt
+          printf 'docs_only=%s\n' "$docs_only"
+
+  lightweight:
+    name: Lightweight Checks
+    runs-on: ubuntu-latest
+    needs: changes
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Validate shell syntax
+        run: bash -n TEST/run_debug_components.sh
+
+      - name: Validate TODO status format
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -Eq '^- \[[ x]\] #[0-9]+ ' TODO.md
+          python3 -c 'import re; from pathlib import Path; numbers=[int(m.group(1)) for line in Path("TODO.md").read_text(encoding="utf-8").splitlines() for m in [re.match(r"- \[[ x]\] #([0-9]+) ", line)] if m]; assert numbers == sorted(numbers), "TODO items are not sorted by number"; assert len(numbers) == len(set(numbers)), "TODO item numbers contain duplicates"'
+
+  build-and-verify:
+    name: Build And Verify
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docs_only != '1'
+    env:
+      CDSE_VERIFY_REDACT: "1"
+      CDSE_VERIFY_PREFIX: /tmp/cdse-verify
+      CDSE_VERIFY_LOG_DIR: /tmp/cdse-ci-components
+      CDSE_DEBUG_TEST_TIMEOUT: 120s
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            autoconf \
+            automake \
+            build-essential \
+            ca-certificates \
+            curl \
+            gawk \
+            libcrypt-dev \
+            libgnutls28-dev \
+            libmicrohttpd-dev \
+            libnsl-dev \
+            libperl-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libtool \
+            perl \
+            pkg-config \
+            python3
+
+      - name: Configure DEBUG test build
+        run: ./configure --prefix=/tmp/cdse-verify --enable-DEBUG --enable-TESTDATABASE --enable-BYPASSTLSAUTHINHTTP
+
+      - name: Build
+        run: make
+
+      - name: Run make check
+        run: make check
+
+      - name: Run standalone sample self-tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 samples/delegated-token-broker/delegated_token_broker.py self-test
+          python3 samples/agent-rag-connector/caumedse_rag_connector.py self-test
+          python3 samples/review-workspace/review_workspace.py self-test
+          python3 samples/audit-dashboard/audit_dashboard.py self-test
+          python3 samples/mcp-server/caumedse_mcp_server.py self-test
+          python3 samples/policy-authz-tester/policy_authz_tester.py self-test
+          python3 samples/encrypted-backup-restore/cdse_backup_restore.py self-test
+          python3 samples/reprotect-workflow/reprotect_workflow.py self-test
+          python3 samples/operational-readiness/readiness_check.py self-test
+
+      - name: Run component verifier without web sockets
+        run: TEST/run_debug_components.sh --skip-build --skip-web
+
+      - name: Try CI web smoke verifier
+        id: web_smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/cdse-ci-web-smoke
+          export CDSE_VERIFY_LOG_DIR=/tmp/cdse-ci-web-smoke
+          set +e
+          TEST/run_debug_components.sh --ci-smoke
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -R -E 'Operation not permitted|could not reserve .* test port|service did not start' /tmp/cdse-ci-web-smoke >/tmp/cdse-ci-web-smoke/socket-denied.txt 2>/dev/null; then
+            printf '%s\n' 'CI runner could not create or bind local web sockets; non-web verifier already passed.'
+            exit 0
+          fi
+
+          printf 'CI web smoke failed for a non-socket-denial reason. Summary follows:\n'
+          if [ -f /tmp/cdse-ci-web-smoke/summary.txt ]; then
+            cat /tmp/cdse-ci-web-smoke/summary.txt
+          fi
+          exit "$rc"
+
+      - name: Upload verifier artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: caumedse-verifier-logs
+          path: |
+            /tmp/cdse-ci-components
+            /tmp/cdse-ci-web-smoke
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Run make check
         run: make check
 
+      - name: Install DEBUG test build
+        run: make install
+
       - name: Run standalone sample self-tests
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -2391,6 +2391,16 @@ The `--ci-smoke` profile runs configure, build, install, component markers,
 HTTP/HTTPS startup checks, and one live API protocol. It defaults to HTTP live
 coverage; use `--ci-smoke --web-protocol=https` to select HTTPS instead.
 
+Pull requests run the GitHub Actions workflow in `.github/workflows/pr-ci.yml`.
+Documentation-only PRs run lightweight syntax and TODO-format checks. Code,
+build, test, workflow, and sample changes run the DEBUG configure/build path,
+`make`, `make check`, standalone sample self-tests, and the redacted DEBUG
+component verifier. The CI workflow also attempts `TEST/run_debug_components.sh
+--ci-smoke`; if a GitHub-hosted runner denies local socket creation or binding,
+the web smoke step is treated as an environment limitation only after the
+non-web component verifier has passed. Redacted verifier logs are uploaded as
+short-lived PR artifacts.
+
 The committed test database under `TEST/testDB_opt_cdse` uses
 `0CDBB9AF76AF43BDB72E095989E612CC` as the `EngineAdmin` / `EngineOrg`
 organization key in the DEBUG resource component tests and API examples.

--- a/TODO.md
+++ b/TODO.md
@@ -1022,3 +1022,4 @@
   - Batch 1: added `.github/workflows/pr-ci.yml` with pull-request change classification, lightweight documentation checks, DEBUG configure/build/check coverage, standalone sample self-tests, redacted non-web verifier coverage, web-smoke fallback for socket-denied runners, uploaded verifier artifacts, README CI guidance, and local syntax validation.
   - Batch 2: refreshed autotools files in CI with the runner-provided toolchain before the build, reconfigured afterward, cleaned generated outputs before compilation, and enabled verbose make logs for clearer PR failure diagnostics.
   - Batch 3: installed the DEBUG build before running the `--skip-build --skip-web` component verifier so installed harness paths under `CDSE_VERIFY_PREFIX` are available in CI.
+  - Batch 4: reused the installed DEBUG prefix for CI web-smoke verification and capped the smoke step runtime so GitHub PR checks do not linger indefinitely.

--- a/TODO.md
+++ b/TODO.md
@@ -1008,3 +1008,15 @@
   - Batch 10: added readiness remediation action items for degraded, misconfigured, and unsafe checks.
   - Batch 11: added a configurable readiness threshold gate for CI and monitoring policies.
   - Batch 12: added a final readiness completion check for safe JSON, required checks, monitoring outputs, agent context, remediation output, and threshold policy.
+
+- [x] #108 Add automated GitHub Actions CI tests for pull requests.
+  - Source: `.github/workflows/`, `configure.ac`, `Makefile.am`, `TEST/run_debug_components.sh`, sample self-tests under `samples/`, and project documentation.
+  - Goal: run repeatable automated checks for every pull request so build, DEBUG component coverage, sample workflows, and verifier regressions are caught before merge.
+  - Plan:
+    - Add a pull-request GitHub Actions workflow that installs required Linux packages for CaumeDSE, configures the DEBUG test build, runs `make`, and runs `make check`.
+    - Run the CI-friendly verifier profile, preferring `TEST/run_debug_components.sh --ci-smoke` when GitHub-hosted runners permit local web sockets and falling back to a documented `--skip-web` component profile when networking is unavailable.
+    - Run standalone sample self-tests for re-protect workflow, policy authorization tester, operational readiness, encrypted backup/restore, MCP write guards, agent RAG connector, review workspace, audit dashboard, and delegated token broker.
+    - Upload redacted verifier summaries/logs as CI artifacts, using `CDSE_VERIFY_REDACT=1` for shared logs and preserving enough failure context for PR review.
+    - Add workflow path filters or job grouping so documentation-only PRs can run lightweight checks while code, build, test, and sample changes run the full suite.
+    - Document local parity commands and GitHub runner limitations in the contributor guidance.
+  - Batch 1: added `.github/workflows/pr-ci.yml` with pull-request change classification, lightweight documentation checks, DEBUG configure/build/check coverage, standalone sample self-tests, redacted non-web verifier coverage, web-smoke fallback for socket-denied runners, uploaded verifier artifacts, README CI guidance, and local syntax validation.

--- a/TODO.md
+++ b/TODO.md
@@ -1020,3 +1020,4 @@
     - Add workflow path filters or job grouping so documentation-only PRs can run lightweight checks while code, build, test, and sample changes run the full suite.
     - Document local parity commands and GitHub runner limitations in the contributor guidance.
   - Batch 1: added `.github/workflows/pr-ci.yml` with pull-request change classification, lightweight documentation checks, DEBUG configure/build/check coverage, standalone sample self-tests, redacted non-web verifier coverage, web-smoke fallback for socket-denied runners, uploaded verifier artifacts, README CI guidance, and local syntax validation.
+  - Batch 2: refreshed autotools files in CI with the runner-provided toolchain before the build, reconfigured afterward, cleaned generated outputs before compilation, and enabled verbose make logs for clearer PR failure diagnostics.

--- a/TODO.md
+++ b/TODO.md
@@ -1022,4 +1022,4 @@
   - Batch 1: added `.github/workflows/pr-ci.yml` with pull-request change classification, lightweight documentation checks, DEBUG configure/build/check coverage, standalone sample self-tests, redacted non-web verifier coverage, web-smoke fallback for socket-denied runners, uploaded verifier artifacts, README CI guidance, and local syntax validation.
   - Batch 2: refreshed autotools files in CI with the runner-provided toolchain before the build, reconfigured afterward, cleaned generated outputs before compilation, and enabled verbose make logs for clearer PR failure diagnostics.
   - Batch 3: installed the DEBUG build before running the `--skip-build --skip-web` component verifier so installed harness paths under `CDSE_VERIFY_PREFIX` are available in CI.
-  - Batch 4: reused the installed DEBUG prefix for CI web-smoke verification and capped the smoke step runtime so GitHub PR checks do not linger indefinitely.
+  - Batch 4: reused the installed DEBUG prefix for focused live HTTP web-smoke verification and capped the smoke step runtime so GitHub PR checks do not linger indefinitely.

--- a/TODO.md
+++ b/TODO.md
@@ -1021,3 +1021,4 @@
     - Document local parity commands and GitHub runner limitations in the contributor guidance.
   - Batch 1: added `.github/workflows/pr-ci.yml` with pull-request change classification, lightweight documentation checks, DEBUG configure/build/check coverage, standalone sample self-tests, redacted non-web verifier coverage, web-smoke fallback for socket-denied runners, uploaded verifier artifacts, README CI guidance, and local syntax validation.
   - Batch 2: refreshed autotools files in CI with the runner-provided toolchain before the build, reconfigured afterward, cleaned generated outputs before compilation, and enabled verbose make logs for clearer PR failure diagnostics.
+  - Batch 3: installed the DEBUG build before running the `--skip-build --skip-web` component verifier so installed harness paths under `CDSE_VERIFY_PREFIX` are available in CI.


### PR DESCRIPTION
## Summary

Adds automated GitHub Actions CI for pull requests:

- classifies documentation-only PRs for lightweight checks
- runs shell syntax and TODO format validation
- installs CaumeDSE build dependencies on Ubuntu runners
- runs DEBUG configure, `make`, and `make check` for code/workflow/sample changes
- runs standalone sample self-tests
- runs redacted non-web component verifier coverage
- attempts the CI web smoke verifier and treats socket-denied runners as an environment limitation only after non-web verifier coverage passes
- uploads redacted verifier logs as short-lived artifacts
- documents the PR CI behavior in README and marks TODO #108 complete

## Validation

- all standalone sample self-tests passed
- `bash -n TEST/run_debug_components.sh`
- TODO numbering/status check
- workflow structural marker check
- `git diff --check`

## Notes

`actionlint` is not installed in this local environment, so the workflow was validated with structural checks and the shell/Python commands it runs locally.